### PR TITLE
fix(plugin): add missing JSON.stringify to camofox_evaluate request body

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -449,7 +449,7 @@ export default function register(api: PluginApi) {
       const userId = ctx.agentId || fallbackUserId;
       const result = await fetchApi(baseUrl, `/tabs/${tabId}/evaluate`, {
         method: "POST",
-        body: { userId, expression },
+        body: JSON.stringify({ userId, expression }),
       });
       return toToolResult(result);
     },


### PR DESCRIPTION
## Problem

`camofox_evaluate` passes a raw object as `fetch()` body, which gets serialized as `"[object Object]"` instead of valid JSON. The server returns `400 SyntaxError` on every call — the tool is completely unusable.

All other tools (click, type, navigate, scroll, screenshot, cookies) correctly use `JSON.stringify()`. This was missed in #27.

## Fix

```diff
- body: { userId, expression },
+ body: JSON.stringify({ userId, expression }),
```