### PR TITLE
feat: add evaluate endpoint for JS execution in page context

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -433,6 +433,29 @@ export default function register(api: PluginApi) {
   }));
 
   api.registerTool((ctx: ToolContext) => ({
+    name: "camofox_evaluate",
+    description:
+      "Execute JavaScript in a Camoufox tab's page context. Returns the result of the expression. Use for injecting scripts, reading page state, or calling web app APIs.",
+    parameters: {
+      type: "object",
+      properties: {
+        tabId: { type: "string", description: "Tab identifier" },
+        expression: { type: "string", description: "JavaScript expression to evaluate in the page context" },
+      },
+      required: ["tabId", "expression"],
+    },
+    async execute(_id, params) {
+      const { tabId, expression } = params as { tabId: string; expression: string };
+      const userId = ctx.agentId || fallbackUserId;
+      const result = await fetchApi(baseUrl, `/tabs/${tabId}/evaluate`, {
+        method: "POST",
+        body: { userId, expression },
+      });
+      return toToolResult(result);
+    },
+  }));
+
+  api.registerTool((ctx: ToolContext) => ({
     name: "camofox_list_tabs",
     description: "List all open Camoufox tabs for a user.",
     parameters: {

--- a/server.js
+++ b/server.js
@@ -1405,6 +1405,30 @@ app.get('/tabs/:tabId/stats', async (req, res) => {
   }
 });
 
+// Evaluate JavaScript in page context
+app.post('/tabs/:tabId/evaluate', express.json({ limit: '1mb' }), async (req, res) => {
+  try {
+    const { userId, expression } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId is required' });
+    if (!expression) return res.status(400).json({ error: 'expression is required' });
+
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, req.params.tabId);
+    if (!found) return res.status(404).json({ error: 'Tab not found' });
+
+    session.lastAccess = Date.now();
+    const { tabState } = found;
+    tabState.toolCalls++;
+
+    const result = await tabState.page.evaluate(expression);
+    log('info', 'evaluate', { reqId: req.reqId, tabId: req.params.tabId, userId, resultType: typeof result });
+    res.json({ ok: true, result });
+  } catch (err) {
+    log('error', 'evaluate failed', { reqId: req.reqId, error: err.message });
+    res.status(500).json({ error: safeError(err) });
+  }
+});
+
 // Close tab
 app.delete('/tabs/:tabId', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary

Adds `POST /tabs/:tabId/evaluate` — a new endpoint to execute JavaScript directly in a tab's page context via Playwright's `page.evaluate()`.

## Motivation

The current Camofox toolset covers navigation, clicking, typing, and snapshots, but there's no way to run arbitrary JS in the page. This is needed for:

- **Injecting scripts** into web apps to access internal SDK/transport APIs
- **Reading page state** beyond what the DOM snapshot exposes
- **Calling web app APIs** directly (e.g., marking messages as read, fetching data from internal endpoints)

Without this, users have to work around it with brittle DOM selectors or external CDP connections.

## Changes

### `server.js`
- New `POST /tabs/:tabId/evaluate` endpoint
- Accepts `{ userId, expression }` in the request body
- Returns `{ ok: true, result }` with the evaluated value
- Expression size limit: 1MB (to support large script injections)
- Updates `session.lastAccess` and `tabState.toolCalls` for proper session keepalive

### `plugin.ts`
- New `camofox_evaluate` tool registration so OpenClaw agents can call it natively

## Usage

```bash
curl -X POST http://localhost:9377/tabs/TAB_ID/evaluate \
  -H 'Content-Type: application/json' \
  -d '{"userId": "main", "expression": "document.title"}'
# → {"ok": true, "result": "My Page Title"}
```

Supports async expressions (Playwright resolves promises automatically):
```bash
curl -X POST http://localhost:9377/tabs/TAB_ID/evaluate \
  -H 'Content-Type: application/json' \
  -d '{"userId": "main", "expression": "fetch('/api/data').then(r => r.json())"}'
```
