### PR TITLE
fix: start idle timer after browser pre-warm (#32)

### DIFF
--- a/server.js
+++ b/server.js
@@ -2660,6 +2660,7 @@ const server = app.listen(PORT, async () => {
     const start = Date.now();
     await ensureBrowser();
     log('info', 'browser pre-warmed', { ms: Date.now() - start });
+    scheduleBrowserIdleShutdown();
   } catch (err) {
     log('error', 'browser pre-warm failed (will retry on first request)', { error: err.message });
   }


### PR DESCRIPTION
## Summary

Fixes #32 — `browserIdleTimeoutMs` has no effect when no sessions are ever created.

The browser is pre-warmed on server startup via `ensureBrowser()`, but `scheduleBrowserIdleShutdown()` was never called afterward. The idle timer only starts when `sessions.size` drops to 0 after a session existed — if no session is ever created, the timer never fires and the browser stays alive indefinitely (~735 MB RSS with 0 active tabs).

## Fix

One-line addition: call `scheduleBrowserIdleShutdown()` after successful pre-warm so the idle timer starts immediately. If no tabs are created within `browserIdleTimeoutMs` (default 5 min), the browser shuts down. It re-launches transparently on the next tab creation via `ensureBrowser()`.

## Test plan

- Start server with `browserIdleTimeoutMs` set to 30000 (30s)
- Do not create any tabs
- Verify browser process exits after 30s
- Create a tab after browser exits — verify it re-launches and works normally