### PR TITLE
Add cookie injection endpoint + Netscape cookie import tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ If you’re using the OpenClaw plugin, you can import a Netscape-format cookie f
 - Tool: `camofox_import_cookies`
 - Server endpoint: `POST /sessions/:userId/cookies`
 
+**Security:** this endpoint is disabled unless `CAMOFOX_API_KEY` is set on the server. When enabled, callers must include `Authorization: Bearer <CAMOFOX_API_KEY>`.
+
 ```bash
 # OpenClaw tool usage (conceptual)
 # camofox_import_cookies({ cookiesPath: "/path/to/cookies.txt", domainSuffix: "linkedin.com" })
@@ -84,10 +86,11 @@ If you’re using the OpenClaw plugin, you can import a Netscape-format cookie f
 # Direct server usage (Playwright cookie objects)
 curl -X POST http://localhost:9377/sessions/agent1/cookies \
   -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer YOUR_CAMOFOX_API_KEY' \
   -d '{"cookies":[{"name":"foo","value":"bar","domain":"example.com","path":"/","expires":-1,"httpOnly":false,"secure":false}]}'
 ```
 
-## Usage
+### Basic Browsing
 
 ```bash
 # Create a tab

--- a/plugin.ts
+++ b/plugin.ts
@@ -218,7 +218,7 @@ function parseNetscapeCookieFile(text: string) {
 
     const domain = parts[0];
     const path = parts[2];
-    const secure = parts[3].toUpperCase() == 'TRUE';
+    const secure = parts[3].toUpperCase() === 'TRUE';
     const expires = Number(parts[4]);
     const name = parts[5];
     const value = parts.slice(6).join('\t');
@@ -515,14 +515,20 @@ export default function register(api: PluginApi) {
         secure: !!c.secure,
       }));
 
-      const result = await fetchApi(
-        baseUrl,
-        `/sessions/${encodeURIComponent(userId)}/cookies`,
-        {
-          method: "POST",
-          body: JSON.stringify({ cookies: pwCookies }),
-        }
-      );
+      const apiKey = process.env.CAMOFOX_API_KEY;
+      if (!apiKey) {
+        throw new Error(
+          "CAMOFOX_API_KEY is not set. Cookie import is disabled unless you set CAMOFOX_API_KEY for both the server and the OpenClaw plugin environment."
+        );
+      }
+
+      const result = await fetchApi(baseUrl, `/sessions/${encodeURIComponent(userId)}/cookies`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({ cookies: pwCookies }),
+      });
 
       return toToolResult({ imported: pwCookies.length, userId, result });
     },

--- a/server.js
+++ b/server.js
@@ -11,13 +11,53 @@ app.use(express.json({ limit: '5mb' }));
 
 // Import cookies into a user's browser context (Playwright cookies format)
 // POST /sessions/:userId/cookies { cookies: Cookie[] }
+//
+// SECURITY:
+// Cookie injection moves this from "anonymous browsing" to "authenticated browsing".
+// This endpoint is DISABLED unless CAMOFOX_API_KEY is set.
+// When enabled, caller must send: Authorization: Bearer <CAMOFOX_API_KEY>
 app.post('/sessions/:userId/cookies', async (req, res) => {
   try {
+    const apiKey = process.env.CAMOFOX_API_KEY;
+    if (!apiKey) {
+      return res.status(403).json({
+        error: 'Cookie import is disabled. Set CAMOFOX_API_KEY to enable this endpoint.',
+      });
+    }
+
+    const auth = String(req.headers['authorization'] || '');
+    const match = auth.match(/^Bearer\s+(.+)$/i);
+    if (!match || match[1] !== apiKey) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
     const userId = req.params.userId;
     const cookies = (req.body && req.body.cookies) || [];
     if (!Array.isArray(cookies)) {
       return res.status(400).json({ error: 'cookies must be an array' });
     }
+
+    // Validate before passing to Playwright to avoid cryptic 500s
+    const invalid = [];
+    for (let i = 0; i < cookies.length; i++) {
+      const c = cookies[i];
+      const missing = [];
+      if (!c || typeof c !== 'object') {
+        invalid.push({ index: i, error: 'cookie must be an object' });
+        continue;
+      }
+      if (typeof c.name !== 'string' || !c.name) missing.push('name');
+      if (typeof c.value !== 'string') missing.push('value');
+      if (typeof c.domain !== 'string' || !c.domain) missing.push('domain');
+      if (missing.length) invalid.push({ index: i, missing });
+    }
+    if (invalid.length) {
+      return res.status(400).json({
+        error: 'Invalid cookie objects: each cookie must include name, value, and domain',
+        invalid,
+      });
+    }
+
     const session = await getSession(userId);
     await session.context.addCookies(cookies);
     const result = { ok: true, userId: String(userId), count: cookies.length };


### PR DESCRIPTION
Adds cookie injection support to camofox-browser.

What's included:
- Server: `POST /sessions/:userId/cookies` to inject Playwright cookie objects into the user's BrowserContext.
- OpenClaw tool: `camofox_import_cookies` to parse a Netscape-format cookie file (optional `domainSuffix`) and POST cookies to the server.
- README: documents the new tool + endpoint.

Tested:
- `npm ci`
- `npm test`

Use case:
Authenticate against sites like LinkedIn without an interactive login flow by importing browser-exported cookies.