### PR TITLE
fix: navigate returns 400 for blocked URLs, remove session count from health endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -601,7 +601,6 @@ app.get('/health', (req, res) => {
     engine: 'camoufox',
     browserConnected: running,
     browserRunning: running,
-    sessions: sessions.size,
   });
 });
 
@@ -699,7 +698,8 @@ app.post('/tabs/:tabId/navigate', async (req, res) => {
     res.json(result);
   } catch (err) {
     log('error', 'navigate failed', { reqId: req.reqId, tabId, error: err.message });
-    res.status(500).json({ error: safeError(err) });
+    const status = err.message && err.message.startsWith('Blocked URL scheme') ? 400 : 500;
+    res.status(status).json({ error: safeError(err) });
   }
 });
 
@@ -1215,7 +1215,6 @@ app.get('/', (req, res) => {
     engine: 'camoufox',
     browserConnected: running,
     browserRunning: running,
-    sessions: sessions.size,
   });
 });
 


### PR DESCRIPTION
Three bugs found during v1.2.0 testing:

### 1. `navigate` returning 500 for blocked URL schemes (should be 400)

`POST /tabs/:tabId/navigate` was returning HTTP 500 when a blocked URL scheme was passed. The correct response for a client error is 400.

Blocked schemes are anything outside the `['http:', 'https:']` allowlist. Examples caught by the security tests:

```
file:///etc/passwd        → local filesystem access
javascript:alert(1)       → script injection
data:text/html,<script>   → inline content injection
ftp://internal-host       → non-web protocols
blob:                     → object URLs
```

**Fix:** Check if the error message starts with `Blocked URL scheme` and return 400.

### 2. `GET /health` leaking session count (info disclosure)

The health endpoint included `sessions: sessions.size` in its response. Health checks should return liveness/readiness only — not internal state that reveals active session inventory.

**Fix:** Removed the `sessions` field.

### 3. `GET /` (root info endpoint) same session count leak

Same fix applied for consistency.

---

**Tests:** 75/75 unit, 46/46 e2e all passing.