### PR TITLE
feat: convert to ESM, add version sync script

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,4 +1,6 @@
 module.exports = {
+  // Disable transforms — we use native ESM via --experimental-vm-modules
+  transform: {},
   testEnvironment: 'node',
   testTimeout: 60000, // 60 seconds per test
   

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,8 +5,8 @@
  * flag plugin.ts or server.js for env-harvesting (env + network in same file).
  */
 
-const { join } = require('path');
-const os = require('os');
+import { join } from 'path';
+import os from 'os';
 
 function loadConfig() {
   return {
@@ -47,4 +47,4 @@ function loadConfig() {
   };
 }
 
-module.exports = { loadConfig };
+export { loadConfig };

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -2,8 +2,8 @@
  * Cookie file reading and parsing for camofox-browser.
  */
 
-const fs = require('fs/promises');
-const path = require('path');
+import fs from 'fs/promises';
+import path from 'path';
 
 /**
  * Parse a Netscape-format cookie file into structured cookie objects.
@@ -79,4 +79,4 @@ async function readCookieFile({ cookiesDir, cookiesPath, domainSuffix, maxBytes 
   }));
 }
 
-module.exports = { parseNetscapeCookieFile, readCookieFile };
+export { parseNetscapeCookieFile, readCookieFile };

--- a/lib/downloads.js
+++ b/lib/downloads.js
@@ -5,10 +5,10 @@
  * in-page image source extraction with optional inline data.
  */
 
-const crypto = require('crypto');
-const path = require('path');
-const os = require('os');
-const fs = require('node:fs/promises');
+import crypto from 'crypto';
+import path from 'path';
+import os from 'os';
+import fs from 'node:fs/promises';
 
 const MAX_DOWNLOAD_RECORDS_PER_TAB = 20;
 const MAX_DOWNLOAD_INLINE_BYTES = 20 * 1024 * 1024;
@@ -228,7 +228,7 @@ async function extractPageImages(page, { includeData = false, maxBytes = MAX_DOW
   );
 }
 
-module.exports = {
+export {
   MAX_DOWNLOAD_INLINE_BYTES,
   sanitizeFilename,
   guessMimeTypeFromName,

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -2,8 +2,8 @@
  * Server subprocess launcher for camofox-browser.
  */
 
-const cp = require('child_process');
-const { join } = require('path');
+import cp from 'child_process';
+import { join } from 'path';
 
 // Alias to avoid overzealous scanner pattern matching on the function name
 const startProcess = cp.spawn;
@@ -44,4 +44,4 @@ function launchServer({ pluginDir, port, env, nodeArgs, log }) {
   return proc;
 }
 
-module.exports = { launchServer };
+export { launchServer };

--- a/lib/macros.js
+++ b/lib/macros.js
@@ -24,7 +24,7 @@ function getSupportedMacros() {
   return Object.keys(MACROS);
 }
 
-module.exports = {
+export {
   expandMacro,
   getSupportedMacros,
   MACROS

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -38,4 +38,4 @@ function windowSnapshot(yaml, offset = 0) {
   };
 }
 
-module.exports = { windowSnapshot, MAX_SNAPSHOT_CHARS, SNAPSHOT_TAIL_CHARS };
+export { windowSnapshot, MAX_SNAPSHOT_CHARS, SNAPSHOT_TAIL_CHARS };

--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -4,10 +4,10 @@
  * Kept in a separate module so transcript process logic stays isolated.
  */
 
-const childProcess = require('child_process');
-const { mkdtemp, readFile, readdir, rm } = require('fs/promises');
-const { tmpdir } = require('os');
-const { join } = require('path');
+import childProcess from 'child_process';
+import { mkdtemp, readFile, readdir, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 const runProgram = childProcess.execFile;
 
@@ -283,4 +283,4 @@ function formatVttTs(ts) {
   return ts;
 }
 
-module.exports = { detectYtDlp, hasYtDlp, ytDlpTranscript, parseJson3, parseVtt, parseXml };
+export { detectYtDlp, hasYtDlp, ytDlpTranscript, parseJson3, parseVtt, parseXml };

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "camofox-browser",
   "name": "Camofox Browser",
   "description": "Anti-detection browser automation for AI agents using Camoufox (Firefox-based)",
-  "version": "1.0.12",
+  "version": "1.3.1",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@askjo/camofox-browser",
   "version": "1.3.1",
   "description": "Headless browser automation server and OpenClaw plugin for AI agents - anti-detection, element refs, and session isolation",
+  "type": "module",
   "main": "server.js",
   "license": "MIT",
   "author": "Jo Inc <oss@askjo.ai>",
@@ -38,6 +39,7 @@
     "lib/",
     "plugin.ts",
     "openclaw.plugin.json",
+    "scripts/",
     "run.sh",
     "Dockerfile",
     "README.md",
@@ -50,10 +52,12 @@
   },
   "scripts": {
     "start": "node server.js",
-    "test": "jest --runInBand --forceExit",
-    "test:e2e": "jest --runInBand --forceExit tests/e2e",
-    "test:live": "RUN_LIVE_TESTS=1 jest --runInBand --forceExit tests/live",
-    "test:debug": "DEBUG_SERVER=1 jest --runInBand --forceExit",
+    "test": "NODE_OPTIONS='--experimental-vm-modules' jest --runInBand --forceExit",
+    "test:e2e": "NODE_OPTIONS='--experimental-vm-modules' jest --runInBand --forceExit tests/e2e",
+    "test:live": "RUN_LIVE_TESTS=1 NODE_OPTIONS='--experimental-vm-modules' jest --runInBand --forceExit tests/live",
+    "test:debug": "DEBUG_SERVER=1 NODE_OPTIONS='--experimental-vm-modules' jest --runInBand --forceExit",
+    "version:sync": "node scripts/sync-version.js",
+    "version": "node scripts/sync-version.js && git add openclaw.plugin.json",
     "postinstall": "npx camoufox-js fetch || true"
   },
   "dependencies": {

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+/**
+ * Sync openclaw.plugin.json version with package.json.
+ * Run via: npm run version:sync
+ * Auto-runs on npm version via the "version" lifecycle script.
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
+const pluginPath = join(root, 'openclaw.plugin.json');
+const plugin = JSON.parse(await readFile(pluginPath, 'utf8'));
+
+if (plugin.version !== pkg.version) {
+  plugin.version = pkg.version;
+  await writeFile(pluginPath, JSON.stringify(plugin, null, 2) + '\n');
+  console.log(`openclaw.plugin.json version synced to ${pkg.version}`);
+} else {
+  console.log(`openclaw.plugin.json already at ${pkg.version}`);
+}

--- a/tests/e2e/concurrency.test.js
+++ b/tests/e2e/concurrency.test.js
@@ -1,6 +1,6 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { startTestSite, stopTestSite, getTestSiteUrl } = require('../helpers/testSite');
-const { createClient } = require('../helpers/client');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
 
 describe('Concurrency', () => {
   let serverUrl;

--- a/tests/e2e/downloadsImages.test.js
+++ b/tests/e2e/downloadsImages.test.js
@@ -1,6 +1,6 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { startTestSite, stopTestSite, getTestSiteUrl } = require('../helpers/testSite');
-const { createClient } = require('../helpers/client');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
 
 describe('Downloads and Images', () => {
   let serverUrl;

--- a/tests/e2e/formSubmission.test.js
+++ b/tests/e2e/formSubmission.test.js
@@ -1,6 +1,6 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { startTestSite, stopTestSite, getTestSiteUrl } = require('../helpers/testSite');
-const { createClient } = require('../helpers/client');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
 
 describe('Form Submission', () => {
   let serverUrl;

--- a/tests/e2e/macroNavigation.test.js
+++ b/tests/e2e/macroNavigation.test.js
@@ -1,6 +1,6 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { startTestSite, stopTestSite, getTestSiteUrl } = require('../helpers/testSite');
-const { createClient } = require('../helpers/client');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
 
 describe('Macro Navigation', () => {
   let serverUrl;

--- a/tests/e2e/navigation.test.js
+++ b/tests/e2e/navigation.test.js
@@ -1,6 +1,6 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { startTestSite, stopTestSite, getTestSiteUrl } = require('../helpers/testSite');
-const { createClient } = require('../helpers/client');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
 
 describe('Navigation', () => {
   let serverUrl;

--- a/tests/e2e/screenshot.test.js
+++ b/tests/e2e/screenshot.test.js
@@ -1,6 +1,6 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { startTestSite, stopTestSite, getTestSiteUrl } = require('../helpers/testSite');
-const { createClient } = require('../helpers/client');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
 
 describe('Screenshot', () => {
   let serverUrl;

--- a/tests/e2e/scroll.test.js
+++ b/tests/e2e/scroll.test.js
@@ -1,6 +1,6 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { startTestSite, stopTestSite, getTestSiteUrl } = require('../helpers/testSite');
-const { createClient } = require('../helpers/client');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
 
 describe('Scroll', () => {
   let serverUrl;

--- a/tests/e2e/snapshot-truncation.test.js
+++ b/tests/e2e/snapshot-truncation.test.js
@@ -1,7 +1,7 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { startTestSite, stopTestSite, getTestSiteUrl } = require('../helpers/testSite');
-const { createClient } = require('../helpers/client');
-const { MAX_SNAPSHOT_CHARS } = require('../../lib/snapshot');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
+import { MAX_SNAPSHOT_CHARS } from '../../lib/snapshot.js';
 
 describe('Snapshot truncation (e2e)', () => {
   let serverUrl;

--- a/tests/e2e/snapshotLinks.test.js
+++ b/tests/e2e/snapshotLinks.test.js
@@ -1,6 +1,6 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { startTestSite, stopTestSite, getTestSiteUrl } = require('../helpers/testSite');
-const { createClient } = require('../helpers/client');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
 
 describe('Snapshot and Links', () => {
   let serverUrl;

--- a/tests/e2e/snapshotScreenshot.test.js
+++ b/tests/e2e/snapshotScreenshot.test.js
@@ -1,7 +1,7 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { startTestSite, stopTestSite, getTestSiteUrl } = require('../helpers/testSite');
-const { createClient } = require('../helpers/client');
-const { PNG } = require('pngjs');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
+import { PNG } from 'pngjs';
 
 describe('Snapshot with includeScreenshot', () => {
   let serverUrl;

--- a/tests/e2e/tabLifecycle.test.js
+++ b/tests/e2e/tabLifecycle.test.js
@@ -1,6 +1,6 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { startTestSite, stopTestSite, getTestSiteUrl } = require('../helpers/testSite');
-const { createClient } = require('../helpers/client');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
 
 describe('Tab Lifecycle', () => {
   let serverUrl;

--- a/tests/e2e/typingEnter.test.js
+++ b/tests/e2e/typingEnter.test.js
@@ -1,6 +1,6 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { startTestSite, stopTestSite, getTestSiteUrl } = require('../helpers/testSite');
-const { createClient } = require('../helpers/client');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
 
 describe('Typing and Enter', () => {
   let serverUrl;

--- a/tests/helpers/client.js
+++ b/tests/helpers/client.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto');
+import crypto from 'crypto';
 
 class BrowserClient {
   constructor(baseUrl) {
@@ -236,7 +236,7 @@ function createClient(baseUrl) {
   return new BrowserClient(baseUrl);
 }
 
-module.exports = {
+export {
   BrowserClient,
   createClient
 };

--- a/tests/helpers/testSite.js
+++ b/tests/helpers/testSite.js
@@ -1,4 +1,4 @@
-const express = require('express');
+import express from 'express';
 
 let server = null;
 let port = null;
@@ -317,7 +317,7 @@ function getTestSiteUrl() {
   return `http://localhost:${port}`;
 }
 
-module.exports = {
+export {
   startTestSite,
   stopTestSite,
   getTestSiteUrl

--- a/tests/live/googleSearch.test.js
+++ b/tests/live/googleSearch.test.js
@@ -1,5 +1,5 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { createClient } = require('../helpers/client');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { createClient } from '../helpers/client.js';
 
 // Live Google tests are opt-in due to potential captchas/rate limiting
 const SKIP_LIVE_TESTS = !process.env.RUN_LIVE_TESTS;

--- a/tests/live/macroExpansion.test.js
+++ b/tests/live/macroExpansion.test.js
@@ -1,5 +1,5 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { createClient } = require('../helpers/client');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { createClient } from '../helpers/client.js';
 
 // Live macro tests are opt-in due to external site dependencies
 const SKIP_LIVE_TESTS = !process.env.RUN_LIVE_TESTS;

--- a/tests/unit/downloads.test.js
+++ b/tests/unit/downloads.test.js
@@ -1,14 +1,14 @@
-const {
+import {
   sanitizeFilename,
   guessMimeTypeFromName,
   clearTabDownloads,
   clearSessionDownloads,
   getDownloadsList,
-} = require('../../lib/downloads');
+} from '../../lib/downloads.js';
 
-const fs = require('node:fs/promises');
-const os = require('os');
-const path = require('path');
+import fs from 'node:fs/promises';
+import os from 'os';
+import path from 'path';
 
 describe('lib/downloads', () => {
   describe('sanitizeFilename', () => {

--- a/tests/unit/macros.test.js
+++ b/tests/unit/macros.test.js
@@ -1,4 +1,4 @@
-const { expandMacro, getSupportedMacros, MACROS } = require('../../lib/macros');
+import { expandMacro, getSupportedMacros, MACROS } from '../../lib/macros.js';
 
 describe('Macro URL Expansion (unit)', () => {
   

--- a/tests/unit/screenshotToolResult.test.js
+++ b/tests/unit/screenshotToolResult.test.js
@@ -1,4 +1,4 @@
-const http = require('http');
+import http from 'http';
 
 /**
  * Unit tests for the plugin's camofox_screenshot tool result format.

--- a/tests/unit/security.test.js
+++ b/tests/unit/security.test.js
@@ -1,6 +1,6 @@
-const { startServer, stopServer, getServerUrl } = require('../helpers/startServer');
-const { startTestSite, stopTestSite, getTestSiteUrl } = require('../helpers/testSite');
-const { createClient } = require('../helpers/client');
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
 
 describe('Security', () => {
   let serverUrl;

--- a/tests/unit/snapshot.test.js
+++ b/tests/unit/snapshot.test.js
@@ -1,4 +1,4 @@
-const { windowSnapshot, MAX_SNAPSHOT_CHARS, SNAPSHOT_TAIL_CHARS } = require('../../lib/snapshot');
+import { windowSnapshot, MAX_SNAPSHOT_CHARS, SNAPSHOT_TAIL_CHARS } from '../../lib/snapshot.js';
 
 describe('windowSnapshot', () => {
   const CONTENT_BUDGET = MAX_SNAPSHOT_CHARS - SNAPSHOT_TAIL_CHARS - 200;


### PR DESCRIPTION
Converts the codebase from CommonJS to ES Modules and adds automated version syncing.

### Changes
- Convert all `lib/`, `tests/`, and config files from CJS (`require`/`module.exports`) to ESM (`import`/`export`)
- Add `"type": "module"` to package.json
- Rename `jest.config.js` → `jest.config.cjs` (Jest requires CJS config in ESM projects)
- Add `NODE_OPTIONS='--experimental-vm-modules'` to test scripts
- Add `scripts/sync-version.js` + npm `version` hook to keep `openclaw.plugin.json` in sync (fixes #26)

### Testing
All 169 tests pass (9 skipped — live Google tests)

Closes #26, addresses #18