### PR TITLE
chore: pin node:20-slim Docker image to sha256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:20-slim@sha256:a82f40540f5959e0003fb7b3c0f80490def2927be8bdbee7e3e0ac65cce3be92
 
 # Pinned Camoufox version for reproducible builds
 # Update these when upgrading Camoufox


### PR DESCRIPTION
 ## Summary
  - Pins the `node:20-slim` base image in the Dockerfile to a specific sha256 manifest list digest
  - Prevents supply chain attacks via upstream tag mutation
  - Uses the manifest list digest, so multi-platform builds (amd64, arm64, etc.) continue to work

  ## Notes
  - The pinned digest will need periodic updates to pick up upstream security patches
  - Current digest: `sha256:a82f40540f5959e0003fb7b3c0f80490def2927be8bdbee7e3e0ac65cce3be92`

  ## Test plan
  - [ ] Build the Docker image and verify it pulls the correct base image
  - [ ] Verify the container starts and runs correctly