### PR TITLE
feat: use Makefile to better control arch during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:20-slim
 # Update these when upgrading Camoufox
 ARG CAMOUFOX_VERSION=135.0.1
 ARG CAMOUFOX_RELEASE=beta.24
-ARG CAMOUFOX_URL=https://github.com/daijro/camoufox/releases/download/v${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}/camoufox-${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}-lin.x86_64.zip
+ARG ARCH=x86_64
 
 # Install dependencies for Camoufox (Firefox-based)
 RUN apt-get update && apt-get install -y \
@@ -29,26 +29,23 @@ RUN apt-get update && apt-get install -y \
     fontconfig \
     # Utils
     ca-certificates \
-    curl \
     unzip \
     # yt-dlp runtime dependency
     python3-minimal \
     && rm -rf /var/lib/apt/lists/*
 
-# Install yt-dlp for YouTube transcript extraction (no browser needed)
-RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp \
-    && chmod +x /usr/local/bin/yt-dlp
-
-# Pre-bake Camoufox browser binary into image
-# This avoids downloading at runtime and pins the version
+# Pre-bake Camoufox browser binary into image via bind mount (downloaded by Makefile)
 # Note: unzip returns exit code 1 for warnings (Unicode filenames), so we use || true and verify
-RUN mkdir -p /root/.cache/camoufox \
-    && curl -L -o /tmp/camoufox.zip "${CAMOUFOX_URL}" \
-    && (unzip -q /tmp/camoufox.zip -d /root/.cache/camoufox || true) \
-    && rm /tmp/camoufox.zip \
+RUN --mount=type=bind,source=dist,target=/dist \
+    mkdir -p /root/.cache/camoufox \
+    && (unzip -q /dist/camoufox-${ARCH}.zip -d /root/.cache/camoufox || true) \
     && chmod -R 755 /root/.cache/camoufox \
     && echo "{\"version\":\"${CAMOUFOX_VERSION}\",\"release\":\"${CAMOUFOX_RELEASE}\"}" > /root/.cache/camoufox/version.json \
     && test -f /root/.cache/camoufox/camoufox-bin && echo "Camoufox installed successfully"
+
+# Install yt-dlp for YouTube transcript extraction (no browser needed)
+RUN --mount=type=bind,source=dist,target=/dist \
+    install -m 755 /dist/yt-dlp-${ARCH} /usr/local/bin/yt-dlp
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,78 @@
+VERSION  ?= 135.0.1
+RELEASE  ?= beta.24
+
+# Auto-detect host architecture; map arm64 (macOS) → aarch64
+UNAME_ARCH := $(shell uname -m)
+ifeq ($(UNAME_ARCH),arm64)
+  ARCH ?= aarch64
+else
+  ARCH ?= $(UNAME_ARCH)
+endif
+
+# Map ARCH to the platform suffixes used by upstream release filenames
+ifeq ($(ARCH),aarch64)
+  CAMOUFOX_ARCH := arm64
+  YTDLP_ARCH    := _aarch64
+else
+  CAMOUFOX_ARCH := x86_64
+  YTDLP_ARCH    :=
+endif
+
+IMAGE        := camofox-browser:$(VERSION)-$(ARCH)
+CAMOUFOX_ZIP := dist/camoufox-$(ARCH).zip
+YTDLP_BIN    := dist/yt-dlp-$(ARCH)
+
+CAMOUFOX_URL := https://github.com/daijro/camoufox/releases/download/v$(VERSION)-$(RELEASE)/camoufox-$(VERSION)-$(RELEASE)-lin.$(CAMOUFOX_ARCH).zip
+YTDLP_URL    := https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux$(YTDLP_ARCH)
+
+.PHONY: build build-arm64 build-x86 fetch fetch-arm64 fetch-x86 up down reset clean
+
+## Build the Docker image for the current ARCH (default: x86_64)
+build: fetch
+	docker build --no-cache \
+	  --build-arg ARCH=$(ARCH) \
+	  --build-arg CAMOUFOX_VERSION=$(VERSION) \
+	  --build-arg CAMOUFOX_RELEASE=$(RELEASE) \
+	  -t $(IMAGE) .
+
+## Convenience targets
+build-arm64:
+	$(MAKE) build ARCH=aarch64
+
+build-x86:
+	$(MAKE) build ARCH=x86_64
+
+## Download both binaries into dist/ for the current ARCH
+fetch: $(CAMOUFOX_ZIP) $(YTDLP_BIN)
+
+fetch-arm64:
+	$(MAKE) fetch ARCH=aarch64
+
+fetch-x86:
+	$(MAKE) fetch ARCH=x86_64
+
+$(CAMOUFOX_ZIP):
+	mkdir -p dist
+	curl -fSL "$(CAMOUFOX_URL)" -o $@
+
+$(YTDLP_BIN):
+	mkdir -p dist
+	curl -fSL "$(YTDLP_URL)" -o $@
+
+up:
+	@if ! docker image inspect $(IMAGE) > /dev/null 2>&1; then \
+	  $(MAKE) build; \
+	fi
+	docker run -d --restart unless-stopped --name camofox-browser -p 9377:9377 $(IMAGE)
+
+down:
+	docker stop camofox-browser && docker rm camofox-browser
+
+reset:
+	-docker stop camofox-browser 2>/dev/null
+	-docker rm camofox-browser 2>/dev/null
+	-docker rmi $(IMAGE) 2>/dev/null
+	$(MAKE) build
+
+clean:
+	rm -rf dist

--- a/README.md
+++ b/README.md
@@ -77,8 +77,18 @@ Default port is `9377`. See [Environment Variables](#environment-variables) for 
 ### Docker
 
 ```bash
-docker build -t camofox-browser .
-docker run -p 9377:9377 camofox-browser
+# Build and start (auto-detects arch: aarch64 on M1/M2, x86_64 on Intel)
+make up
+
+# Stop and remove the container
+make down
+
+# Force a clean rebuild (e.g. after upgrading VERSION/RELEASE)
+make reset
+
+# Override arch or version explicitly
+make up ARCH=x86_64
+make up VERSION=135.0.1 RELEASE=beta.24
 ```
 
 ### Fly.io / Railway


### PR DESCRIPTION
## Summary

- Add a `Makefile` to orchestrate dependencies download and CPU architecture detection.
- Download `camoufox` and `yt-dlp` outside of Docker build step to speed up repeat build process (e.g: during test)

<details>
<summary>
Build log
</summary>

```
╭─mihado@Genjokoan ~/Repos/camofox-browser ‹master› 
╰─$ make clean
rm -rf dist
╭─mihado@Genjokoan ~/Repos/camofox-browser ‹master› 
╰─$ make reset
docker stop camofox-browser 2>/dev/null
camofox-browser
docker rm camofox-browser 2>/dev/null
camofox-browser
docker rmi camofox-browser:135.0.1-aarch64 2>/dev/null
Untagged: camofox-browser:135.0.1-aarch64
Deleted: sha256:a12c2732c99d5c0324a033f76c8f94623974ca29766cfd3b5c1252049e156ef0
/Applications/Xcode.app/Contents/Developer/usr/bin/make build
mkdir -p dist
curl -fSL "https://github.com/daijro/camoufox/releases/download/v135.0.1-beta.24/camoufox-135.0.1-beta.24-lin.arm64.zip" -o dist/camoufox-aarch64.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  674M  100  674M    0     0  45.1M      0  0:00:14  0:00:14 --:--:-- 60.2M
mkdir -p dist
curl -fSL "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_aarch64" -o dist/yt-dlp-aarch64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 34.2M  100 34.2M    0     0  19.7M      0  0:00:01  0:00:01 --:--:-- 22.6M
docker build --no-cache \
          --build-arg ARCH=aarch64 \
          --build-arg CAMOUFOX_VERSION=135.0.1 \
          --build-arg CAMOUFOX_RELEASE=beta.24 \
          -t camofox-browser:135.0.1-aarch64 .
[+] Building 29.7s (6/13)                                                                                                                        docker:desktop-linux
[+] Building 29.8s (6/13)                                                                                                                        docker:desktop-linux
[+] Building 29.9s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
[+] Building 30.1s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
[+] Building 30.1s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s
[+] Building 30.3s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s 
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s 
[+] Building 30.4s (6/13)                                                                                                                        docker:desktop-linux 
 => [internal] load build definition from Dockerfile                                                                                                             0.0s 
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s 
[+] Building 30.5s (6/13)                                                                                                                        docker:desktop-linux 
 => [internal] load build definition from Dockerfile                                                                                                             0.0s 
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s 
[+] Building 30.7s (6/13)                                                                                                                        docker:desktop-linux 
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 30.8s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 31.0s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 31.1s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 31.3s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 31.4s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 31.6s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 31.7s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 31.9s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 32.0s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 32.2s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 32.3s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 32.5s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 32.6s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 32.8s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 32.9s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 33.1s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 33.2s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 33.4s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 33.5s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 33.7s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 33.8s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 34.0s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 34.1s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 34.3s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 34.5s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 34.6s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 34.7s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 34.9s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 35.0s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 35.2s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 35.3s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
[+] Building 35.4s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
[+] Building 35.5s (6/13)                                                                                                                        docker:desktop-linux,
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
[+] Building 35.7s (6/13)                                                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s,
[+] Building 68.7s (14/14) FINISHED                                                                                                              docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 1.84kB                                                                                                                           0.0s,
 => [internal] load metadata for docker.io/library/node:20-slim                                                                                                  0.9s
 => [internal] load .dockerignore                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                  0.0s,
 => CACHED [stage-0 1/9] FROM docker.io/library/node:20-slim@sha256:1e85773c98c31d4fe5b545e4cb17379e617b348832fb3738b22a08f68dec30f3                             0.0s,
 => [internal] load build context                                                                                                                                7.9s
 => => transferring context: 742.93MB                                                                                                                            7.7s,
 => [stage-0 2/9] RUN apt-get update && apt-get install -y     libgtk-3-0     libdbus-glib-1-2     libxt6     libasound2     libx11-xcb1     libxcomposite1     22.4s,
 => [stage-0 3/9] RUN --mount=type=bind,source=dist,target=/dist     mkdir -p /root/.cache/camoufox     && (unzip -q /dist/camoufox-aarch64.zip -d /root/.cach  12.4s,
 => [stage-0 4/9] RUN --mount=type=bind,source=dist,target=/dist     install -m 755 /dist/yt-dlp-aarch64 /usr/local/bin/yt-dlp                                   0.2s 
 => [stage-0 5/9] WORKDIR /app                                                                                                                                   0.0s 
 => [stage-0 6/9] COPY package.json ./                                                                                                                           0.0s 
 => [stage-0 7/9] RUN npm install --production                                                                                                                  28.9s 
 => [stage-0 8/9] COPY server.js ./                                                                                                                              0.0s 
 => [stage-0 9/9] COPY lib/ ./lib/                                                                                                                               0.0s 
 => exporting to image                                                                                                                                           3.7s 
 => => exporting layers                                                                                                                                          3.7s 
 => => writing image sha256:03db9fd2d186c2732d44f746cd8859dc67b08965feb10dd1bc42cf6f8cf535ae                                                                     0.0s 
 => => naming to docker.io/library/camofox-browser:135.0.1-aarch64                                                                                               0.0s 

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/zjdvql0l4rcf1gvjuhbay6w6f

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview 

╭─mihado@Genjokoan ~/Repos/camofox-browser ‹master› 
╰─$ make up
docker run -d --restart unless-stopped --name camofox-browser -p 9377:9377 camofox-browser:135.0.1-aarch64
060f0167504d8ed8e811ee8fa7b189b0e10aae813cddc82367bb8e2abe0b1fd5
╭─mihado@Genjokoan ~/Repos/camofox-browser ‹master› 
╰─$ docker ps -a --filter name=camofox-browser

CONTAINER ID   IMAGE                             COMMAND                  CREATED         STATUS         PORTS                                         NAMES
060f0167504d   camofox-browser:135.0.1-aarch64   "docker-entrypoint.s…"   8 seconds ago   Up 7 seconds   0.0.0.0:9377->9377/tcp, [::]:9377->9377/tcp   camofox-browser

```
</details>