### PR TITLE
fix: bind to 0.0.0.0 and fix multi-arch Docker builds for Apple Silicon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# camofox-browser
+
+## Tech Stack
+
+- Runtime: Node.js 20
+- Framework: Express (REST API)
+- Browser Engine: Camoufox (Firefox fork with C++-level fingerprint spoofing)
+- Container: Docker (multi-arch: linux/amd64, linux/arm64)
+
+## Structure
+
+```
+server.js        # Express entry point
+lib/             # Core modules (browser, routes, utils)
+tests/           # Jest test suite
+scripts/         # Build/utility scripts
+Dockerfile       # Multi-arch image build
+docker-compose.yml
+```
+
+## Conventions
+
+- Commits: conventional commits (`fix(scope): desc`)
+- Branch: `fix/*`, `feature/*` from `main`
+- Tests: Jest (`npm test`)
+
+## Scripts
+
+- `npm start` — start server
+- `npm test` — run tests
+- `docker build` — build image
+
+## Docker Multi-Arch Notes
+
+- `TARGETARCH` is injected by Docker buildx as `amd64` or `arm64`
+- Camoufox release filenames use `x86_64` and `aarch64` — map explicitly in `RUN` steps
+- Do NOT use `ARG` interpolation for arch-dependent URLs; use a `case` statement in `RUN`
+
+## Setup
+
+```bash
+npm install
+cp .env.example .env  # if applicable
+npm start
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install yt-dlp for YouTube transcript extraction (no browser needed)
-RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp \
+RUN curl -fL https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp \
     && chmod +x /usr/local/bin/yt-dlp
 
 # Pre-bake Camoufox browser binary into image

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM node:20-slim
 # Update these when upgrading Camoufox
 ARG CAMOUFOX_VERSION=135.0.1
 ARG CAMOUFOX_RELEASE=beta.24
-ARG CAMOUFOX_URL=https://github.com/daijro/camoufox/releases/download/v${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}/camoufox-${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}-lin.x86_64.zip
+ARG TARGETARCH
+ARG CAMOUFOX_URL=https://github.com/daijro/camoufox/releases/download/v${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}/camoufox-${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}-lin.${TARGETARCH:-x86_64}.zip
 
 # Install dependencies for Camoufox (Firefox-based)
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ FROM node:20-slim
 ARG CAMOUFOX_VERSION=135.0.1
 ARG CAMOUFOX_RELEASE=beta.24
 ARG TARGETARCH
-ARG CAMOUFOX_URL=https://github.com/daijro/camoufox/releases/download/v${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}/camoufox-${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}-lin.${TARGETARCH:-x86_64}.zip
 
 # Install dependencies for Camoufox (Firefox-based)
 RUN apt-get update && apt-get install -y \
@@ -43,7 +42,14 @@ RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o 
 # Pre-bake Camoufox browser binary into image
 # This avoids downloading at runtime and pins the version
 # Note: unzip returns exit code 1 for warnings (Unicode filenames), so we use || true and verify
-RUN mkdir -p /root/.cache/camoufox \
+# TARGETARCH is injected by Docker buildx as "amd64"/"arm64"; Camoufox uses "x86_64"/"aarch64"
+RUN case "${TARGETARCH}" in \
+      arm64) CAMOUFOX_ARCH=aarch64 ;; \
+      amd64|"") CAMOUFOX_ARCH=x86_64 ;; \
+      *) echo "Unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac \
+    && CAMOUFOX_URL="https://github.com/daijro/camoufox/releases/download/v${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}/camoufox-${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}-lin.${CAMOUFOX_ARCH}.zip" \
+    && mkdir -p /root/.cache/camoufox \
     && curl -L -o /tmp/camoufox.zip "${CAMOUFOX_URL}" \
     && (unzip -q /tmp/camoufox.zip -d /root/.cache/camoufox || true) \
     && rm /tmp/camoufox.zip \

--- a/server.js
+++ b/server.js
@@ -1,12 +1,12 @@
-import { Camoufox, launchOptions } from 'camoufox-js';
-import { firefox } from 'playwright-core';
-import express from 'express';
-import crypto from 'crypto';
-import os from 'os';
-import { expandMacro } from './lib/macros.js';
-import { loadConfig } from './lib/config.js';
-import { normalizePlaywrightProxy } from './lib/proxy.js';
-import { windowSnapshot } from './lib/snapshot.js';
+import { Camoufox, launchOptions } from "camoufox-js";
+import { firefox } from "playwright-core";
+import express from "express";
+import crypto from "crypto";
+import os from "os";
+import { expandMacro } from "./lib/macros.js";
+import { loadConfig } from "./lib/config.js";
+import { normalizePlaywrightProxy } from "./lib/proxy.js";
+import { windowSnapshot } from "./lib/snapshot.js";
 import {
   MAX_DOWNLOAD_INLINE_BYTES,
   clearTabDownloads,
@@ -14,14 +14,26 @@ import {
   attachDownloadListener,
   getDownloadsList,
   extractPageImages,
-} from './lib/downloads.js';
-import { detectYtDlp, hasYtDlp, ytDlpTranscript, parseJson3, parseVtt, parseXml } from './lib/youtube.js';
+} from "./lib/downloads.js";
+import {
+  detectYtDlp,
+  hasYtDlp,
+  ytDlpTranscript,
+  parseJson3,
+  parseVtt,
+  parseXml,
+} from "./lib/youtube.js";
 import {
   register as metricsRegister,
-  requestsTotal, requestDuration, pageLoadDuration,
-  activeTabsGauge, tabLockQueueDepth,
-  tabLockTimeoutsTotal, startMemoryReporter, actionFromReq,
-} from './lib/metrics.js';
+  requestsTotal,
+  requestDuration,
+  pageLoadDuration,
+  activeTabsGauge,
+  tabLockQueueDepth,
+  tabLockTimeoutsTotal,
+  startMemoryReporter,
+  actionFromReq,
+} from "./lib/metrics.js";
 
 const CONFIG = loadConfig();
 
@@ -34,15 +46,15 @@ function log(level, msg, fields = {}) {
     ...fields,
   };
   const line = JSON.stringify(entry);
-  if (level === 'error') {
-    process.stderr.write(line + '\n');
+  if (level === "error") {
+    process.stderr.write(line + "\n");
   } else {
-    process.stdout.write(line + '\n');
+    process.stdout.write(line + "\n");
   }
 }
 
 const app = express();
-app.use(express.json({ limit: '100kb' }));
+app.use(express.json({ limit: "100kb" }));
 
 // Request logging + metrics middleware
 app.use((req, res, next) => {
@@ -50,9 +62,9 @@ app.use((req, res, next) => {
   req.reqId = reqId;
   req.startTime = Date.now();
 
-  const userId = req.body?.userId || req.query?.userId || '-';
-  if (req.path !== '/health') {
-    log('info', 'req', { reqId, method: req.method, path: req.path, userId });
+  const userId = req.body?.userId || req.query?.userId || "-";
+  if (req.path !== "/health") {
+    log("info", "req", { reqId, method: req.method, path: req.path, userId });
   }
 
   const action = actionFromReq(req);
@@ -62,11 +74,11 @@ app.use((req, res, next) => {
   res.end = function (...args) {
     const ms = Date.now() - req.startTime;
     const isErrorStatus = res.statusCode >= 400;
-    requestsTotal.labels(action, isErrorStatus ? 'error' : 'success').inc();
+    requestsTotal.labels(action, isErrorStatus ? "error" : "success").inc();
     done();
 
-    if (req.path !== '/health') {
-      log('info', 'res', { reqId, status: res.statusCode, ms });
+    if (req.path !== "/health") {
+      log("info", "res", { reqId, status: res.statusCode, ms });
     }
 
     return origEnd(...args);
@@ -75,23 +87,30 @@ app.use((req, res, next) => {
   next();
 });
 
-const ALLOWED_URL_SCHEMES = ['http:', 'https:'];
+const ALLOWED_URL_SCHEMES = ["http:", "https:"];
 
 // Interactive roles to include - exclude combobox to avoid opening complex widgets
 // (date pickers, dropdowns) that can interfere with navigation
 const INTERACTIVE_ROLES = [
-  'button', 'link', 'textbox', 'checkbox', 'radio',
-  'menuitem', 'tab', 'searchbox', 'slider', 'spinbutton', 'switch'
+  "button",
+  "link",
+  "textbox",
+  "checkbox",
+  "radio",
+  "menuitem",
+  "tab",
+  "searchbox",
+  "slider",
+  "spinbutton",
+  "switch",
   // 'combobox' excluded - can trigger date pickers and complex dropdowns
 ];
 
 // Patterns to skip (date pickers, calendar widgets)
-const SKIP_PATTERNS = [
-  /date/i, /calendar/i, /picker/i, /datepicker/i
-];
+const SKIP_PATTERNS = [/date/i, /calendar/i, /picker/i, /datepicker/i];
 
 function timingSafeCompare(a, b) {
-  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  if (typeof a !== "string" || typeof b !== "string") return false;
   const bufA = Buffer.from(a);
   const bufB = Buffer.from(b);
   if (bufA.length !== bufB.length) {
@@ -104,27 +123,29 @@ function timingSafeCompare(a, b) {
 // Custom error for stale/unknown element refs — returned as 422 instead of 500
 class StaleRefsError extends Error {
   constructor(ref, maxRef, totalRefs) {
-    super(`Unknown ref: ${ref} (valid refs: e1-${maxRef}, ${totalRefs} total). Refs reset after navigation - call snapshot first.`);
-    this.name = 'StaleRefsError';
-    this.code = 'stale_refs';
+    super(
+      `Unknown ref: ${ref} (valid refs: e1-${maxRef}, ${totalRefs} total). Refs reset after navigation - call snapshot first.`,
+    );
+    this.name = "StaleRefsError";
+    this.code = "stale_refs";
     this.ref = ref;
   }
 }
 
 function safeError(err) {
-  if (CONFIG.nodeEnv === 'production') {
-    log('error', 'internal error', { error: err.message, stack: err.stack });
-    return 'Internal server error';
+  if (CONFIG.nodeEnv === "production") {
+    log("error", "internal error", { error: err.message, stack: err.stack });
+    return "Internal server error";
   }
   return err.message;
 }
 
 // Send error response with appropriate status code (422 for stale refs, 500 otherwise)
 function sendError(res, err, extraFields = {}) {
-  const status = err instanceof StaleRefsError ? 422 : (err.statusCode || 500);
+  const status = err instanceof StaleRefsError ? 422 : err.statusCode || 500;
   const body = { error: safeError(err), ...extraFields };
   if (err instanceof StaleRefsError) {
-    body.code = 'stale_refs';
+    body.code = "stale_refs";
     body.ref = err.ref;
   }
   res.status(status).json(body);
@@ -144,7 +165,11 @@ function validateUrl(url) {
 
 function isLoopbackAddress(address) {
   if (!address) return false;
-  return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1';
+  return (
+    address === "127.0.0.1" ||
+    address === "::1" ||
+    address === "::ffff:127.0.0.1"
+  );
 }
 
 // Import cookies into a user's browser context (Playwright cookies format)
@@ -156,78 +181,108 @@ function isLoopbackAddress(address) {
 // For local development convenience, when CAMOFOX_API_KEY is NOT set, we allow
 // unauthenticated cookie import ONLY from loopback (127.0.0.1 / ::1) and ONLY
 // when NODE_ENV != production.
-app.post('/sessions/:userId/cookies', express.json({ limit: '512kb' }), async (req, res) => {
-  try {
-    if (CONFIG.apiKey) {
-      const apiKey = CONFIG.apiKey;
-      const auth = String(req.headers['authorization'] || '');
-      const match = auth.match(/^Bearer\s+(.+)$/i);
-      if (!match || !timingSafeCompare(match[1], apiKey)) {
-        return res.status(403).json({ error: 'Forbidden' });
+app.post(
+  "/sessions/:userId/cookies",
+  express.json({ limit: "512kb" }),
+  async (req, res) => {
+    try {
+      if (CONFIG.apiKey) {
+        const apiKey = CONFIG.apiKey;
+        const auth = String(req.headers["authorization"] || "");
+        const match = auth.match(/^Bearer\s+(.+)$/i);
+        if (!match || !timingSafeCompare(match[1], apiKey)) {
+          return res.status(403).json({ error: "Forbidden" });
+        }
+      } else {
+        const remoteAddress = req.socket?.remoteAddress || "";
+        const allowUnauthedLocal =
+          CONFIG.nodeEnv !== "production" && isLoopbackAddress(remoteAddress);
+        if (!allowUnauthedLocal) {
+          return res.status(403).json({
+            error:
+              "Cookie import is disabled without CAMOFOX_API_KEY except for loopback requests in non-production environments.",
+          });
+        }
       }
-    } else {
-      const remoteAddress = req.socket?.remoteAddress || '';
-      const allowUnauthedLocal = CONFIG.nodeEnv !== 'production' && isLoopbackAddress(remoteAddress);
-      if (!allowUnauthedLocal) {
-        return res.status(403).json({
+
+      const userId = req.params.userId;
+      if (!req.body || !("cookies" in req.body)) {
+        return res
+          .status(400)
+          .json({ error: 'Missing "cookies" field in request body' });
+      }
+      const cookies = req.body.cookies;
+      if (!Array.isArray(cookies)) {
+        return res.status(400).json({ error: "cookies must be an array" });
+      }
+
+      if (cookies.length > 500) {
+        return res
+          .status(400)
+          .json({ error: "Too many cookies. Maximum 500 per request." });
+      }
+
+      const invalid = [];
+      for (let i = 0; i < cookies.length; i++) {
+        const c = cookies[i];
+        const missing = [];
+        if (!c || typeof c !== "object") {
+          invalid.push({ index: i, error: "cookie must be an object" });
+          continue;
+        }
+        if (typeof c.name !== "string" || !c.name) missing.push("name");
+        if (typeof c.value !== "string") missing.push("value");
+        if (typeof c.domain !== "string" || !c.domain) missing.push("domain");
+        if (missing.length) invalid.push({ index: i, missing });
+      }
+      if (invalid.length) {
+        return res.status(400).json({
           error:
-            'Cookie import is disabled without CAMOFOX_API_KEY except for loopback requests in non-production environments.',
+            "Invalid cookie objects: each cookie must include name, value, and domain",
+          invalid,
         });
       }
-    }
 
-    const userId = req.params.userId;
-    if (!req.body || !('cookies' in req.body)) {
-      return res.status(400).json({ error: 'Missing "cookies" field in request body' });
-    }
-    const cookies = req.body.cookies;
-    if (!Array.isArray(cookies)) {
-      return res.status(400).json({ error: 'cookies must be an array' });
-    }
-
-    if (cookies.length > 500) {
-      return res.status(400).json({ error: 'Too many cookies. Maximum 500 per request.' });
-    }
-
-    const invalid = [];
-    for (let i = 0; i < cookies.length; i++) {
-      const c = cookies[i];
-      const missing = [];
-      if (!c || typeof c !== 'object') {
-        invalid.push({ index: i, error: 'cookie must be an object' });
-        continue;
-      }
-      if (typeof c.name !== 'string' || !c.name) missing.push('name');
-      if (typeof c.value !== 'string') missing.push('value');
-      if (typeof c.domain !== 'string' || !c.domain) missing.push('domain');
-      if (missing.length) invalid.push({ index: i, missing });
-    }
-    if (invalid.length) {
-      return res.status(400).json({
-        error: 'Invalid cookie objects: each cookie must include name, value, and domain',
-        invalid,
+      const allowedFields = [
+        "name",
+        "value",
+        "domain",
+        "path",
+        "expires",
+        "httpOnly",
+        "secure",
+        "sameSite",
+      ];
+      const sanitized = cookies.map((c) => {
+        const clean = {};
+        for (const k of allowedFields) {
+          if (c[k] !== undefined) clean[k] = c[k];
+        }
+        return clean;
       });
+
+      const session = await getSession(userId);
+      await session.context.addCookies(sanitized);
+      const result = {
+        ok: true,
+        userId: String(userId),
+        count: sanitized.length,
+      };
+      log("info", "cookies imported", {
+        reqId: req.reqId,
+        userId: String(userId),
+        count: sanitized.length,
+      });
+      res.json(result);
+    } catch (err) {
+      log("error", "cookie import failed", {
+        reqId: req.reqId,
+        error: err.message,
+      });
+      res.status(500).json({ error: safeError(err) });
     }
-
-    const allowedFields = ['name', 'value', 'domain', 'path', 'expires', 'httpOnly', 'secure', 'sameSite'];
-    const sanitized = cookies.map(c => {
-      const clean = {};
-      for (const k of allowedFields) {
-        if (c[k] !== undefined) clean[k] = c[k];
-      }
-      return clean;
-    });
-
-    const session = await getSession(userId);
-    await session.context.addCookies(sanitized);
-    const result = { ok: true, userId: String(userId), count: sanitized.length };
-    log('info', 'cookies imported', { reqId: req.reqId, userId: String(userId), count: sanitized.length });
-    res.json(result);
-  } catch (err) {
-    log('error', 'cookie import failed', { reqId: req.reqId, error: err.message });
-    res.status(500).json({ error: safeError(err) });
-  }
-});
+  },
+);
 
 let browser = null;
 // userId -> { context, tabGroups: Map<sessionKey, Map<tabId, TabState>>, lastAccess }
@@ -266,7 +321,7 @@ class TabLock {
         if (idx !== -1) this.queue.splice(idx, 1);
         tabLockTimeoutsTotal.inc();
         refreshTabLockQueueDepth();
-        reject(new Error('Tab lock queue timeout'));
+        reject(new Error("Tab lock queue timeout"));
       }, timeoutMs);
       this.queue.push(entry);
       refreshTabLockQueueDepth();
@@ -293,7 +348,7 @@ class TabLock {
     this.active = true;
     for (const entry of this.queue) {
       clearTimeout(entry.timer);
-      entry.reject(new Error('Tab destroyed'));
+      entry.reject(new Error("Tab destroyed"));
     }
     this.queue = [];
     refreshTabLockQueueDepth();
@@ -314,7 +369,7 @@ async function withTabLock(tabId, operation, timeoutMs = HANDLER_TIMEOUT_MS) {
   const lock = getTabLock(tabId);
   await lock.acquire(TAB_LOCK_TIMEOUT_MS);
   try {
-    return await withTimeout(operation(), timeoutMs, 'action');
+    return await withTimeout(operation(), timeoutMs, "action");
   } finally {
     lock.release();
   }
@@ -324,8 +379,11 @@ function withTimeout(promise, ms, label) {
   return Promise.race([
     promise,
     new Promise((_, reject) =>
-      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
-    )
+      setTimeout(
+        () => reject(new Error(`${label} timed out after ${ms}ms`)),
+        ms,
+      ),
+    ),
   ]);
 }
 
@@ -340,8 +398,14 @@ async function withUserLimit(userId, operation) {
   }
   if (state.active >= MAX_CONCURRENT_PER_USER) {
     await new Promise((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('User concurrency limit reached, try again')), 30000);
-      state.queue.push(() => { clearTimeout(timer); resolve(); });
+      const timer = setTimeout(
+        () => reject(new Error("User concurrency limit reached, try again")),
+        30000,
+      );
+      state.queue.push(() => {
+        clearTimeout(timer);
+        resolve();
+      });
     });
   }
   state.active++;
@@ -367,30 +431,30 @@ async function safePageClose(page) {
   try {
     await Promise.race([
       page.close(),
-      new Promise(resolve => setTimeout(resolve, PAGE_CLOSE_TIMEOUT_MS))
+      new Promise((resolve) => setTimeout(resolve, PAGE_CLOSE_TIMEOUT_MS)),
     ]);
   } catch (e) {
-    log('warn', 'page close failed', { error: e.message });
+    log("warn", "page close failed", { error: e.message });
   }
 }
 
 // Detect host OS for fingerprint generation
 function getHostOS() {
   const platform = os.platform();
-  if (platform === 'darwin') return 'macos';
-  if (platform === 'win32') return 'windows';
-  return 'linux';
+  if (platform === "darwin") return "macos";
+  if (platform === "win32") return "windows";
+  return "linux";
 }
 
 function buildProxyConfig() {
   const { host, port, username, password } = CONFIG.proxy;
-  
+
   if (!host || !port) {
-    log('info', 'no proxy configured');
+    log("info", "no proxy configured");
     return null;
   }
-  
-  log('info', 'proxy configured', { host, port });
+
+  log("info", "proxy configured", { host, port });
   return {
     server: `http://${host}:${port}`,
     username,
@@ -407,7 +471,7 @@ function scheduleBrowserIdleShutdown() {
   if (sessions.size === 0 && browser) {
     browserIdleTimer = setTimeout(async () => {
       if (sessions.size === 0 && browser) {
-        log('info', 'browser idle shutdown (no sessions)');
+        log("info", "browser idle shutdown (no sessions)");
         const b = browser;
         browser = null;
         await b.close().catch(() => {});
@@ -444,7 +508,10 @@ function recordNavFailure() {
 async function restartBrowser(reason) {
   if (healthState.isRecovering) return;
   healthState.isRecovering = true;
-  log('error', 'restarting browser', { reason, failures: healthState.consecutiveNavFailures });
+  log("error", "restarting browser", {
+    reason,
+    failures: healthState.consecutiveNavFailures,
+  });
   try {
     for (const [, session] of sessions) {
       await session.context.close().catch(() => {});
@@ -458,9 +525,9 @@ async function restartBrowser(reason) {
     await ensureBrowser();
     healthState.consecutiveNavFailures = 0;
     healthState.lastSuccessfulNav = Date.now();
-    log('info', 'browser restarted successfully');
+    log("info", "browser restarted successfully");
   } catch (err) {
-    log('error', 'browser restart failed', { error: err.message });
+    log("error", "browser restart failed", { error: err.message });
   } finally {
     healthState.isRecovering = false;
   }
@@ -479,9 +546,9 @@ function getTotalTabCount() {
 async function launchBrowserInstance() {
   const hostOS = getHostOS();
   const proxy = buildProxyConfig();
-  
-  log('info', 'launching camoufox', { hostOS, geoip: !!proxy });
-  
+
+  log("info", "launching camoufox", { hostOS, geoip: !!proxy });
+
   const options = await launchOptions({
     headless: true,
     os: hostOS,
@@ -491,18 +558,22 @@ async function launchBrowserInstance() {
     geoip: !!proxy,
   });
   options.proxy = normalizePlaywrightProxy(options.proxy);
-  
+
   browser = await firefox.launch(options);
-  log('info', 'camoufox launched');
+  log("info", "camoufox launched");
   return browser;
 }
 
 async function ensureBrowser() {
   clearBrowserIdleTimer();
   if (browser && !browser.isConnected()) {
-    log('warn', 'browser disconnected, clearing dead sessions and relaunching', {
-      deadSessions: sessions.size,
-    });
+    log(
+      "warn",
+      "browser disconnected, clearing dead sessions and relaunching",
+      {
+        deadSessions: sessions.size,
+      },
+    );
     for (const [userId, session] of sessions) {
       await session.context.close().catch(() => {});
     }
@@ -513,8 +584,15 @@ async function ensureBrowser() {
   if (browserLaunchPromise) return browserLaunchPromise;
   browserLaunchPromise = Promise.race([
     launchBrowserInstance(),
-    new Promise((_, reject) => setTimeout(() => reject(new Error('Browser launch timeout (30s)')), 30000)),
-  ]).finally(() => { browserLaunchPromise = null; });
+    new Promise((_, reject) =>
+      setTimeout(
+        () => reject(new Error("Browser launch timeout (30s)")),
+        30000,
+      ),
+    ),
+  ]).finally(() => {
+    browserLaunchPromise = null;
+  });
   return browserLaunchPromise;
 }
 
@@ -526,41 +604,44 @@ function normalizeUserId(userId) {
 async function getSession(userId) {
   const key = normalizeUserId(userId);
   let session = sessions.get(key);
-  
+
   // Check if existing session's context is still alive
   if (session) {
     try {
       // Lightweight probe: pages() is synchronous-ish and throws if context is dead
       session.context.pages();
     } catch (err) {
-      log('warn', 'session context dead, recreating', { userId: key, error: err.message });
+      log("warn", "session context dead, recreating", {
+        userId: key,
+        error: err.message,
+      });
       session.context.close().catch(() => {});
       sessions.delete(key);
       session = null;
     }
   }
-  
+
   if (!session) {
     if (sessions.size >= MAX_SESSIONS) {
-      throw new Error('Maximum concurrent sessions reached');
+      throw new Error("Maximum concurrent sessions reached");
     }
     const b = await ensureBrowser();
     const contextOptions = {
       viewport: { width: 1280, height: 720 },
-      permissions: ['geolocation'],
+      permissions: ["geolocation"],
     };
     // When geoip is active (proxy configured), camoufox auto-configures
     // locale/timezone/geolocation from the proxy IP. Without proxy, use defaults.
     if (!CONFIG.proxy.host) {
-      contextOptions.locale = 'en-US';
-      contextOptions.timezoneId = 'America/Los_Angeles';
+      contextOptions.locale = "en-US";
+      contextOptions.timezoneId = "America/Los_Angeles";
       contextOptions.geolocation = { latitude: 37.7749, longitude: -122.4194 };
     }
     const context = await b.newContext(contextOptions);
-    
+
     session = { context, tabGroups: new Map(), lastAccess: Date.now() };
     sessions.set(key, session);
-    log('info', 'session created', { userId: key });
+    log("info", "session created", { userId: key });
   }
   session.lastAccess = Date.now();
   return session;
@@ -576,25 +657,29 @@ function getTabGroup(session, listItemId) {
 }
 
 function isDeadContextError(err) {
-  const msg = err && err.message || '';
-  return msg.includes('Target page, context or browser has been closed') ||
-         msg.includes('browser has been closed') ||
-         msg.includes('Context closed') ||
-         msg.includes('Browser closed');
+  const msg = (err && err.message) || "";
+  return (
+    msg.includes("Target page, context or browser has been closed") ||
+    msg.includes("browser has been closed") ||
+    msg.includes("Context closed") ||
+    msg.includes("Browser closed")
+  );
 }
 
 function isTimeoutError(err) {
-  const msg = err && err.message || '';
-  return msg.includes('timed out after') ||
-         (msg.includes('Timeout') && msg.includes('exceeded'));
+  const msg = (err && err.message) || "";
+  return (
+    msg.includes("timed out after") ||
+    (msg.includes("Timeout") && msg.includes("exceeded"))
+  );
 }
 
 function isTabLockQueueTimeout(err) {
-  return err && err.message === 'Tab lock queue timeout';
+  return err && err.message === "Tab lock queue timeout";
 }
 
 function isTabDestroyedError(err) {
-  return err && err.message === 'Tab destroyed';
+  return err && err.message === "Tab destroyed";
 }
 
 // Centralized error handler for route catch blocks.
@@ -613,7 +698,10 @@ function handleRouteError(err, req, res, extraFields = {}) {
       if (found) {
         found.tabState.consecutiveTimeouts++;
         if (found.tabState.consecutiveTimeouts >= MAX_CONSECUTIVE_TIMEOUTS) {
-          log('warn', 'auto-destroying tab after consecutive timeouts', { tabId, count: found.tabState.consecutiveTimeouts });
+          log("warn", "auto-destroying tab after consecutive timeouts", {
+            tabId,
+            count: found.tabState.consecutiveTimeouts,
+          });
           destroyTab(session, tabId);
         }
       }
@@ -626,11 +714,18 @@ function handleRouteError(err, req, res, extraFields = {}) {
     if (session && tabId) {
       destroyTab(session, tabId);
     }
-    return res.status(503).json({ error: 'Tab unresponsive and has been destroyed. Open a new tab.', ...extraFields });
+    return res
+      .status(503)
+      .json({
+        error: "Tab unresponsive and has been destroyed. Open a new tab.",
+        ...extraFields,
+      });
   }
   // Tab was destroyed while this request was queued in the lock
   if (isTabDestroyedError(err)) {
-    return res.status(410).json({ error: 'Tab was destroyed. Open a new tab.', ...extraFields });
+    return res
+      .status(410)
+      .json({ error: "Tab was destroyed. Open a new tab.", ...extraFields });
   }
   sendError(res, err, extraFields);
 }
@@ -645,7 +740,11 @@ function destroyTab(session, tabId) {
   for (const [listItemId, group] of session.tabGroups) {
     if (group.has(tabId)) {
       const tabState = group.get(tabId);
-      log('warn', 'destroying stuck tab', { tabId, listItemId, toolCalls: tabState.toolCalls });
+      log("warn", "destroying stuck tab", {
+        tabId,
+        listItemId,
+        toolCalls: tabState.toolCalls,
+      });
       safePageClose(tabState.page);
       group.delete(tabId);
       if (group.size === 0) session.tabGroups.delete(listItemId);
@@ -660,7 +759,7 @@ function destroySession(userId) {
   const key = normalizeUserId(userId);
   const session = sessions.get(key);
   if (!session) return;
-  log('warn', 'destroying dead session', { userId: key });
+  log("warn", "destroying dead session", { userId: key });
   session.context.close().catch(() => {});
   sessions.delete(key);
 }
@@ -708,48 +807,54 @@ async function withPageLoadDuration(action, fn) {
   }
 }
 
-
-
 async function waitForPageReady(page, options = {}) {
   const { timeout = 10000, waitForNetwork = true } = options;
-  
+
   try {
-    await page.waitForLoadState('domcontentloaded', { timeout });
-    
+    await page.waitForLoadState("domcontentloaded", { timeout });
+
     if (waitForNetwork) {
-      await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {
-        log('warn', 'networkidle timeout, continuing');
-      });
+      await page
+        .waitForLoadState("networkidle", { timeout: 5000 })
+        .catch(() => {
+          log("warn", "networkidle timeout, continuing");
+        });
     }
-    
+
     // Framework hydration wait (React/Next.js/Vue) - mirrors Swift WebView.swift logic
     // Wait for readyState === 'complete' + network quiet (40 iterations × 250ms max)
-    await page.evaluate(async () => {
-      for (let i = 0; i < 40; i++) {
-        // Check if network is quiet (no recent resource loads)
-        const entries = performance.getEntriesByType('resource');
-        const recentEntries = entries.slice(-5);
-        const netQuiet = recentEntries.every(e => (performance.now() - e.responseEnd) > 400);
-        
-        if (document.readyState === 'complete' && netQuiet) {
-          // Double RAF to ensure paint is complete
-          await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
-          break;
+    await page
+      .evaluate(async () => {
+        for (let i = 0; i < 40; i++) {
+          // Check if network is quiet (no recent resource loads)
+          const entries = performance.getEntriesByType("resource");
+          const recentEntries = entries.slice(-5);
+          const netQuiet = recentEntries.every(
+            (e) => performance.now() - e.responseEnd > 400,
+          );
+
+          if (document.readyState === "complete" && netQuiet) {
+            // Double RAF to ensure paint is complete
+            await new Promise((r) =>
+              requestAnimationFrame(() => requestAnimationFrame(r)),
+            );
+            break;
+          }
+          await new Promise((r) => setTimeout(r, 250));
         }
-        await new Promise(r => setTimeout(r, 250));
-      }
-    }).catch(() => {
-      log('warn', 'hydration wait failed, continuing');
-    });
-    
+      })
+      .catch(() => {
+        log("warn", "hydration wait failed, continuing");
+      });
+
     await page.waitForTimeout(200);
-    
+
     // Auto-dismiss common consent/privacy dialogs
     await dismissConsentDialogs(page);
-    
+
     return true;
   } catch (err) {
-    log('warn', 'page ready failed', { error: err.message });
+    log("warn", "page ready failed", { error: err.message });
     return false;
   }
 }
@@ -758,9 +863,9 @@ async function dismissConsentDialogs(page) {
   // Common consent/privacy dialog selectors (matches Swift WebView.swift patterns)
   const dismissSelectors = [
     // OneTrust (very common)
-    '#onetrust-banner-sdk button#onetrust-accept-btn-handler',
-    '#onetrust-banner-sdk button#onetrust-reject-all-handler',
-    '#onetrust-close-btn-container button',
+    "#onetrust-banner-sdk button#onetrust-accept-btn-handler",
+    "#onetrust-banner-sdk button#onetrust-reject-all-handler",
+    "#onetrust-close-btn-container button",
     // Generic patterns
     'button[data-test="cookie-accept-all"]',
     'button[aria-label="Accept all"]',
@@ -783,13 +888,13 @@ async function dismissConsentDialogs(page) {
     '[class*="modal"] button[class*="close"]',
     '[class*="overlay"] button[class*="close"]',
   ];
-  
+
   for (const selector of dismissSelectors) {
     try {
       const button = page.locator(selector).first();
       if (await button.isVisible({ timeout: 100 })) {
         await button.click({ timeout: 1000 }).catch(() => {});
-        log('info', 'dismissed consent dialog', { selector });
+        log("info", "dismissed consent dialog", { selector });
         await page.waitForTimeout(300); // Brief pause after dismiss
         break; // Only dismiss one dialog per page load
       }
@@ -803,7 +908,7 @@ async function dismissConsentDialogs(page) {
 function isGoogleSerp(url) {
   try {
     const parsed = new URL(url);
-    return parsed.hostname.includes('google.') && parsed.pathname === '/search';
+    return parsed.hostname.includes("google.") && parsed.pathname === "/search";
   } catch {
     return false;
   }
@@ -813,100 +918,139 @@ function isGoogleSerp(url) {
 // Returns { refs: Map, snapshot: string }
 async function extractGoogleSerp(page) {
   const refs = new Map();
-  if (!page || page.isClosed()) return { refs, snapshot: '' };
-  
+  if (!page || page.isClosed()) return { refs, snapshot: "" };
+
   const start = Date.now();
-  
-  const alreadyRendered = await page.evaluate(() => !!document.querySelector('#rso h3, #search h3, #rso [data-snhf]')).catch(() => false);
+
+  const alreadyRendered = await page
+    .evaluate(
+      () => !!document.querySelector("#rso h3, #search h3, #rso [data-snhf]"),
+    )
+    .catch(() => false);
   if (!alreadyRendered) {
     try {
-      await page.waitForSelector('#rso h3, #search h3, #rso [data-snhf]', { timeout: 5000 });
+      await page.waitForSelector("#rso h3, #search h3, #rso [data-snhf]", {
+        timeout: 5000,
+      });
     } catch {
       try {
-        await page.waitForSelector('#rso a[href]:not([href^="/search"]), #search a[href]:not([href^="/search"])', { timeout: 2000 });
+        await page.waitForSelector(
+          '#rso a[href]:not([href^="/search"]), #search a[href]:not([href^="/search"])',
+          { timeout: 2000 },
+        );
       } catch {}
     }
   }
-  
+
   const extracted = await page.evaluate(() => {
     const snapshot = [];
     const elements = [];
     let refCounter = 1;
-    
+
     function addRef(role, name) {
-      const id = 'e' + refCounter++;
+      const id = "e" + refCounter++;
       elements.push({ id, role, name });
       return id;
     }
-    
+
     snapshot.push('- heading "' + document.title.replace(/"/g, '\\"') + '"');
-    
-    const searchInput = document.querySelector('input[name="q"], textarea[name="q"]');
+
+    const searchInput = document.querySelector(
+      'input[name="q"], textarea[name="q"]',
+    );
     if (searchInput) {
-      const name = 'Search';
-      const refId = addRef('searchbox', name);
-      snapshot.push('- searchbox "' + name + '" [' + refId + ']: ' + (searchInput.value || ''));
+      const name = "Search";
+      const refId = addRef("searchbox", name);
+      snapshot.push(
+        '- searchbox "' +
+          name +
+          '" [' +
+          refId +
+          "]: " +
+          (searchInput.value || ""),
+      );
     }
-    
-    const navContainer = document.querySelector('div[role="navigation"], div[role="list"]');
+
+    const navContainer = document.querySelector(
+      'div[role="navigation"], div[role="list"]',
+    );
     if (navContainer) {
-      const navLinks = navContainer.querySelectorAll('a');
+      const navLinks = navContainer.querySelectorAll("a");
       if (navLinks.length > 0) {
-        snapshot.push('- navigation:');
-        navLinks.forEach(a => {
-          const text = (a.textContent || '').trim();
+        snapshot.push("- navigation:");
+        navLinks.forEach((a) => {
+          const text = (a.textContent || "").trim();
           if (!text || text.length < 1) return;
           if (/^\d+$/.test(text) && parseInt(text) < 50) return;
-          const refId = addRef('link', text);
-          snapshot.push('  - link "' + text + '" [' + refId + ']');
+          const refId = addRef("link", text);
+          snapshot.push('  - link "' + text + '" [' + refId + "]");
         });
       }
     }
-    
-    const resultContainer = document.querySelector('#rso') || document.querySelector('#search');
+
+    const resultContainer =
+      document.querySelector("#rso") || document.querySelector("#search");
     if (resultContainer) {
-      const resultBlocks = resultContainer.querySelectorAll(':scope > div');
+      const resultBlocks = resultContainer.querySelectorAll(":scope > div");
       for (const block of resultBlocks) {
-        const h3 = block.querySelector('h3');
-        const mainLink = h3 ? h3.closest('a') : null;
-        
+        const h3 = block.querySelector("h3");
+        const mainLink = h3 ? h3.closest("a") : null;
+
         if (h3 && mainLink) {
           const title = h3.textContent.trim().replace(/"/g, '\\"');
           const href = mainLink.href;
-          const cite = block.querySelector('cite');
-          const displayUrl = cite ? cite.textContent.trim() : '';
-          
-          let snippet = '';
-          for (const sel of ['[data-sncf]', '[data-content-feature="1"]', '.VwiC3b', 'div[style*="-webkit-line-clamp"]', 'span.aCOpRe']) {
+          const cite = block.querySelector("cite");
+          const displayUrl = cite ? cite.textContent.trim() : "";
+
+          let snippet = "";
+          for (const sel of [
+            "[data-sncf]",
+            '[data-content-feature="1"]',
+            ".VwiC3b",
+            'div[style*="-webkit-line-clamp"]',
+            "span.aCOpRe",
+          ]) {
             const el = block.querySelector(sel);
-            if (el) { snippet = el.textContent.trim().slice(0, 300); break; }
+            if (el) {
+              snippet = el.textContent.trim().slice(0, 300);
+              break;
+            }
           }
           if (!snippet) {
-            const allText = block.textContent.trim().replace(/\s+/g, ' ');
-            const titleLen = title.length + (displayUrl ? displayUrl.length : 0);
+            const allText = block.textContent.trim().replace(/\s+/g, " ");
+            const titleLen =
+              title.length + (displayUrl ? displayUrl.length : 0);
             if (allText.length > titleLen + 20) {
               snippet = allText.slice(titleLen).trim().slice(0, 300);
             }
           }
-          
-          const refId = addRef('link', title);
-          snapshot.push('- link "' + title + '" [' + refId + ']:');
-          snapshot.push('  - /url: ' + href);
-          if (displayUrl) snapshot.push('  - cite: ' + displayUrl);
-          if (snippet) snapshot.push('  - text: ' + snippet);
+
+          const refId = addRef("link", title);
+          snapshot.push('- link "' + title + '" [' + refId + "]:");
+          snapshot.push("  - /url: " + href);
+          if (displayUrl) snapshot.push("  - cite: " + displayUrl);
+          if (snippet) snapshot.push("  - text: " + snippet);
         } else {
-          const blockLinks = block.querySelectorAll('a[href^="http"]:not([href*="google.com/search"])');
+          const blockLinks = block.querySelectorAll(
+            'a[href^="http"]:not([href*="google.com/search"])',
+          );
           if (blockLinks.length > 0) {
-            const blockText = block.textContent.trim().replace(/\s+/g, ' ').slice(0, 200);
+            const blockText = block.textContent
+              .trim()
+              .replace(/\s+/g, " ")
+              .slice(0, 200);
             if (blockText.length > 10) {
-              snapshot.push('- group:');
-              snapshot.push('  - text: ' + blockText);
-              blockLinks.forEach(a => {
-                const linkText = (a.textContent || '').trim().replace(/"/g, '\\"').slice(0, 100);
+              snapshot.push("- group:");
+              snapshot.push("  - text: " + blockText);
+              blockLinks.forEach((a) => {
+                const linkText = (a.textContent || "")
+                  .trim()
+                  .replace(/"/g, '\\"')
+                  .slice(0, 100);
                 if (linkText.length > 2) {
-                  const refId = addRef('link', linkText);
-                  snapshot.push('  - link "' + linkText + '" [' + refId + ']:');
-                  snapshot.push('    - /url: ' + a.href);
+                  const refId = addRef("link", linkText);
+                  snapshot.push('  - link "' + linkText + '" [' + refId + "]:");
+                  snapshot.push("    - /url: " + a.href);
                 }
               });
             }
@@ -914,29 +1058,36 @@ async function extractGoogleSerp(page) {
         }
       }
     }
-    
-    const paaItems = document.querySelectorAll('[jsname="Cpkphb"], div.related-question-pair');
+
+    const paaItems = document.querySelectorAll(
+      '[jsname="Cpkphb"], div.related-question-pair',
+    );
     if (paaItems.length > 0) {
       snapshot.push('- heading "People also ask"');
-      paaItems.forEach(q => {
-        const text = (q.textContent || '').trim().replace(/"/g, '\\"').slice(0, 150);
+      paaItems.forEach((q) => {
+        const text = (q.textContent || "")
+          .trim()
+          .replace(/"/g, '\\"')
+          .slice(0, 150);
         if (text) {
-          const refId = addRef('button', text);
-          snapshot.push('  - button "' + text + '" [' + refId + ']');
+          const refId = addRef("button", text);
+          snapshot.push('  - button "' + text + '" [' + refId + "]");
         }
       });
     }
-    
-    const nextLink = document.querySelector('#botstuff a[aria-label="Next page"], td.d6cvqb a, a#pnnext');
+
+    const nextLink = document.querySelector(
+      '#botstuff a[aria-label="Next page"], td.d6cvqb a, a#pnnext',
+    );
     if (nextLink) {
-      const refId = addRef('link', 'Next');
+      const refId = addRef("link", "Next");
       snapshot.push('- navigation "pagination":');
-      snapshot.push('  - link "Next" [' + refId + ']');
+      snapshot.push('  - link "Next" [' + refId + "]");
     }
-    
-    return { snapshot: snapshot.join('\n'), elements };
+
+    return { snapshot: snapshot.join("\n"), elements };
   });
-  
+
   const seenCounts = new Map();
   for (const el of extracted.elements) {
     const key = `${el.role}:${el.name}`;
@@ -944,41 +1095,49 @@ async function extractGoogleSerp(page) {
     seenCounts.set(key, nth + 1);
     refs.set(el.id, { role: el.role, name: el.name, nth });
   }
-  
-  log('info', 'extractGoogleSerp', { elapsed: Date.now() - start, refs: refs.size });
+
+  log("info", "extractGoogleSerp", {
+    elapsed: Date.now() - start,
+    refs: refs.size,
+  });
   return { refs, snapshot: extracted.snapshot };
 }
 
 async function buildRefs(page) {
   const refs = new Map();
-  
+
   if (!page || page.isClosed()) {
-    log('warn', 'buildRefs: page closed or invalid');
+    log("warn", "buildRefs: page closed or invalid");
     return refs;
   }
-  
+
   // Google SERP fast path — skip ariaSnapshot entirely
   const url = page.url();
   if (isGoogleSerp(url)) {
     const { refs: googleRefs } = await extractGoogleSerp(page);
     return googleRefs;
   }
-  
+
   const start = Date.now();
-  
+
   // Hard total timeout on the entire buildRefs operation
-  const timeoutPromise = new Promise((_, reject) => 
-    setTimeout(() => reject(new Error('buildRefs_timeout')), BUILDREFS_TIMEOUT_MS)
+  const timeoutPromise = new Promise((_, reject) =>
+    setTimeout(
+      () => reject(new Error("buildRefs_timeout")),
+      BUILDREFS_TIMEOUT_MS,
+    ),
   );
-  
+
   try {
     return await Promise.race([
       _buildRefsInner(page, refs, start),
-      timeoutPromise
+      timeoutPromise,
     ]);
   } catch (err) {
-    if (err.message === 'buildRefs_timeout') {
-      log('warn', 'buildRefs: total timeout exceeded', { elapsed: Date.now() - start });
+    if (err.message === "buildRefs_timeout") {
+      log("warn", "buildRefs: total timeout exceeded", {
+        elapsed: Date.now() - start,
+      });
       return refs;
     }
     throw err;
@@ -987,67 +1146,73 @@ async function buildRefs(page) {
 
 async function _buildRefsInner(page, refs, start) {
   await waitForPageReady(page, { waitForNetwork: false });
-  
+
   // Budget remaining time for ariaSnapshot
   const elapsed = Date.now() - start;
   const remaining = BUILDREFS_TIMEOUT_MS - elapsed;
   if (remaining < 2000) {
-    log('warn', 'buildRefs: insufficient time for ariaSnapshot', { elapsed });
+    log("warn", "buildRefs: insufficient time for ariaSnapshot", { elapsed });
     return refs;
   }
-  
+
   let ariaYaml;
   try {
-    ariaYaml = await page.locator('body').ariaSnapshot({ timeout: Math.min(remaining - 1000, 5000) });
+    ariaYaml = await page
+      .locator("body")
+      .ariaSnapshot({ timeout: Math.min(remaining - 1000, 5000) });
   } catch (err) {
-    log('warn', 'ariaSnapshot failed, retrying');
+    log("warn", "ariaSnapshot failed, retrying");
     const retryBudget = BUILDREFS_TIMEOUT_MS - (Date.now() - start);
     if (retryBudget < 2000) return refs;
     try {
-      ariaYaml = await page.locator('body').ariaSnapshot({ timeout: Math.min(retryBudget - 500, 5000) });
+      ariaYaml = await page
+        .locator("body")
+        .ariaSnapshot({ timeout: Math.min(retryBudget - 500, 5000) });
     } catch (retryErr) {
-      log('warn', 'ariaSnapshot retry failed, returning empty refs', { error: retryErr.message });
+      log("warn", "ariaSnapshot retry failed, returning empty refs", {
+        error: retryErr.message,
+      });
       return refs;
     }
   }
-  
+
   if (!ariaYaml) {
-    log('warn', 'buildRefs: no aria snapshot');
+    log("warn", "buildRefs: no aria snapshot");
     return refs;
   }
-  
-  const lines = ariaYaml.split('\n');
+
+  const lines = ariaYaml.split("\n");
   let refCounter = 1;
-  
+
   // Track occurrences of each role+name combo for nth disambiguation
   const seenCounts = new Map(); // "role:name" -> count
-  
+
   for (const line of lines) {
     if (refCounter > MAX_SNAPSHOT_NODES) break;
-    
+
     const match = line.match(/^\s*-\s+(\w+)(?:\s+"([^"]*)")?/);
     if (match) {
       const [, role, name] = match;
       const normalizedRole = role.toLowerCase();
-      
-      if (normalizedRole === 'combobox') continue;
-      
-      if (name && SKIP_PATTERNS.some(p => p.test(name))) continue;
-      
+
+      if (normalizedRole === "combobox") continue;
+
+      if (name && SKIP_PATTERNS.some((p) => p.test(name))) continue;
+
       if (INTERACTIVE_ROLES.includes(normalizedRole)) {
-        const normalizedName = name || '';
+        const normalizedName = name || "";
         const key = `${normalizedRole}:${normalizedName}`;
-        
+
         // Get current count and increment
         const nth = seenCounts.get(key) || 0;
         seenCounts.set(key, nth + 1);
-        
+
         const refId = `e${refCounter++}`;
         refs.set(refId, { role: normalizedRole, name: normalizedName, nth });
       }
     }
   }
-  
+
   return refs;
 }
 
@@ -1057,9 +1222,9 @@ async function getAriaSnapshot(page) {
   }
   await waitForPageReady(page, { waitForNetwork: false });
   try {
-    return await page.locator('body').ariaSnapshot({ timeout: 5000 });
+    return await page.locator("body").ariaSnapshot({ timeout: 5000 });
   } catch (err) {
-    log('warn', 'getAriaSnapshot failed', { error: err.message });
+    log("warn", "getAriaSnapshot failed", { error: err.message });
     return null;
   }
 }
@@ -1067,14 +1232,14 @@ async function getAriaSnapshot(page) {
 function refToLocator(page, ref, refs) {
   const info = refs.get(ref);
   if (!info) return null;
-  
+
   const { role, name, nth } = info;
   let locator = page.getByRole(role, name ? { name } : undefined);
-  
+
   // Always use .nth() to disambiguate duplicate role+name combinations
   // This avoids "strict mode violation" when multiple elements match
   locator = locator.nth(nth);
-  
+
   return locator;
 }
 
@@ -1084,63 +1249,90 @@ function refToLocator(page, ref, refs) {
 
 detectYtDlp(log);
 
-app.post('/youtube/transcript', async (req, res) => {
+app.post("/youtube/transcript", async (req, res) => {
   const reqId = req.reqId;
   try {
-    const { url, languages = ['en'] } = req.body;
-    if (!url) return res.status(400).json({ error: 'url is required' });
+    const { url, languages = ["en"] } = req.body;
+    if (!url) return res.status(400).json({ error: "url is required" });
 
     const urlErr = validateUrl(url);
     if (urlErr) return res.status(400).json({ error: urlErr });
 
     const videoIdMatch = url.match(
-      /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/|youtube\.com\/shorts\/)([a-zA-Z0-9_-]{11})/
+      /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/|youtube\.com\/shorts\/)([a-zA-Z0-9_-]{11})/,
     );
     if (!videoIdMatch) {
-      return res.status(400).json({ error: 'Could not extract YouTube video ID from URL' });
+      return res
+        .status(400)
+        .json({ error: "Could not extract YouTube video ID from URL" });
     }
     const videoId = videoIdMatch[1];
-    const lang = languages[0] || 'en';
+    const lang = languages[0] || "en";
 
-    log('info', 'youtube transcript: starting', { reqId, videoId, lang, method: hasYtDlp() ? 'yt-dlp' : 'browser' });
+    log("info", "youtube transcript: starting", {
+      reqId,
+      videoId,
+      lang,
+      method: hasYtDlp() ? "yt-dlp" : "browser",
+    });
 
     let result;
     if (hasYtDlp()) {
       try {
         result = await ytDlpTranscript(reqId, url, videoId, lang);
       } catch (ytErr) {
-        log('warn', 'yt-dlp failed, falling back to browser', { reqId, error: ytErr.message });
+        log("warn", "yt-dlp failed, falling back to browser", {
+          reqId,
+          error: ytErr.message,
+        });
         result = await browserTranscript(reqId, url, videoId, lang);
       }
     } else {
       result = await browserTranscript(reqId, url, videoId, lang);
     }
 
-    log('info', 'youtube transcript: done', { reqId, videoId, status: result.status, words: result.total_words });
+    log("info", "youtube transcript: done", {
+      reqId,
+      videoId,
+      status: result.status,
+      words: result.total_words,
+    });
     res.json(result);
   } catch (err) {
-    log('error', 'youtube transcript failed', { reqId, error: err.message, stack: err.stack });
+    log("error", "youtube transcript failed", {
+      reqId,
+      error: err.message,
+      stack: err.stack,
+    });
     res.status(500).json({ error: safeError(err) });
   }
 });
 
 // Browser fallback — play video, intercept timedtext network response
 async function browserTranscript(reqId, url, videoId, lang) {
-  return await withUserLimit('__yt_transcript__', async () => {
+  return await withUserLimit("__yt_transcript__", async () => {
     await ensureBrowser();
-    const session = await getSession('__yt_transcript__');
+    const session = await getSession("__yt_transcript__");
     const page = await session.context.newPage();
 
     try {
       await page.addInitScript(() => {
         const origPlay = HTMLMediaElement.prototype.play;
-        HTMLMediaElement.prototype.play = function() { this.volume = 0; this.muted = true; return origPlay.call(this); };
+        HTMLMediaElement.prototype.play = function () {
+          this.volume = 0;
+          this.muted = true;
+          return origPlay.call(this);
+        };
       });
 
       let interceptedCaptions = null;
-      page.on('response', async (response) => {
+      page.on("response", async (response) => {
         const respUrl = response.url();
-        if (respUrl.includes('/api/timedtext') && respUrl.includes(`v=${videoId}`) && !interceptedCaptions) {
+        if (
+          respUrl.includes("/api/timedtext") &&
+          respUrl.includes(`v=${videoId}`) &&
+          !interceptedCaptions
+        ) {
           try {
             const body = await response.text();
             if (body && body.length > 0) interceptedCaptions = body;
@@ -1148,29 +1340,53 @@ async function browserTranscript(reqId, url, videoId, lang) {
         }
       });
 
-      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: NAVIGATE_TIMEOUT_MS });
+      await page.goto(url, {
+        waitUntil: "domcontentloaded",
+        timeout: NAVIGATE_TIMEOUT_MS,
+      });
       await page.waitForTimeout(2000);
 
       // Extract caption track URLs and metadata from ytInitialPlayerResponse
       const meta = await page.evaluate(() => {
-        const r = window.ytInitialPlayerResponse || (typeof ytInitialPlayerResponse !== 'undefined' ? ytInitialPlayerResponse : null);
-        if (!r) return { title: '', tracks: [] };
-        const tracks = r?.captions?.playerCaptionsTracklistRenderer?.captionTracks || [];
+        const r =
+          window.ytInitialPlayerResponse ||
+          (typeof ytInitialPlayerResponse !== "undefined"
+            ? ytInitialPlayerResponse
+            : null);
+        if (!r) return { title: "", tracks: [] };
+        const tracks =
+          r?.captions?.playerCaptionsTracklistRenderer?.captionTracks || [];
         return {
-          title: r?.videoDetails?.title || '',
-          tracks: tracks.map(t => ({ code: t.languageCode, name: t.name?.simpleText || t.languageCode, kind: t.kind || 'manual', url: t.baseUrl })),
+          title: r?.videoDetails?.title || "",
+          tracks: tracks.map((t) => ({
+            code: t.languageCode,
+            name: t.name?.simpleText || t.languageCode,
+            kind: t.kind || "manual",
+            url: t.baseUrl,
+          })),
         };
       });
 
-      log('info', 'youtube transcript: extracted caption tracks', { reqId, title: meta.title, trackCount: meta.tracks.length, tracks: meta.tracks.map(t => t.code) });
+      log("info", "youtube transcript: extracted caption tracks", {
+        reqId,
+        title: meta.title,
+        trackCount: meta.tracks.length,
+        tracks: meta.tracks.map((t) => t.code),
+      });
 
       // Strategy A: Fetch caption track URL directly from ytInitialPlayerResponse
       // These URLs are freshly signed by YouTube and work immediately
       if (meta.tracks && meta.tracks.length > 0) {
-        const track = meta.tracks.find(t => t.code === lang) || meta.tracks[0];
+        const track =
+          meta.tracks.find((t) => t.code === lang) || meta.tracks[0];
         if (track && track.url) {
-          const captionUrl = track.url + (track.url.includes('?') ? '&' : '?') + 'fmt=json3';
-          log('info', 'youtube transcript: fetching caption track', { reqId, lang: track.code, url: captionUrl.substring(0, 100) });
+          const captionUrl =
+            track.url + (track.url.includes("?") ? "&" : "?") + "fmt=json3";
+          log("info", "youtube transcript: fetching caption track", {
+            reqId,
+            lang: track.code,
+            url: captionUrl.substring(0, 100),
+          });
           try {
             const captionResp = await page.evaluate(async (fetchUrl) => {
               const resp = await fetch(fetchUrl);
@@ -1178,29 +1394,48 @@ async function browserTranscript(reqId, url, videoId, lang) {
             }, captionUrl);
             if (captionResp && captionResp.length > 0) {
               let transcriptText = null;
-              if (captionResp.trimStart().startsWith('{')) transcriptText = parseJson3(captionResp);
-              else if (captionResp.includes('WEBVTT')) transcriptText = parseVtt(captionResp);
-              else if (captionResp.includes('<text')) transcriptText = parseXml(captionResp);
+              if (captionResp.trimStart().startsWith("{"))
+                transcriptText = parseJson3(captionResp);
+              else if (captionResp.includes("WEBVTT"))
+                transcriptText = parseVtt(captionResp);
+              else if (captionResp.includes("<text"))
+                transcriptText = parseXml(captionResp);
               if (transcriptText && transcriptText.trim()) {
                 return {
-                  status: 'ok', transcript: transcriptText,
-                  video_url: url, video_id: videoId, video_title: meta.title,
-                  language: track.code, total_words: transcriptText.split(/\s+/).length,
-                  available_languages: meta.tracks.map(t => ({ code: t.code, name: t.name, kind: t.kind })),
+                  status: "ok",
+                  transcript: transcriptText,
+                  video_url: url,
+                  video_id: videoId,
+                  video_title: meta.title,
+                  language: track.code,
+                  total_words: transcriptText.split(/\s+/).length,
+                  available_languages: meta.tracks.map((t) => ({
+                    code: t.code,
+                    name: t.name,
+                    kind: t.kind,
+                  })),
                 };
               }
             }
           } catch (fetchErr) {
-            log('warn', 'youtube transcript: caption track fetch failed', { reqId, error: fetchErr.message });
+            log("warn", "youtube transcript: caption track fetch failed", {
+              reqId,
+              error: fetchErr.message,
+            });
           }
         }
       }
 
       // Strategy B: Play video and intercept timedtext network response
-      await page.evaluate(() => {
-        const v = document.querySelector('video');
-        if (v) { v.muted = true; v.play().catch(() => {}); }
-      }).catch(() => {});
+      await page
+        .evaluate(() => {
+          const v = document.querySelector("video");
+          if (v) {
+            v.muted = true;
+            v.play().catch(() => {});
+          }
+        })
+        .catch(() => {});
 
       for (let i = 0; i < 40 && !interceptedCaptions; i++) {
         await page.waitForTimeout(500);
@@ -1208,31 +1443,47 @@ async function browserTranscript(reqId, url, videoId, lang) {
 
       if (!interceptedCaptions) {
         return {
-          status: 'error', code: 404,
-          message: 'No captions available for this video',
-          video_url: url, video_id: videoId, title: meta.title,
+          status: "error",
+          code: 404,
+          message: "No captions available for this video",
+          video_url: url,
+          video_id: videoId,
+          title: meta.title,
         };
       }
 
-      log('info', 'youtube transcript: intercepted captions', { reqId, len: interceptedCaptions.length });
+      log("info", "youtube transcript: intercepted captions", {
+        reqId,
+        len: interceptedCaptions.length,
+      });
 
       let transcriptText = null;
-      if (interceptedCaptions.trimStart().startsWith('{')) transcriptText = parseJson3(interceptedCaptions);
-      else if (interceptedCaptions.includes('WEBVTT')) transcriptText = parseVtt(interceptedCaptions);
-      else if (interceptedCaptions.includes('<text')) transcriptText = parseXml(interceptedCaptions);
+      if (interceptedCaptions.trimStart().startsWith("{"))
+        transcriptText = parseJson3(interceptedCaptions);
+      else if (interceptedCaptions.includes("WEBVTT"))
+        transcriptText = parseVtt(interceptedCaptions);
+      else if (interceptedCaptions.includes("<text"))
+        transcriptText = parseXml(interceptedCaptions);
 
       if (!transcriptText || !transcriptText.trim()) {
         return {
-          status: 'error', code: 404,
-          message: 'Caption data intercepted but could not be parsed',
-          video_url: url, video_id: videoId, title: meta.title,
+          status: "error",
+          code: 404,
+          message: "Caption data intercepted but could not be parsed",
+          video_url: url,
+          video_id: videoId,
+          title: meta.title,
         };
       }
 
       return {
-        status: 'ok', transcript: transcriptText,
-        video_url: url, video_id: videoId, video_title: meta.title,
-        language: lang, total_words: transcriptText.split(/\s+/).length,
+        status: "ok",
+        transcript: transcriptText,
+        video_url: url,
+        video_id: videoId,
+        video_title: meta.title,
+        language: lang,
+        total_words: transcriptText.split(/\s+/).length,
         available_languages: meta.languages,
       };
     } finally {
@@ -1241,14 +1492,16 @@ async function browserTranscript(reqId, url, videoId, lang) {
   });
 }
 
-app.get('/health', (req, res) => {
+app.get("/health", (req, res) => {
   if (healthState.isRecovering) {
-    return res.status(503).json({ ok: false, engine: 'camoufox', recovering: true });
+    return res
+      .status(503)
+      .json({ ok: false, engine: "camoufox", recovering: true });
   }
   const running = browser !== null && (browser.isConnected?.() ?? false);
-  res.json({ 
-    ok: true, 
-    engine: 'camoufox',
+  res.json({
+    ok: true,
+    engine: "camoufox",
     browserConnected: running,
     browserRunning: running,
     activeTabs: getTotalTabCount(),
@@ -1256,151 +1509,219 @@ app.get('/health', (req, res) => {
   });
 });
 
-app.get('/metrics', async (_req, res) => {
-  res.set('Content-Type', metricsRegister.contentType);
+app.get("/metrics", async (_req, res) => {
+  res.set("Content-Type", metricsRegister.contentType);
   res.send(await metricsRegister.metrics());
 });
 
 // Create new tab
-app.post('/tabs', async (req, res) => {
+app.post("/tabs", async (req, res) => {
   try {
     const { userId, sessionKey, listItemId, url } = req.body;
     // Accept both sessionKey (preferred) and listItemId (legacy) for backward compatibility
     const resolvedSessionKey = sessionKey || listItemId;
     if (!userId || !resolvedSessionKey) {
-      return res.status(400).json({ error: 'userId and sessionKey required' });
+      return res.status(400).json({ error: "userId and sessionKey required" });
     }
-    
-    const result = await withTimeout((async () => {
-      const session = await getSession(userId);
-      
-      let totalTabs = 0;
-      for (const group of session.tabGroups.values()) totalTabs += group.size;
-      if (totalTabs >= MAX_TABS_PER_SESSION) {
-        throw Object.assign(new Error('Maximum tabs per session reached'), { statusCode: 429 });
-      }
-      
-      if (getTotalTabCount() >= MAX_TABS_GLOBAL) {
-        throw Object.assign(new Error('Maximum global tabs reached'), { statusCode: 429 });
-      }
-      
-      const group = getTabGroup(session, resolvedSessionKey);
-      
-      const page = await session.context.newPage();
-      const tabId = crypto.randomUUID();
-      const tabState = createTabState(page);
-      attachDownloadListener(tabState, tabId);
-      group.set(tabId, tabState);
-      refreshActiveTabsGauge();
-      
-      if (url) {
-        const urlErr = validateUrl(url);
-        if (urlErr) throw Object.assign(new Error(urlErr), { statusCode: 400 });
-        await withPageLoadDuration('open_url', () => page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 }));
-        tabState.visitedUrls.add(url);
-      }
-      
-      log('info', 'tab created', { reqId: req.reqId, tabId, userId, sessionKey: resolvedSessionKey, url: page.url() });
-      return { tabId, url: page.url() };
-    })(), HANDLER_TIMEOUT_MS, 'tab create');
+
+    const result = await withTimeout(
+      (async () => {
+        const session = await getSession(userId);
+
+        let totalTabs = 0;
+        for (const group of session.tabGroups.values()) totalTabs += group.size;
+        if (totalTabs >= MAX_TABS_PER_SESSION) {
+          throw Object.assign(new Error("Maximum tabs per session reached"), {
+            statusCode: 429,
+          });
+        }
+
+        if (getTotalTabCount() >= MAX_TABS_GLOBAL) {
+          throw Object.assign(new Error("Maximum global tabs reached"), {
+            statusCode: 429,
+          });
+        }
+
+        const group = getTabGroup(session, resolvedSessionKey);
+
+        const page = await session.context.newPage();
+        const tabId = crypto.randomUUID();
+        const tabState = createTabState(page);
+        attachDownloadListener(tabState, tabId);
+        group.set(tabId, tabState);
+        refreshActiveTabsGauge();
+
+        if (url) {
+          const urlErr = validateUrl(url);
+          if (urlErr)
+            throw Object.assign(new Error(urlErr), { statusCode: 400 });
+          await withPageLoadDuration("open_url", () =>
+            page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 }),
+          );
+          tabState.visitedUrls.add(url);
+        }
+
+        log("info", "tab created", {
+          reqId: req.reqId,
+          tabId,
+          userId,
+          sessionKey: resolvedSessionKey,
+          url: page.url(),
+        });
+        return { tabId, url: page.url() };
+      })(),
+      HANDLER_TIMEOUT_MS,
+      "tab create",
+    );
 
     res.json(result);
   } catch (err) {
-    log('error', 'tab create failed', { reqId: req.reqId, error: err.message });
+    log("error", "tab create failed", { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
   }
 });
 
 // Navigate
-app.post('/tabs/:tabId/navigate', async (req, res) => {
+app.post("/tabs/:tabId/navigate", async (req, res) => {
   const tabId = req.params.tabId;
-  
+
   try {
     const { userId, url, macro, query, sessionKey, listItemId } = req.body;
-    if (!userId) return res.status(400).json({ error: 'userId required' });
+    if (!userId) return res.status(400).json({ error: "userId required" });
 
-    const result = await withUserLimit(userId, () => withTimeout((async () => {
-      await ensureBrowser();
-      let session = sessions.get(normalizeUserId(userId));
-      let found = session && findTab(session, tabId);
-      
-      let tabState;
-      if (!found) {
-        const resolvedSessionKey = sessionKey || listItemId || 'default';
-        session = await getSession(userId);
-        let sessionTabs = 0;
-        for (const g of session.tabGroups.values()) sessionTabs += g.size;
-        if (getTotalTabCount() >= MAX_TABS_GLOBAL || sessionTabs >= MAX_TABS_PER_SESSION) {
-          // Reuse oldest tab in session instead of rejecting
-          let oldestTab = null;
-          let oldestGroup = null;
-          let oldestTabId = null;
-          for (const [gKey, group] of session.tabGroups) {
-            for (const [tid, ts] of group) {
-              if (!oldestTab || ts.toolCalls < oldestTab.toolCalls) {
-                oldestTab = ts;
-                oldestGroup = group;
-                oldestTabId = tid;
+    const result = await withUserLimit(userId, () =>
+      withTimeout(
+        (async () => {
+          await ensureBrowser();
+          let session = sessions.get(normalizeUserId(userId));
+          let found = session && findTab(session, tabId);
+
+          let tabState;
+          if (!found) {
+            const resolvedSessionKey = sessionKey || listItemId || "default";
+            session = await getSession(userId);
+            let sessionTabs = 0;
+            for (const g of session.tabGroups.values()) sessionTabs += g.size;
+            if (
+              getTotalTabCount() >= MAX_TABS_GLOBAL ||
+              sessionTabs >= MAX_TABS_PER_SESSION
+            ) {
+              // Reuse oldest tab in session instead of rejecting
+              let oldestTab = null;
+              let oldestGroup = null;
+              let oldestTabId = null;
+              for (const [gKey, group] of session.tabGroups) {
+                for (const [tid, ts] of group) {
+                  if (!oldestTab || ts.toolCalls < oldestTab.toolCalls) {
+                    oldestTab = ts;
+                    oldestGroup = group;
+                    oldestTabId = tid;
+                  }
+                }
               }
+              if (oldestTab) {
+                tabState = oldestTab;
+                const group = getTabGroup(session, resolvedSessionKey);
+                if (oldestGroup) oldestGroup.delete(oldestTabId);
+                group.set(tabId, tabState);
+                {
+                  const _l = tabLocks.get(oldestTabId);
+                  if (_l) _l.drain();
+                  tabLocks.delete(oldestTabId);
+                }
+                log("info", "tab recycled (limit reached)", {
+                  reqId: req.reqId,
+                  tabId,
+                  recycledFrom: oldestTabId,
+                  userId,
+                });
+              } else {
+                throw new Error("Maximum tabs per session reached");
+              }
+            } else {
+              const page = await session.context.newPage();
+              tabState = createTabState(page);
+              attachDownloadListener(tabState, tabId, log);
+              const group = getTabGroup(session, resolvedSessionKey);
+              group.set(tabId, tabState);
+              refreshActiveTabsGauge();
+              log("info", "tab auto-created on navigate", {
+                reqId: req.reqId,
+                tabId,
+                userId,
+              });
             }
-          }
-          if (oldestTab) {
-            tabState = oldestTab;
-            const group = getTabGroup(session, resolvedSessionKey);
-            if (oldestGroup) oldestGroup.delete(oldestTabId);
-            group.set(tabId, tabState);
-            { const _l = tabLocks.get(oldestTabId); if (_l) _l.drain(); tabLocks.delete(oldestTabId); }
-            log('info', 'tab recycled (limit reached)', { reqId: req.reqId, tabId, recycledFrom: oldestTabId, userId });
           } else {
-            throw new Error('Maximum tabs per session reached');
+            tabState = found.tabState;
           }
-        } else {
-          const page = await session.context.newPage();
-          tabState = createTabState(page);
-          attachDownloadListener(tabState, tabId, log);
-          const group = getTabGroup(session, resolvedSessionKey);
-          group.set(tabId, tabState);
-          refreshActiveTabsGauge();
-          log('info', 'tab auto-created on navigate', { reqId: req.reqId, tabId, userId });
-        }
-      } else {
-        tabState = found.tabState;
-      }
-      tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
-      
-      let targetUrl = url;
-      if (macro && macro !== '__NO__' && macro !== 'none' && macro !== 'null') {
-        targetUrl = expandMacro(macro, query) || url;
-      }
-      
-      if (!targetUrl) throw new Error('url or macro required');
-      
-      const urlErr = validateUrl(targetUrl);
-      if (urlErr) throw new Error(urlErr);
-      
-      return await withTabLock(tabId, async () => {
-        await withPageLoadDuration('navigate', () => tabState.page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 30000 }));
-        tabState.visitedUrls.add(targetUrl);
-        tabState.lastSnapshot = null;
-        
-        // For Google SERP: skip eager ref building during navigate.
-        // Results render asynchronously after DOMContentLoaded — the snapshot
-        // call will wait for and extract them.
-        if (isGoogleSerp(tabState.page.url())) {
-          tabState.refs = new Map();
-          return { ok: true, tabId, url: tabState.page.url(), refsAvailable: false, googleSerp: true };
-        }
-        
-        tabState.refs = await buildRefs(tabState.page);
-        return { ok: true, tabId, url: tabState.page.url(), refsAvailable: tabState.refs.size > 0 };
-      });
-    })(), HANDLER_TIMEOUT_MS, 'navigate'));
-    
-    log('info', 'navigated', { reqId: req.reqId, tabId, url: result.url });
+          tabState.toolCalls++;
+          tabState.consecutiveTimeouts = 0;
+
+          let targetUrl = url;
+          if (
+            macro &&
+            macro !== "__NO__" &&
+            macro !== "none" &&
+            macro !== "null"
+          ) {
+            targetUrl = expandMacro(macro, query) || url;
+          }
+
+          if (!targetUrl) throw new Error("url or macro required");
+
+          const urlErr = validateUrl(targetUrl);
+          if (urlErr) throw new Error(urlErr);
+
+          return await withTabLock(tabId, async () => {
+            await withPageLoadDuration("navigate", () =>
+              tabState.page.goto(targetUrl, {
+                waitUntil: "domcontentloaded",
+                timeout: 30000,
+              }),
+            );
+            tabState.visitedUrls.add(targetUrl);
+            tabState.lastSnapshot = null;
+
+            // For Google SERP: skip eager ref building during navigate.
+            // Results render asynchronously after DOMContentLoaded — the snapshot
+            // call will wait for and extract them.
+            if (isGoogleSerp(tabState.page.url())) {
+              tabState.refs = new Map();
+              return {
+                ok: true,
+                tabId,
+                url: tabState.page.url(),
+                refsAvailable: false,
+                googleSerp: true,
+              };
+            }
+
+            tabState.refs = await buildRefs(tabState.page);
+            return {
+              ok: true,
+              tabId,
+              url: tabState.page.url(),
+              refsAvailable: tabState.refs.size > 0,
+            };
+          });
+        })(),
+        HANDLER_TIMEOUT_MS,
+        "navigate",
+      ),
+    );
+
+    log("info", "navigated", { reqId: req.reqId, tabId, url: result.url });
     res.json(result);
   } catch (err) {
-    log('error', 'navigate failed', { reqId: req.reqId, tabId, error: err.message });
-    const is400 = err.message && (err.message.startsWith('Blocked URL scheme') || err.message === 'url or macro required');
+    log("error", "navigate failed", {
+      reqId: req.reqId,
+      tabId,
+      error: err.message,
+    });
+    const is400 =
+      err.message &&
+      (err.message.startsWith("Blocked URL scheme") ||
+        err.message === "url or macro required");
     if (is400) {
       return res.status(400).json({ error: safeError(err) });
     }
@@ -1409,97 +1730,23 @@ app.post('/tabs/:tabId/navigate', async (req, res) => {
 });
 
 // Snapshot
-app.get('/tabs/:tabId/snapshot', async (req, res) => {
+app.get("/tabs/:tabId/snapshot", async (req, res) => {
   try {
     const userId = req.query.userId;
-    if (!userId) return res.status(400).json({ error: 'userId required' });
-    const format = req.query.format || 'text';
+    if (!userId) return res.status(400).json({ error: "userId required" });
+    const format = req.query.format || "text";
     const offset = parseInt(req.query.offset) || 0;
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, req.params.tabId);
-    if (!found) return res.status(404).json({ error: 'Tab not found' });
-    
+    if (!found) return res.status(404).json({ error: "Tab not found" });
+
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++;
+    tabState.consecutiveTimeouts = 0;
 
     // Cached chunk retrieval for offset>0 requests
     if (offset > 0 && tabState.lastSnapshot) {
       const win = windowSnapshot(tabState.lastSnapshot, offset);
-      const response = { url: tabState.page.url(), snapshot: win.text, refsCount: tabState.refs.size, truncated: win.truncated, totalChars: win.totalChars, hasMore: win.hasMore, nextOffset: win.nextOffset };
-      if (req.query.includeScreenshot === 'true') {
-        const pngBuffer = await tabState.page.screenshot({ type: 'png' });
-        response.screenshot = { data: pngBuffer.toString('base64'), mimeType: 'image/png' };
-      }
-      log('info', 'snapshot (cached offset)', { reqId: req.reqId, tabId: req.params.tabId, offset, totalChars: win.totalChars });
-      return res.json(response);
-    }
-
-    const result = await withUserLimit(userId, () => withTimeout((async () => {
-      const pageUrl = tabState.page.url();
-      
-      // Google SERP fast path — DOM extraction instead of ariaSnapshot
-      if (isGoogleSerp(pageUrl)) {
-        const { refs: googleRefs, snapshot: googleSnapshot } = await extractGoogleSerp(tabState.page);
-        tabState.refs = googleRefs;
-        tabState.lastSnapshot = googleSnapshot;
-        const annotatedYaml = googleSnapshot;
-        const win = windowSnapshot(annotatedYaml, 0);
-        const response = {
-          url: pageUrl,
-          snapshot: win.text,
-          refsCount: tabState.refs.size,
-          truncated: win.truncated,
-          totalChars: win.totalChars,
-          hasMore: win.hasMore,
-          nextOffset: win.nextOffset,
-        };
-        if (req.query.includeScreenshot === 'true') {
-          const pngBuffer = await tabState.page.screenshot({ type: 'png' });
-          response.screenshot = { data: pngBuffer.toString('base64'), mimeType: 'image/png' };
-        }
-        return response;
-      }
-      
-      tabState.refs = await buildRefs(tabState.page);
-      const ariaYaml = await getAriaSnapshot(tabState.page);
-      
-      let annotatedYaml = ariaYaml || '';
-      if (annotatedYaml && tabState.refs.size > 0) {
-        const refsByKey = new Map();
-        for (const [refId, info] of tabState.refs) {
-          const key = `${info.role}:${info.name}:${info.nth}`;
-          refsByKey.set(key, refId);
-        }
-        
-        const annotationCounts = new Map();
-        const lines = annotatedYaml.split('\n');
-        
-        annotatedYaml = lines.map(line => {
-          const match = line.match(/^(\s*-\s+)(\w+)(\s+"([^"]*)")?(.*)$/);
-          if (match) {
-            const [, prefix, role, nameMatch, name, suffix] = match;
-            const normalizedRole = role.toLowerCase();
-            if (normalizedRole === 'combobox') return line;
-            if (name && SKIP_PATTERNS.some(p => p.test(name))) return line;
-            if (INTERACTIVE_ROLES.includes(normalizedRole)) {
-              const normalizedName = name || '';
-              const countKey = `${normalizedRole}:${normalizedName}`;
-              const nth = annotationCounts.get(countKey) || 0;
-              annotationCounts.set(countKey, nth + 1);
-              const key = `${normalizedRole}:${normalizedName}:${nth}`;
-              const refId = refsByKey.get(key);
-              if (refId) {
-                return `${prefix}${role}${nameMatch || ''} [${refId}]${suffix}`;
-              }
-            }
-          }
-          return line;
-        }).join('\n');
-      }
-      
-      tabState.lastSnapshot = annotatedYaml;
-      const win = windowSnapshot(annotatedYaml, 0);
-
       const response = {
         url: tabState.page.url(),
         snapshot: win.text,
@@ -1509,195 +1756,365 @@ app.get('/tabs/:tabId/snapshot', async (req, res) => {
         hasMore: win.hasMore,
         nextOffset: win.nextOffset,
       };
-
-      if (req.query.includeScreenshot === 'true') {
-        const pngBuffer = await tabState.page.screenshot({ type: 'png' });
-        response.screenshot = { data: pngBuffer.toString('base64'), mimeType: 'image/png' };
+      if (req.query.includeScreenshot === "true") {
+        const pngBuffer = await tabState.page.screenshot({ type: "png" });
+        response.screenshot = {
+          data: pngBuffer.toString("base64"),
+          mimeType: "image/png",
+        };
       }
+      log("info", "snapshot (cached offset)", {
+        reqId: req.reqId,
+        tabId: req.params.tabId,
+        offset,
+        totalChars: win.totalChars,
+      });
+      return res.json(response);
+    }
 
-      return response;
-    })(), HANDLER_TIMEOUT_MS, 'snapshot'));
+    const result = await withUserLimit(userId, () =>
+      withTimeout(
+        (async () => {
+          const pageUrl = tabState.page.url();
 
-    log('info', 'snapshot', { reqId: req.reqId, tabId: req.params.tabId, url: result.url, snapshotLen: result.snapshot?.length, refsCount: result.refsCount, hasScreenshot: !!result.screenshot, truncated: result.truncated });
+          // Google SERP fast path — DOM extraction instead of ariaSnapshot
+          if (isGoogleSerp(pageUrl)) {
+            const { refs: googleRefs, snapshot: googleSnapshot } =
+              await extractGoogleSerp(tabState.page);
+            tabState.refs = googleRefs;
+            tabState.lastSnapshot = googleSnapshot;
+            const annotatedYaml = googleSnapshot;
+            const win = windowSnapshot(annotatedYaml, 0);
+            const response = {
+              url: pageUrl,
+              snapshot: win.text,
+              refsCount: tabState.refs.size,
+              truncated: win.truncated,
+              totalChars: win.totalChars,
+              hasMore: win.hasMore,
+              nextOffset: win.nextOffset,
+            };
+            if (req.query.includeScreenshot === "true") {
+              const pngBuffer = await tabState.page.screenshot({ type: "png" });
+              response.screenshot = {
+                data: pngBuffer.toString("base64"),
+                mimeType: "image/png",
+              };
+            }
+            return response;
+          }
+
+          tabState.refs = await buildRefs(tabState.page);
+          const ariaYaml = await getAriaSnapshot(tabState.page);
+
+          let annotatedYaml = ariaYaml || "";
+          if (annotatedYaml && tabState.refs.size > 0) {
+            const refsByKey = new Map();
+            for (const [refId, info] of tabState.refs) {
+              const key = `${info.role}:${info.name}:${info.nth}`;
+              refsByKey.set(key, refId);
+            }
+
+            const annotationCounts = new Map();
+            const lines = annotatedYaml.split("\n");
+
+            annotatedYaml = lines
+              .map((line) => {
+                const match = line.match(/^(\s*-\s+)(\w+)(\s+"([^"]*)")?(.*)$/);
+                if (match) {
+                  const [, prefix, role, nameMatch, name, suffix] = match;
+                  const normalizedRole = role.toLowerCase();
+                  if (normalizedRole === "combobox") return line;
+                  if (name && SKIP_PATTERNS.some((p) => p.test(name)))
+                    return line;
+                  if (INTERACTIVE_ROLES.includes(normalizedRole)) {
+                    const normalizedName = name || "";
+                    const countKey = `${normalizedRole}:${normalizedName}`;
+                    const nth = annotationCounts.get(countKey) || 0;
+                    annotationCounts.set(countKey, nth + 1);
+                    const key = `${normalizedRole}:${normalizedName}:${nth}`;
+                    const refId = refsByKey.get(key);
+                    if (refId) {
+                      return `${prefix}${role}${nameMatch || ""} [${refId}]${suffix}`;
+                    }
+                  }
+                }
+                return line;
+              })
+              .join("\n");
+          }
+
+          tabState.lastSnapshot = annotatedYaml;
+          const win = windowSnapshot(annotatedYaml, 0);
+
+          const response = {
+            url: tabState.page.url(),
+            snapshot: win.text,
+            refsCount: tabState.refs.size,
+            truncated: win.truncated,
+            totalChars: win.totalChars,
+            hasMore: win.hasMore,
+            nextOffset: win.nextOffset,
+          };
+
+          if (req.query.includeScreenshot === "true") {
+            const pngBuffer = await tabState.page.screenshot({ type: "png" });
+            response.screenshot = {
+              data: pngBuffer.toString("base64"),
+              mimeType: "image/png",
+            };
+          }
+
+          return response;
+        })(),
+        HANDLER_TIMEOUT_MS,
+        "snapshot",
+      ),
+    );
+
+    log("info", "snapshot", {
+      reqId: req.reqId,
+      tabId: req.params.tabId,
+      url: result.url,
+      snapshotLen: result.snapshot?.length,
+      refsCount: result.refsCount,
+      hasScreenshot: !!result.screenshot,
+      truncated: result.truncated,
+    });
     res.json(result);
   } catch (err) {
-    log('error', 'snapshot failed', { reqId: req.reqId, tabId: req.params.tabId, error: err.message });
+    log("error", "snapshot failed", {
+      reqId: req.reqId,
+      tabId: req.params.tabId,
+      error: err.message,
+    });
     handleRouteError(err, req, res);
   }
 });
 
 // Wait for page ready
-app.post('/tabs/:tabId/wait', async (req, res) => {
+app.post("/tabs/:tabId/wait", async (req, res) => {
   try {
     const { userId, timeout = 10000, waitForNetwork = true } = req.body;
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, req.params.tabId);
-    if (!found) return res.status(404).json({ error: 'Tab not found' });
-    
+    if (!found) return res.status(404).json({ error: "Tab not found" });
+
     const { tabState } = found;
-    const ready = await waitForPageReady(tabState.page, { timeout, waitForNetwork });
-    
+    const ready = await waitForPageReady(tabState.page, {
+      timeout,
+      waitForNetwork,
+    });
+
     res.json({ ok: true, ready });
   } catch (err) {
-    log('error', 'wait failed', { reqId: req.reqId, error: err.message });
+    log("error", "wait failed", { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
   }
 });
 
 // Click
-app.post('/tabs/:tabId/click', async (req, res) => {
+app.post("/tabs/:tabId/click", async (req, res) => {
   const tabId = req.params.tabId;
-  
+
   try {
     const { userId, ref, selector } = req.body;
-    if (!userId) return res.status(400).json({ error: 'userId required' });
+    if (!userId) return res.status(400).json({ error: "userId required" });
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, tabId);
-    if (!found) return res.status(404).json({ error: 'Tab not found' });
-    
+    if (!found) return res.status(404).json({ error: "Tab not found" });
+
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
-    
+    tabState.toolCalls++;
+    tabState.consecutiveTimeouts = 0;
+
     if (!ref && !selector) {
-      return res.status(400).json({ error: 'ref or selector required' });
+      return res.status(400).json({ error: "ref or selector required" });
     }
-    
-    const result = await withUserLimit(userId, () => withTabLock(tabId, async () => {
-      const clickStart = Date.now();
-      const remainingBudget = () => Math.max(0, HANDLER_TIMEOUT_MS - 2000 - (Date.now() - clickStart));
-      // Full mouse event sequence for stubborn JS click handlers (mirrors Swift WebView.swift)
-      // Dispatches: mouseover → mouseenter → mousedown → mouseup → click
-      const dispatchMouseSequence = async (locator) => {
-        const box = await locator.boundingBox();
-        if (!box) throw new Error('Element not visible (no bounding box)');
-        
-        const x = box.x + box.width / 2;
-        const y = box.y + box.height / 2;
-        
-        // Move mouse to element (triggers mouseover/mouseenter)
-        await tabState.page.mouse.move(x, y);
-        await tabState.page.waitForTimeout(50);
-        
-        // Full click sequence
-        await tabState.page.mouse.down();
-        await tabState.page.waitForTimeout(50);
-        await tabState.page.mouse.up();
-        
-        log('info', 'mouse sequence dispatched', { x: x.toFixed(0), y: y.toFixed(0) });
-      };
-      
-      // On Google SERPs, skip the normal click attempt (always intercepted by overlays)
-      // and go directly to force click — saves 5s timeout per click
-      const onGoogleSerp = isGoogleSerp(tabState.page.url());
-      
-      const doClick = async (locatorOrSelector, isLocator) => {
-        const locator = isLocator ? locatorOrSelector : tabState.page.locator(locatorOrSelector);
-        
-        if (onGoogleSerp) {
-          try {
-            await locator.click({ timeout: 3000, force: true });
-          } catch (forceErr) {
-            log('warn', 'google force click failed, trying mouse sequence');
-            await dispatchMouseSequence(locator);
-          }
-          return;
-        }
-        
-        try {
-          // First try normal click (respects visibility, enabled, not-obscured)
-          await locator.click({ timeout: 3000 });
-        } catch (err) {
-          // Fallback 1: If intercepted by overlay, retry with force
-          if (err.message.includes('intercepts pointer events')) {
-            log('warn', 'click intercepted, retrying with force');
+
+    const result = await withUserLimit(userId, () =>
+      withTabLock(tabId, async () => {
+        const clickStart = Date.now();
+        const remainingBudget = () =>
+          Math.max(0, HANDLER_TIMEOUT_MS - 2000 - (Date.now() - clickStart));
+        // Full mouse event sequence for stubborn JS click handlers (mirrors Swift WebView.swift)
+        // Dispatches: mouseover → mouseenter → mousedown → mouseup → click
+        const dispatchMouseSequence = async (locator) => {
+          const box = await locator.boundingBox();
+          if (!box) throw new Error("Element not visible (no bounding box)");
+
+          const x = box.x + box.width / 2;
+          const y = box.y + box.height / 2;
+
+          // Move mouse to element (triggers mouseover/mouseenter)
+          await tabState.page.mouse.move(x, y);
+          await tabState.page.waitForTimeout(50);
+
+          // Full click sequence
+          await tabState.page.mouse.down();
+          await tabState.page.waitForTimeout(50);
+          await tabState.page.mouse.up();
+
+          log("info", "mouse sequence dispatched", {
+            x: x.toFixed(0),
+            y: y.toFixed(0),
+          });
+        };
+
+        // On Google SERPs, skip the normal click attempt (always intercepted by overlays)
+        // and go directly to force click — saves 5s timeout per click
+        const onGoogleSerp = isGoogleSerp(tabState.page.url());
+
+        const doClick = async (locatorOrSelector, isLocator) => {
+          const locator = isLocator
+            ? locatorOrSelector
+            : tabState.page.locator(locatorOrSelector);
+
+          if (onGoogleSerp) {
             try {
               await locator.click({ timeout: 3000, force: true });
             } catch (forceErr) {
-              // Fallback 2: Full mouse event sequence for stubborn JS handlers
-              log('warn', 'force click failed, trying mouse sequence');
+              log("warn", "google force click failed, trying mouse sequence");
               await dispatchMouseSequence(locator);
             }
-          } else if (err.message.includes('not visible') || err.message.toLowerCase().includes('timeout')) {
-            // Fallback 2: Element not responding to click, try mouse sequence
-            log('warn', 'click timeout, trying mouse sequence');
-            await dispatchMouseSequence(locator);
-          } else {
-            throw err;
+            return;
           }
-        }
-      };
-      
-      if (ref) {
-        let locator = refToLocator(tabState.page, ref, tabState.refs);
-        if (!locator) {
-          // Use tight timeout (4s max) to leave budget for click + post-click buildRefs
-          log('info', 'auto-refreshing refs before click', { ref, hadRefs: tabState.refs.size });
+
           try {
-            const preClickBudget = Math.min(4000, remainingBudget());
-            const refreshPromise = buildRefs(tabState.page);
-            const refreshBudget = new Promise((_, reject) => setTimeout(() => reject(new Error('pre_click_refs_timeout')), preClickBudget));
-            tabState.refs = await Promise.race([refreshPromise, refreshBudget]);
-          } catch (e) {
-            if (e.message === 'pre_click_refs_timeout' || e.message === 'buildRefs_timeout') {
-              log('warn', 'pre-click buildRefs timed out, proceeding without refresh');
+            // First try normal click (respects visibility, enabled, not-obscured)
+            await locator.click({ timeout: 3000 });
+          } catch (err) {
+            // Fallback 1: If intercepted by overlay, retry with force
+            if (err.message.includes("intercepts pointer events")) {
+              log("warn", "click intercepted, retrying with force");
+              try {
+                await locator.click({ timeout: 3000, force: true });
+              } catch (forceErr) {
+                // Fallback 2: Full mouse event sequence for stubborn JS handlers
+                log("warn", "force click failed, trying mouse sequence");
+                await dispatchMouseSequence(locator);
+              }
+            } else if (
+              err.message.includes("not visible") ||
+              err.message.toLowerCase().includes("timeout")
+            ) {
+              // Fallback 2: Element not responding to click, try mouse sequence
+              log("warn", "click timeout, trying mouse sequence");
+              await dispatchMouseSequence(locator);
             } else {
-              throw e;
+              throw err;
             }
           }
-          locator = refToLocator(tabState.page, ref, tabState.refs);
+        };
+
+        if (ref) {
+          let locator = refToLocator(tabState.page, ref, tabState.refs);
+          if (!locator) {
+            // Use tight timeout (4s max) to leave budget for click + post-click buildRefs
+            log("info", "auto-refreshing refs before click", {
+              ref,
+              hadRefs: tabState.refs.size,
+            });
+            try {
+              const preClickBudget = Math.min(4000, remainingBudget());
+              const refreshPromise = buildRefs(tabState.page);
+              const refreshBudget = new Promise((_, reject) =>
+                setTimeout(
+                  () => reject(new Error("pre_click_refs_timeout")),
+                  preClickBudget,
+                ),
+              );
+              tabState.refs = await Promise.race([
+                refreshPromise,
+                refreshBudget,
+              ]);
+            } catch (e) {
+              if (
+                e.message === "pre_click_refs_timeout" ||
+                e.message === "buildRefs_timeout"
+              ) {
+                log(
+                  "warn",
+                  "pre-click buildRefs timed out, proceeding without refresh",
+                );
+              } else {
+                throw e;
+              }
+            }
+            locator = refToLocator(tabState.page, ref, tabState.refs);
+          }
+          if (!locator) {
+            const maxRef =
+              tabState.refs.size > 0 ? `e${tabState.refs.size}` : "none";
+            throw new StaleRefsError(ref, maxRef, tabState.refs.size);
+          }
+          await doClick(locator, true);
+        } else {
+          await doClick(selector, false);
         }
-        if (!locator) {
-          const maxRef = tabState.refs.size > 0 ? `e${tabState.refs.size}` : 'none';
-          throw new StaleRefsError(ref, maxRef, tabState.refs.size);
+
+        // If clicking on a Google SERP, wait for potential navigation to complete
+        if (onGoogleSerp) {
+          try {
+            await tabState.page.waitForLoadState("domcontentloaded", {
+              timeout: 3000,
+            });
+          } catch {}
+          await tabState.page.waitForTimeout(200);
+          // Skip buildRefs here — SERP clicks typically navigate to a new page,
+          // and the caller always requests /snapshot next which rebuilds refs.
+          tabState.lastSnapshot = null;
+          tabState.refs = new Map();
+          const newUrl = tabState.page.url();
+          tabState.visitedUrls.add(newUrl);
+          return { ok: true, url: newUrl, refsAvailable: false };
+        } else {
+          await tabState.page.waitForTimeout(500);
         }
-        await doClick(locator, true);
-      } else {
-        await doClick(selector, false);
-      }
-      
-      // If clicking on a Google SERP, wait for potential navigation to complete
-      if (onGoogleSerp) {
-        try {
-          await tabState.page.waitForLoadState('domcontentloaded', { timeout: 3000 });
-        } catch {}
-        await tabState.page.waitForTimeout(200);
-        // Skip buildRefs here — SERP clicks typically navigate to a new page,
-        // and the caller always requests /snapshot next which rebuilds refs.
         tabState.lastSnapshot = null;
-        tabState.refs = new Map();
+        // buildRefs after click — use remaining budget (min 2s) so we don't blow the handler timeout.
+        // If it times out, return without refs (caller's next /snapshot will rebuild them).
+        const postClickBudget = Math.max(2000, remainingBudget());
+        try {
+          const refsPromise = buildRefs(tabState.page);
+          const refsBudget = new Promise((_, reject) =>
+            setTimeout(
+              () => reject(new Error("post_click_refs_timeout")),
+              postClickBudget,
+            ),
+          );
+          tabState.refs = await Promise.race([refsPromise, refsBudget]);
+        } catch (e) {
+          if (
+            e.message === "post_click_refs_timeout" ||
+            e.message === "buildRefs_timeout"
+          ) {
+            log(
+              "warn",
+              "post-click buildRefs timed out, returning without refs",
+              { budget: postClickBudget, elapsed: Date.now() - clickStart },
+            );
+            tabState.refs = new Map();
+          } else {
+            throw e;
+          }
+        }
+
         const newUrl = tabState.page.url();
         tabState.visitedUrls.add(newUrl);
-        return { ok: true, url: newUrl, refsAvailable: false };
-      } else {
-        await tabState.page.waitForTimeout(500);
-      }
-      tabState.lastSnapshot = null;
-      // buildRefs after click — use remaining budget (min 2s) so we don't blow the handler timeout.
-      // If it times out, return without refs (caller's next /snapshot will rebuild them).
-      const postClickBudget = Math.max(2000, remainingBudget());
-      try {
-        const refsPromise = buildRefs(tabState.page);
-        const refsBudget = new Promise((_, reject) => setTimeout(() => reject(new Error('post_click_refs_timeout')), postClickBudget));
-        tabState.refs = await Promise.race([refsPromise, refsBudget]);
-      } catch (e) {
-        if (e.message === 'post_click_refs_timeout' || e.message === 'buildRefs_timeout') {
-          log('warn', 'post-click buildRefs timed out, returning without refs', { budget: postClickBudget, elapsed: Date.now() - clickStart });
-          tabState.refs = new Map();
-        } else {
-          throw e;
-        }
-      }
-      
-      const newUrl = tabState.page.url();
-      tabState.visitedUrls.add(newUrl);
-      return { ok: true, url: newUrl, refsAvailable: tabState.refs.size > 0 };
-    }));
-    
-    log('info', 'clicked', { reqId: req.reqId, tabId, url: result.url });
+        return { ok: true, url: newUrl, refsAvailable: tabState.refs.size > 0 };
+      }),
+    );
+
+    log("info", "clicked", { reqId: req.reqId, tabId, url: result.url });
     res.json(result);
   } catch (err) {
-    log('error', 'click failed', { reqId: req.reqId, tabId, error: err.message });
-    if (err.message?.includes('timed out')) {
+    log("error", "click failed", {
+      reqId: req.reqId,
+      tabId,
+      error: err.message,
+    });
+    if (err.message?.includes("timed out")) {
       try {
         const session = sessions.get(normalizeUserId(req.body.userId));
         const found = session && findTab(session, tabId);
@@ -1706,13 +2123,15 @@ app.post('/tabs/:tabId/click', async (req, res) => {
           found.tabState.lastSnapshot = null;
           return res.status(500).json({
             error: safeError(err),
-            hint: 'The page may have changed. Call snapshot to see the current state and retry.',
+            hint: "The page may have changed. Call snapshot to see the current state and retry.",
             url: found.tabState.page.url(),
             refsCount: found.tabState.refs.size,
           });
         }
       } catch (refreshErr) {
-        log('warn', 'post-timeout refresh failed', { error: refreshErr.message });
+        log("warn", "post-timeout refresh failed", {
+          error: refreshErr.message,
+        });
       }
     }
     handleRouteError(err, req, res);
@@ -1720,41 +2139,52 @@ app.post('/tabs/:tabId/click', async (req, res) => {
 });
 
 // Type
-app.post('/tabs/:tabId/type', async (req, res) => {
+app.post("/tabs/:tabId/type", async (req, res) => {
   const tabId = req.params.tabId;
-  
+
   try {
     const { userId, ref, selector, text } = req.body;
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, tabId);
-    if (!found) return res.status(404).json({ error: 'Tab not found' });
-    
+    if (!found) return res.status(404).json({ error: "Tab not found" });
+
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
-    
+    tabState.toolCalls++;
+    tabState.consecutiveTimeouts = 0;
+
     if (!ref && !selector) {
-      return res.status(400).json({ error: 'ref or selector required' });
+      return res.status(400).json({ error: "ref or selector required" });
     }
-    
+
     await withTabLock(tabId, async () => {
       if (ref) {
         let locator = refToLocator(tabState.page, ref, tabState.refs);
         if (!locator) {
-          log('info', 'auto-refreshing refs before fill', { ref, hadRefs: tabState.refs.size });
+          log("info", "auto-refreshing refs before fill", {
+            ref,
+            hadRefs: tabState.refs.size,
+          });
           tabState.refs = await buildRefs(tabState.page);
           locator = refToLocator(tabState.page, ref, tabState.refs);
         }
-        if (!locator) { const maxRef = tabState.refs.size > 0 ? `e${tabState.refs.size}` : 'none'; throw new StaleRefsError(ref, maxRef, tabState.refs.size); }
+        if (!locator) {
+          const maxRef =
+            tabState.refs.size > 0 ? `e${tabState.refs.size}` : "none";
+          throw new StaleRefsError(ref, maxRef, tabState.refs.size);
+        }
         await locator.fill(text, { timeout: 10000 });
       } else {
         await tabState.page.fill(selector, text, { timeout: 10000 });
       }
     });
-    
+
     res.json({ ok: true });
   } catch (err) {
-    log('error', 'type failed', { reqId: req.reqId, error: err.message });
-    if (err.message?.includes('timed out') || err.message?.includes('not an <input>')) {
+    log("error", "type failed", { reqId: req.reqId, error: err.message });
+    if (
+      err.message?.includes("timed out") ||
+      err.message?.includes("not an <input>")
+    ) {
       try {
         const session = sessions.get(normalizeUserId(req.body.userId));
         const found = session && findTab(session, tabId);
@@ -1763,13 +2193,15 @@ app.post('/tabs/:tabId/type', async (req, res) => {
           found.tabState.lastSnapshot = null;
           return res.status(500).json({
             error: safeError(err),
-            hint: 'The page may have changed. Call snapshot to see the current state and retry.',
+            hint: "The page may have changed. Call snapshot to see the current state and retry.",
             url: found.tabState.page.url(),
             refsCount: found.tabState.refs.size,
           });
         }
       } catch (refreshErr) {
-        log('warn', 'post-timeout refresh failed', { error: refreshErr.message });
+        log("warn", "post-timeout refresh failed", {
+          error: refreshErr.message,
+        });
       }
     }
     handleRouteError(err, req, res);
@@ -1777,72 +2209,78 @@ app.post('/tabs/:tabId/type', async (req, res) => {
 });
 
 // Press key
-app.post('/tabs/:tabId/press', async (req, res) => {
+app.post("/tabs/:tabId/press", async (req, res) => {
   const tabId = req.params.tabId;
-  
+
   try {
     const { userId, key } = req.body;
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, tabId);
-    if (!found) return res.status(404).json({ error: 'Tab not found' });
-    
+    if (!found) return res.status(404).json({ error: "Tab not found" });
+
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
-    
+    tabState.toolCalls++;
+    tabState.consecutiveTimeouts = 0;
+
     await withTabLock(tabId, async () => {
       await tabState.page.keyboard.press(key);
     });
-    
+
     res.json({ ok: true });
   } catch (err) {
-    log('error', 'press failed', { reqId: req.reqId, error: err.message });
+    log("error", "press failed", { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
   }
 });
 
 // Scroll
-app.post('/tabs/:tabId/scroll', async (req, res) => {
+app.post("/tabs/:tabId/scroll", async (req, res) => {
   try {
-    const { userId, direction = 'down', amount = 500 } = req.body;
+    const { userId, direction = "down", amount = 500 } = req.body;
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, req.params.tabId);
-    if (!found) return res.status(404).json({ error: 'Tab not found' });
-    
+    if (!found) return res.status(404).json({ error: "Tab not found" });
+
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
-    
-    const delta = direction === 'up' ? -amount : amount;
+    tabState.toolCalls++;
+    tabState.consecutiveTimeouts = 0;
+
+    const delta = direction === "up" ? -amount : amount;
     await tabState.page.mouse.wheel(0, delta);
     await tabState.page.waitForTimeout(300);
-    
+
     res.json({ ok: true });
   } catch (err) {
-    log('error', 'scroll failed', { reqId: req.reqId, error: err.message });
+    log("error", "scroll failed", { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
   }
 });
 
 // Back
-app.post('/tabs/:tabId/back', async (req, res) => {
+app.post("/tabs/:tabId/back", async (req, res) => {
   const tabId = req.params.tabId;
-  
+
   try {
     const { userId } = req.body;
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, tabId);
-    if (!found) return res.status(404).json({ error: 'Tab not found' });
-    
+    if (!found) return res.status(404).json({ error: "Tab not found" });
+
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
-    
+    tabState.toolCalls++;
+    tabState.consecutiveTimeouts = 0;
+
     const result = await withTabLock(tabId, async () => {
       try {
         await tabState.page.goBack({ timeout: 10000 });
       } catch (navErr) {
         // NS_BINDING_CANCELLED_OLD_LOAD: Firefox cancels the old load when going back.
         // The navigation itself succeeded — just the prior page's load was interrupted.
-        if (navErr.message && navErr.message.includes('NS_BINDING_CANCELLED')) {
-          log('info', 'goBack cancelled old load (expected)', { reqId: req.reqId, tabId });
+        if (navErr.message && navErr.message.includes("NS_BINDING_CANCELLED")) {
+          log("info", "goBack cancelled old load (expected)", {
+            reqId: req.reqId,
+            tabId,
+          });
         } else {
           throw navErr;
         }
@@ -1850,68 +2288,70 @@ app.post('/tabs/:tabId/back', async (req, res) => {
       tabState.refs = await buildRefs(tabState.page);
       return { ok: true, url: tabState.page.url() };
     });
-    
+
     res.json(result);
   } catch (err) {
-    log('error', 'back failed', { reqId: req.reqId, error: err.message });
+    log("error", "back failed", { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
   }
 });
 
 // Forward
-app.post('/tabs/:tabId/forward', async (req, res) => {
+app.post("/tabs/:tabId/forward", async (req, res) => {
   const tabId = req.params.tabId;
-  
+
   try {
     const { userId } = req.body;
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, tabId);
-    if (!found) return res.status(404).json({ error: 'Tab not found' });
-    
+    if (!found) return res.status(404).json({ error: "Tab not found" });
+
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
-    
+    tabState.toolCalls++;
+    tabState.consecutiveTimeouts = 0;
+
     const result = await withTabLock(tabId, async () => {
       await tabState.page.goForward({ timeout: 10000 });
       tabState.refs = await buildRefs(tabState.page);
       return { ok: true, url: tabState.page.url() };
     });
-    
+
     res.json(result);
   } catch (err) {
-    log('error', 'forward failed', { reqId: req.reqId, error: err.message });
+    log("error", "forward failed", { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
   }
 });
 
 // Refresh
-app.post('/tabs/:tabId/refresh', async (req, res) => {
+app.post("/tabs/:tabId/refresh", async (req, res) => {
   const tabId = req.params.tabId;
-  
+
   try {
     const { userId } = req.body;
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, tabId);
-    if (!found) return res.status(404).json({ error: 'Tab not found' });
-    
+    if (!found) return res.status(404).json({ error: "Tab not found" });
+
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
-    
+    tabState.toolCalls++;
+    tabState.consecutiveTimeouts = 0;
+
     const result = await withTabLock(tabId, async () => {
       await tabState.page.reload({ timeout: 30000 });
       tabState.refs = await buildRefs(tabState.page);
       return { ok: true, url: tabState.page.url() };
     });
-    
+
     res.json(result);
   } catch (err) {
-    log('error', 'refresh failed', { reqId: req.reqId, error: err.message });
+    log("error", "refresh failed", { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
   }
 });
 
 // Get links
-app.get('/tabs/:tabId/links', async (req, res) => {
+app.get("/tabs/:tabId/links", async (req, res) => {
   try {
     const userId = req.query.userId;
     const limit = parseInt(req.query.limit) || 50;
@@ -1919,54 +2359,66 @@ app.get('/tabs/:tabId/links', async (req, res) => {
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, req.params.tabId);
     if (!found) {
-      log('warn', 'links: tab not found', { reqId: req.reqId, tabId: req.params.tabId, userId, hasSession: !!session });
-      return res.status(404).json({ error: 'Tab not found' });
+      log("warn", "links: tab not found", {
+        reqId: req.reqId,
+        tabId: req.params.tabId,
+        userId,
+        hasSession: !!session,
+      });
+      return res.status(404).json({ error: "Tab not found" });
     }
-    
+
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
-    
+    tabState.toolCalls++;
+    tabState.consecutiveTimeouts = 0;
+
     const allLinks = await tabState.page.evaluate(() => {
       const links = [];
-      document.querySelectorAll('a[href]').forEach(a => {
+      document.querySelectorAll("a[href]").forEach((a) => {
         const href = a.href;
-        const text = a.textContent?.trim().slice(0, 100) || '';
-        if (href && href.startsWith('http')) {
+        const text = a.textContent?.trim().slice(0, 100) || "";
+        if (href && href.startsWith("http")) {
           links.push({ url: href, text });
         }
       });
       return links;
     });
-    
+
     const total = allLinks.length;
     const paginated = allLinks.slice(offset, offset + limit);
-    
+
     res.json({
       links: paginated,
-      pagination: { total, offset, limit, hasMore: offset + limit < total }
+      pagination: { total, offset, limit, hasMore: offset + limit < total },
     });
   } catch (err) {
-    log('error', 'links failed', { reqId: req.reqId, error: err.message });
+    log("error", "links failed", { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
   }
 });
 
 // Get captured downloads
-app.get('/tabs/:tabId/downloads', async (req, res) => {
+app.get("/tabs/:tabId/downloads", async (req, res) => {
   try {
     const userId = req.query.userId;
-    const includeData = req.query.includeData === 'true';
-    const consume = req.query.consume === 'true';
+    const includeData = req.query.includeData === "true";
+    const consume = req.query.consume === "true";
     const maxBytesRaw = Number(req.query.maxBytes);
-    const maxBytes = Number.isFinite(maxBytesRaw) && maxBytesRaw > 0 ? maxBytesRaw : MAX_DOWNLOAD_INLINE_BYTES;
+    const maxBytes =
+      Number.isFinite(maxBytesRaw) && maxBytesRaw > 0
+        ? maxBytesRaw
+        : MAX_DOWNLOAD_INLINE_BYTES;
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, req.params.tabId);
-    if (!found) return res.status(404).json({ error: 'Tab not found' });
+    if (!found) return res.status(404).json({ error: "Tab not found" });
 
     const { tabState } = found;
     tabState.toolCalls++;
 
-    const downloads = await getDownloadsList(tabState, { includeData, maxBytes });
+    const downloads = await getDownloadsList(tabState, {
+      includeData,
+      maxBytes,
+    });
 
     if (consume) {
       await clearTabDownloads(tabState);
@@ -1974,63 +2426,73 @@ app.get('/tabs/:tabId/downloads', async (req, res) => {
 
     res.json({ tabId: req.params.tabId, downloads });
   } catch (err) {
-    log('error', 'downloads failed', { reqId: req.reqId, error: err.message });
+    log("error", "downloads failed", { reqId: req.reqId, error: err.message });
     res.status(500).json({ error: safeError(err) });
   }
 });
 
 // Get image elements from current page
-app.get('/tabs/:tabId/images', async (req, res) => {
+app.get("/tabs/:tabId/images", async (req, res) => {
   try {
     const userId = req.query.userId;
-    const includeData = req.query.includeData === 'true';
+    const includeData = req.query.includeData === "true";
     const maxBytesRaw = Number(req.query.maxBytes);
     const limitRaw = Number(req.query.limit);
-    const maxBytes = Number.isFinite(maxBytesRaw) && maxBytesRaw > 0 ? maxBytesRaw : MAX_DOWNLOAD_INLINE_BYTES;
-    const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(Math.floor(limitRaw), 20) : 8;
+    const maxBytes =
+      Number.isFinite(maxBytesRaw) && maxBytesRaw > 0
+        ? maxBytesRaw
+        : MAX_DOWNLOAD_INLINE_BYTES;
+    const limit =
+      Number.isFinite(limitRaw) && limitRaw > 0
+        ? Math.min(Math.floor(limitRaw), 20)
+        : 8;
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, req.params.tabId);
-    if (!found) return res.status(404).json({ error: 'Tab not found' });
+    if (!found) return res.status(404).json({ error: "Tab not found" });
 
     const { tabState } = found;
     tabState.toolCalls++;
 
-    const images = await extractPageImages(tabState.page, { includeData, maxBytes, limit });
+    const images = await extractPageImages(tabState.page, {
+      includeData,
+      maxBytes,
+      limit,
+    });
 
     res.json({ tabId: req.params.tabId, images });
   } catch (err) {
-    log('error', 'images failed', { reqId: req.reqId, error: err.message });
+    log("error", "images failed", { reqId: req.reqId, error: err.message });
     res.status(500).json({ error: safeError(err) });
   }
 });
 
 // Screenshot
-app.get('/tabs/:tabId/screenshot', async (req, res) => {
+app.get("/tabs/:tabId/screenshot", async (req, res) => {
   try {
     const userId = req.query.userId;
-    const fullPage = req.query.fullPage === 'true';
+    const fullPage = req.query.fullPage === "true";
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, req.params.tabId);
-    if (!found) return res.status(404).json({ error: 'Tab not found' });
-    
+    if (!found) return res.status(404).json({ error: "Tab not found" });
+
     const { tabState } = found;
-    const buffer = await tabState.page.screenshot({ type: 'png', fullPage });
-    res.set('Content-Type', 'image/png');
+    const buffer = await tabState.page.screenshot({ type: "png", fullPage });
+    res.set("Content-Type", "image/png");
     res.send(buffer);
   } catch (err) {
-    log('error', 'screenshot failed', { reqId: req.reqId, error: err.message });
+    log("error", "screenshot failed", { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
   }
 });
 
 // Stats
-app.get('/tabs/:tabId/stats', async (req, res) => {
+app.get("/tabs/:tabId/stats", async (req, res) => {
   try {
     const userId = req.query.userId;
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, req.params.tabId);
-    if (!found) return res.status(404).json({ error: 'Tab not found' });
-    
+    if (!found) return res.status(404).json({ error: "Tab not found" });
+
     const { tabState, listItemId } = found;
     res.json({
       tabId: req.params.tabId,
@@ -2038,42 +2500,55 @@ app.get('/tabs/:tabId/stats', async (req, res) => {
       listItemId, // Legacy compatibility
       url: tabState.page.url(),
       visitedUrls: Array.from(tabState.visitedUrls),
-      downloadsCount: Array.isArray(tabState.downloads) ? tabState.downloads.length : 0,
+      downloadsCount: Array.isArray(tabState.downloads)
+        ? tabState.downloads.length
+        : 0,
       toolCalls: tabState.toolCalls,
-      refsCount: tabState.refs.size
+      refsCount: tabState.refs.size,
     });
   } catch (err) {
-    log('error', 'stats failed', { reqId: req.reqId, error: err.message });
+    log("error", "stats failed", { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
   }
 });
 
 // Evaluate JavaScript in page context
-app.post('/tabs/:tabId/evaluate', express.json({ limit: '1mb' }), async (req, res) => {
-  try {
-    const { userId, expression } = req.body;
-    if (!userId) return res.status(400).json({ error: 'userId is required' });
-    if (!expression) return res.status(400).json({ error: 'expression is required' });
+app.post(
+  "/tabs/:tabId/evaluate",
+  express.json({ limit: "1mb" }),
+  async (req, res) => {
+    try {
+      const { userId, expression } = req.body;
+      if (!userId) return res.status(400).json({ error: "userId is required" });
+      if (!expression)
+        return res.status(400).json({ error: "expression is required" });
 
-    const session = sessions.get(normalizeUserId(userId));
-    const found = session && findTab(session, req.params.tabId);
-    if (!found) return res.status(404).json({ error: 'Tab not found' });
+      const session = sessions.get(normalizeUserId(userId));
+      const found = session && findTab(session, req.params.tabId);
+      if (!found) return res.status(404).json({ error: "Tab not found" });
 
-    session.lastAccess = Date.now();
-    const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+      session.lastAccess = Date.now();
+      const { tabState } = found;
+      tabState.toolCalls++;
+      tabState.consecutiveTimeouts = 0;
 
-    const result = await tabState.page.evaluate(expression);
-    log('info', 'evaluate', { reqId: req.reqId, tabId: req.params.tabId, userId, resultType: typeof result });
-    res.json({ ok: true, result });
-  } catch (err) {
-    log('error', 'evaluate failed', { reqId: req.reqId, error: err.message });
-    res.status(500).json({ error: safeError(err) });
-  }
-});
+      const result = await tabState.page.evaluate(expression);
+      log("info", "evaluate", {
+        reqId: req.reqId,
+        tabId: req.params.tabId,
+        userId,
+        resultType: typeof result,
+      });
+      res.json({ ok: true, result });
+    } catch (err) {
+      log("error", "evaluate failed", { reqId: req.reqId, error: err.message });
+      res.status(500).json({ error: safeError(err) });
+    }
+  },
+);
 
 // Close tab
-app.delete('/tabs/:tabId', async (req, res) => {
+app.delete("/tabs/:tabId", async (req, res) => {
   try {
     const { userId } = req.body;
     const session = sessions.get(normalizeUserId(userId));
@@ -2082,22 +2557,31 @@ app.delete('/tabs/:tabId', async (req, res) => {
       await clearTabDownloads(found.tabState);
       await safePageClose(found.tabState.page);
       found.group.delete(req.params.tabId);
-      { const _l = tabLocks.get(req.params.tabId); if (_l) _l.drain(); tabLocks.delete(req.params.tabId); refreshTabLockQueueDepth(); }
+      {
+        const _l = tabLocks.get(req.params.tabId);
+        if (_l) _l.drain();
+        tabLocks.delete(req.params.tabId);
+        refreshTabLockQueueDepth();
+      }
       if (found.group.size === 0) {
         session.tabGroups.delete(found.listItemId);
       }
       refreshActiveTabsGauge();
-      log('info', 'tab closed', { reqId: req.reqId, tabId: req.params.tabId, userId });
+      log("info", "tab closed", {
+        reqId: req.reqId,
+        tabId: req.params.tabId,
+        userId,
+      });
     }
     res.json({ ok: true });
   } catch (err) {
-    log('error', 'tab close failed', { reqId: req.reqId, error: err.message });
+    log("error", "tab close failed", { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
   }
 });
 
 // Close tab group
-app.delete('/tabs/group/:listItemId', async (req, res) => {
+app.delete("/tabs/group/:listItemId", async (req, res) => {
   try {
     const { userId } = req.body;
     const session = sessions.get(normalizeUserId(userId));
@@ -2115,17 +2599,24 @@ app.delete('/tabs/group/:listItemId', async (req, res) => {
       session.tabGroups.delete(req.params.listItemId);
       refreshTabLockQueueDepth();
       refreshActiveTabsGauge();
-      log('info', 'tab group closed', { reqId: req.reqId, listItemId: req.params.listItemId, userId });
+      log("info", "tab group closed", {
+        reqId: req.reqId,
+        listItemId: req.params.listItemId,
+        userId,
+      });
     }
     res.json({ ok: true });
   } catch (err) {
-    log('error', 'tab group close failed', { reqId: req.reqId, error: err.message });
+    log("error", "tab group close failed", {
+      reqId: req.reqId,
+      error: err.message,
+    });
     handleRouteError(err, req, res);
   }
 });
 
 // Close session
-app.delete('/sessions/:userId', async (req, res) => {
+app.delete("/sessions/:userId", async (req, res) => {
   try {
     const userId = normalizeUserId(req.params.userId);
     const session = sessions.get(userId);
@@ -2145,12 +2636,12 @@ app.delete('/sessions/:userId', async (req, res) => {
       }
       refreshTabLockQueueDepth();
       refreshActiveTabsGauge();
-      log('info', 'session closed', { userId });
+      log("info", "session closed", { userId });
     }
     if (sessions.size === 0) scheduleBrowserIdleShutdown();
     res.json({ ok: true });
   } catch (err) {
-    log('error', 'session close failed', { error: err.message });
+    log("error", "session close failed", { error: err.message });
     handleRouteError(err, req, res);
   }
 });
@@ -2164,7 +2655,7 @@ setInterval(() => {
       session.context.close().catch(() => {});
       sessions.delete(userId);
       refreshActiveTabsGauge();
-      log('info', 'session expired', { userId });
+      log("info", "session expired", { userId });
     }
   }
   // When all sessions gone, start idle timer to kill browser
@@ -2188,10 +2679,20 @@ setInterval(() => {
         if (tabState.toolCalls === tabState._lastReaperToolCalls) {
           const idleMs = now - tabState._lastReaperCheck;
           if (idleMs >= TAB_INACTIVITY_MS) {
-            log('info', 'tab reaped (inactive)', { userId, tabId, listItemId, idleMs, toolCalls: tabState.toolCalls });
+            log("info", "tab reaped (inactive)", {
+              userId,
+              tabId,
+              listItemId,
+              idleMs,
+              toolCalls: tabState.toolCalls,
+            });
             safePageClose(tabState.page);
             group.delete(tabId);
-            { const _l = tabLocks.get(tabId); if (_l) _l.drain(); tabLocks.delete(tabId); }
+            {
+              const _l = tabLocks.get(tabId);
+              if (_l) _l.drain();
+              tabLocks.delete(tabId);
+            }
             refreshTabLockQueueDepth();
             refreshActiveTabsGauge();
           }
@@ -2213,28 +2714,28 @@ setInterval(() => {
 // =============================================================================
 
 // GET / - Status (passive — does not launch browser)
-app.get('/', (req, res) => {
+app.get("/", (req, res) => {
   const running = browser !== null && (browser.isConnected?.() ?? false);
-  res.json({ 
+  res.json({
     ok: true,
     enabled: true,
     running,
-    engine: 'camoufox',
+    engine: "camoufox",
     browserConnected: running,
     browserRunning: running,
   });
 });
 
 // GET /tabs - List all tabs (OpenClaw expects this)
-app.get('/tabs', async (req, res) => {
+app.get("/tabs", async (req, res) => {
   try {
     const userId = req.query.userId;
     const session = sessions.get(normalizeUserId(userId));
-    
+
     if (!session) {
       return res.json({ running: true, tabs: [] });
     }
-    
+
     const tabs = [];
     for (const [listItemId, group] of session.tabGroups) {
       for (const [tabId, tabState] of group) {
@@ -2242,88 +2743,99 @@ app.get('/tabs', async (req, res) => {
           targetId: tabId,
           tabId,
           url: tabState.page.url(),
-          title: await tabState.page.title().catch(() => ''),
-          listItemId
+          title: await tabState.page.title().catch(() => ""),
+          listItemId,
         });
       }
     }
-    
+
     res.json({ running: true, tabs });
   } catch (err) {
-    log('error', 'list tabs failed', { reqId: req.reqId, error: err.message });
+    log("error", "list tabs failed", { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
   }
 });
 
 // POST /tabs/open - Open tab (alias for POST /tabs, OpenClaw format)
-app.post('/tabs/open', async (req, res) => {
+app.post("/tabs/open", async (req, res) => {
   try {
-    const { url, userId, listItemId = 'default' } = req.body;
+    const { url, userId, listItemId = "default" } = req.body;
     if (!userId) {
-      return res.status(400).json({ error: 'userId is required' });
+      return res.status(400).json({ error: "userId is required" });
     }
     if (!url) {
-      return res.status(400).json({ error: 'url is required' });
+      return res.status(400).json({ error: "url is required" });
     }
-    
+
     const urlErr = validateUrl(url);
     if (urlErr) return res.status(400).json({ error: urlErr });
-    
+
     const session = await getSession(userId);
-    
+
     // Check global tab limit first
     if (getTotalTabCount() >= MAX_TABS_GLOBAL) {
-      return res.status(429).json({ error: 'Maximum global tabs reached' });
+      return res.status(429).json({ error: "Maximum global tabs reached" });
     }
-    
+
     let totalTabs = 0;
     for (const g of session.tabGroups.values()) totalTabs += g.size;
     if (totalTabs >= MAX_TABS_PER_SESSION) {
-      return res.status(429).json({ error: 'Maximum tabs per session reached' });
+      return res
+        .status(429)
+        .json({ error: "Maximum tabs per session reached" });
     }
-    
+
     const group = getTabGroup(session, listItemId);
-    
+
     const page = await session.context.newPage();
     const tabId = crypto.randomUUID();
     const tabState = createTabState(page);
     attachDownloadListener(tabState, tabId, log);
     group.set(tabId, tabState);
     refreshActiveTabsGauge();
-    
-    await withPageLoadDuration('open_url', () => page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 }));
+
+    await withPageLoadDuration("open_url", () =>
+      page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 }),
+    );
     tabState.visitedUrls.add(url);
-    
-    log('info', 'openclaw tab opened', { reqId: req.reqId, tabId, url: page.url() });
-    res.json({ 
+
+    log("info", "openclaw tab opened", {
+      reqId: req.reqId,
+      tabId,
+      url: page.url(),
+    });
+    res.json({
       ok: true,
       targetId: tabId,
       tabId,
       url: page.url(),
-      title: await page.title().catch(() => '')
+      title: await page.title().catch(() => ""),
     });
   } catch (err) {
-    log('error', 'openclaw tab open failed', { reqId: req.reqId, error: err.message });
+    log("error", "openclaw tab open failed", {
+      reqId: req.reqId,
+      error: err.message,
+    });
     handleRouteError(err, req, res);
   }
 });
 
 // POST /start - Start browser (OpenClaw expects this)
-app.post('/start', async (req, res) => {
+app.post("/start", async (req, res) => {
   try {
     await ensureBrowser();
-    res.json({ ok: true, profile: 'camoufox' });
+    res.json({ ok: true, profile: "camoufox" });
   } catch (err) {
     res.status(500).json({ ok: false, error: safeError(err) });
   }
 });
 
 // POST /stop - Stop browser (OpenClaw expects this)
-app.post('/stop', async (req, res) => {
+app.post("/stop", async (req, res) => {
   try {
-    const adminKey = req.headers['x-admin-key'];
+    const adminKey = req.headers["x-admin-key"];
     if (!adminKey || !timingSafeCompare(adminKey, CONFIG.adminKey)) {
-      return res.status(403).json({ error: 'Forbidden' });
+      return res.status(403).json({ error: "Forbidden" });
     }
     if (browser) {
       await browser.close().catch(() => {});
@@ -2349,142 +2861,183 @@ app.post('/stop', async (req, res) => {
     sessions.clear();
     refreshActiveTabsGauge();
     refreshTabLockQueueDepth();
-    res.json({ ok: true, stopped: true, profile: 'camoufox' });
+    res.json({ ok: true, stopped: true, profile: "camoufox" });
   } catch (err) {
     res.status(500).json({ ok: false, error: safeError(err) });
   }
 });
 
 // POST /navigate - Navigate (OpenClaw format with targetId in body)
-app.post('/navigate', async (req, res) => {
+app.post("/navigate", async (req, res) => {
   try {
     const { targetId, url, userId } = req.body;
     if (!userId) {
-      return res.status(400).json({ error: 'userId is required' });
+      return res.status(400).json({ error: "userId is required" });
     }
     if (!url) {
-      return res.status(400).json({ error: 'url is required' });
+      return res.status(400).json({ error: "url is required" });
     }
-    
+
     const urlErr = validateUrl(url);
     if (urlErr) return res.status(400).json({ error: urlErr });
-    
+
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, targetId);
     if (!found) {
-      return res.status(404).json({ error: 'Tab not found' });
+      return res.status(404).json({ error: "Tab not found" });
     }
-    
+
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
-    
+    tabState.toolCalls++;
+    tabState.consecutiveTimeouts = 0;
+
     const result = await withTabLock(targetId, async () => {
-      await withPageLoadDuration('navigate', () => tabState.page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 }));
+      await withPageLoadDuration("navigate", () =>
+        tabState.page.goto(url, {
+          waitUntil: "domcontentloaded",
+          timeout: 30000,
+        }),
+      );
       tabState.visitedUrls.add(url);
       tabState.lastSnapshot = null;
-      
+
       // Google SERP: defer extraction to snapshot call
       if (isGoogleSerp(tabState.page.url())) {
         tabState.refs = new Map();
-        return { ok: true, targetId, url: tabState.page.url(), googleSerp: true };
+        return {
+          ok: true,
+          targetId,
+          url: tabState.page.url(),
+          googleSerp: true,
+        };
       }
-      
+
       tabState.refs = await buildRefs(tabState.page);
       return { ok: true, targetId, url: tabState.page.url() };
     });
-    
+
     res.json(result);
   } catch (err) {
-    log('error', 'openclaw navigate failed', { reqId: req.reqId, error: err.message });
+    log("error", "openclaw navigate failed", {
+      reqId: req.reqId,
+      error: err.message,
+    });
     handleRouteError(err, req, res);
   }
 });
 
 // GET /snapshot - Snapshot (OpenClaw format with query params)
-app.get('/snapshot', async (req, res) => {
+app.get("/snapshot", async (req, res) => {
   try {
-    const { targetId, userId, format = 'text' } = req.query;
+    const { targetId, userId, format = "text" } = req.query;
     const offset = parseInt(req.query.offset) || 0;
     if (!userId) {
-      return res.status(400).json({ error: 'userId is required' });
+      return res.status(400).json({ error: "userId is required" });
     }
-    
+
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, targetId);
     if (!found) {
-      return res.status(404).json({ error: 'Tab not found' });
+      return res.status(404).json({ error: "Tab not found" });
     }
-    
+
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++;
+    tabState.consecutiveTimeouts = 0;
 
     // Cached chunk retrieval
     if (offset > 0 && tabState.lastSnapshot) {
       const win = windowSnapshot(tabState.lastSnapshot, offset);
-      const response = { ok: true, format: 'aria', targetId, url: tabState.page.url(), snapshot: win.text, refsCount: tabState.refs.size, truncated: win.truncated, totalChars: win.totalChars, hasMore: win.hasMore, nextOffset: win.nextOffset };
-      if (req.query.includeScreenshot === 'true') {
-        const pngBuffer = await tabState.page.screenshot({ type: 'png' });
-        response.screenshot = { data: pngBuffer.toString('base64'), mimeType: 'image/png' };
+      const response = {
+        ok: true,
+        format: "aria",
+        targetId,
+        url: tabState.page.url(),
+        snapshot: win.text,
+        refsCount: tabState.refs.size,
+        truncated: win.truncated,
+        totalChars: win.totalChars,
+        hasMore: win.hasMore,
+        nextOffset: win.nextOffset,
+      };
+      if (req.query.includeScreenshot === "true") {
+        const pngBuffer = await tabState.page.screenshot({ type: "png" });
+        response.screenshot = {
+          data: pngBuffer.toString("base64"),
+          mimeType: "image/png",
+        };
       }
       return res.json(response);
     }
 
     const pageUrl = tabState.page.url();
-    
+
     // Google SERP fast path
     if (isGoogleSerp(pageUrl)) {
-      const { refs: googleRefs, snapshot: googleSnapshot } = await extractGoogleSerp(tabState.page);
+      const { refs: googleRefs, snapshot: googleSnapshot } =
+        await extractGoogleSerp(tabState.page);
       tabState.refs = googleRefs;
       tabState.lastSnapshot = googleSnapshot;
       const annotatedYaml = googleSnapshot;
       const win = windowSnapshot(annotatedYaml, 0);
       const response = {
-        ok: true, format: 'aria', targetId, url: pageUrl,
-        snapshot: win.text, refsCount: tabState.refs.size,
-        truncated: win.truncated, totalChars: win.totalChars,
-        hasMore: win.hasMore, nextOffset: win.nextOffset,
+        ok: true,
+        format: "aria",
+        targetId,
+        url: pageUrl,
+        snapshot: win.text,
+        refsCount: tabState.refs.size,
+        truncated: win.truncated,
+        totalChars: win.totalChars,
+        hasMore: win.hasMore,
+        nextOffset: win.nextOffset,
       };
-      if (req.query.includeScreenshot === 'true') {
-        const pngBuffer = await tabState.page.screenshot({ type: 'png' });
-        response.screenshot = { data: pngBuffer.toString('base64'), mimeType: 'image/png' };
+      if (req.query.includeScreenshot === "true") {
+        const pngBuffer = await tabState.page.screenshot({ type: "png" });
+        response.screenshot = {
+          data: pngBuffer.toString("base64"),
+          mimeType: "image/png",
+        };
       }
       return res.json(response);
     }
-    
+
     tabState.refs = await buildRefs(tabState.page);
-    
+
     const ariaYaml = await getAriaSnapshot(tabState.page);
-    
+
     // Annotate YAML with ref IDs
-    let annotatedYaml = ariaYaml || '';
+    let annotatedYaml = ariaYaml || "";
     if (annotatedYaml && tabState.refs.size > 0) {
       const refsByKey = new Map();
       for (const [refId, el] of tabState.refs) {
-        const key = `${el.role}:${el.name || ''}`;
+        const key = `${el.role}:${el.name || ""}`;
         if (!refsByKey.has(key)) refsByKey.set(key, refId);
       }
-      
-      const lines = annotatedYaml.split('\n');
-      annotatedYaml = lines.map(line => {
-        const match = line.match(/^(\s*)-\s+(\w+)(?:\s+"([^"]*)")?/);
-        if (match) {
-          const [, indent, role, name] = match;
-          const key = `${role}:${name || ''}`;
-          const refId = refsByKey.get(key);
-          if (refId) {
-            return line.replace(/^(\s*-\s+\w+)/, `$1 [${refId}]`);
+
+      const lines = annotatedYaml.split("\n");
+      annotatedYaml = lines
+        .map((line) => {
+          const match = line.match(/^(\s*)-\s+(\w+)(?:\s+"([^"]*)")?/);
+          if (match) {
+            const [, indent, role, name] = match;
+            const key = `${role}:${name || ""}`;
+            const refId = refsByKey.get(key);
+            if (refId) {
+              return line.replace(/^(\s*-\s+\w+)/, `$1 [${refId}]`);
+            }
           }
-        }
-        return line;
-      }).join('\n');
+          return line;
+        })
+        .join("\n");
     }
-    
+
     tabState.lastSnapshot = annotatedYaml;
     const win = windowSnapshot(annotatedYaml, 0);
 
     const response = {
       ok: true,
-      format: 'aria',
+      format: "aria",
       targetId,
       url: tabState.page.url(),
       snapshot: win.text,
@@ -2495,179 +3048,220 @@ app.get('/snapshot', async (req, res) => {
       nextOffset: win.nextOffset,
     };
 
-    if (req.query.includeScreenshot === 'true') {
-      const pngBuffer = await tabState.page.screenshot({ type: 'png' });
-      response.screenshot = { data: pngBuffer.toString('base64'), mimeType: 'image/png' };
+    if (req.query.includeScreenshot === "true") {
+      const pngBuffer = await tabState.page.screenshot({ type: "png" });
+      response.screenshot = {
+        data: pngBuffer.toString("base64"),
+        mimeType: "image/png",
+      };
     }
 
     res.json(response);
   } catch (err) {
-    log('error', 'openclaw snapshot failed', { reqId: req.reqId, error: err.message });
+    log("error", "openclaw snapshot failed", {
+      reqId: req.reqId,
+      error: err.message,
+    });
     handleRouteError(err, req, res);
   }
 });
 
 // POST /act - Combined action endpoint (OpenClaw format)
 // Routes to click/type/scroll/press/etc based on 'kind' parameter
-app.post('/act', async (req, res) => {
+app.post("/act", async (req, res) => {
   try {
     const { kind, targetId, userId, ...params } = req.body;
     if (!userId) {
-      return res.status(400).json({ error: 'userId is required' });
+      return res.status(400).json({ error: "userId is required" });
     }
-    
+
     if (!kind) {
-      return res.status(400).json({ error: 'kind is required' });
+      return res.status(400).json({ error: "kind is required" });
     }
-    
+
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, targetId);
     if (!found) {
-      return res.status(404).json({ error: 'Tab not found' });
+      return res.status(404).json({ error: "Tab not found" });
     }
-    
+
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
-    
+    tabState.toolCalls++;
+    tabState.consecutiveTimeouts = 0;
+
     const result = await withTabLock(targetId, async () => {
       switch (kind) {
-        case 'click': {
+        case "click": {
           const { ref, selector, doubleClick } = params;
           if (!ref && !selector) {
-            throw new Error('ref or selector required');
+            throw new Error("ref or selector required");
           }
-          
+
           const doClick = async (locatorOrSelector, isLocator) => {
-            const locator = isLocator ? locatorOrSelector : tabState.page.locator(locatorOrSelector);
+            const locator = isLocator
+              ? locatorOrSelector
+              : tabState.page.locator(locatorOrSelector);
             const clickOpts = { timeout: 3000 };
             if (doubleClick) clickOpts.clickCount = 2;
-            
+
             try {
               await locator.click(clickOpts);
             } catch (err) {
-              if (err.message.includes('intercepts pointer events')) {
+              if (err.message.includes("intercepts pointer events")) {
                 await locator.click({ ...clickOpts, force: true });
               } else {
                 throw err;
               }
             }
           };
-          
+
           if (ref) {
             let locator = refToLocator(tabState.page, ref, tabState.refs);
             if (!locator) {
-              log('info', 'auto-refreshing refs before click (openclaw)', { ref, hadRefs: tabState.refs.size });
+              log("info", "auto-refreshing refs before click (openclaw)", {
+                ref,
+                hadRefs: tabState.refs.size,
+              });
               tabState.refs = await buildRefs(tabState.page);
               locator = refToLocator(tabState.page, ref, tabState.refs);
             }
-            if (!locator) { const maxRef = tabState.refs.size > 0 ? `e${tabState.refs.size}` : 'none'; throw new StaleRefsError(ref, maxRef, tabState.refs.size); }
+            if (!locator) {
+              const maxRef =
+                tabState.refs.size > 0 ? `e${tabState.refs.size}` : "none";
+              throw new StaleRefsError(ref, maxRef, tabState.refs.size);
+            }
             await doClick(locator, true);
           } else {
             await doClick(selector, false);
           }
-          
+
           await tabState.page.waitForTimeout(500);
           tabState.refs = await buildRefs(tabState.page);
           return { ok: true, targetId, url: tabState.page.url() };
         }
-        
-        case 'type': {
+
+        case "type": {
           const { ref, selector, text, submit } = params;
           if (!ref && !selector) {
-            throw new Error('ref or selector required');
+            throw new Error("ref or selector required");
           }
-          if (typeof text !== 'string') {
-            throw new Error('text is required');
+          if (typeof text !== "string") {
+            throw new Error("text is required");
           }
-          
+
           if (ref) {
             let locator = refToLocator(tabState.page, ref, tabState.refs);
             if (!locator) {
-              log('info', 'auto-refreshing refs before type (openclaw)', { ref, hadRefs: tabState.refs.size });
+              log("info", "auto-refreshing refs before type (openclaw)", {
+                ref,
+                hadRefs: tabState.refs.size,
+              });
               tabState.refs = await buildRefs(tabState.page);
               locator = refToLocator(tabState.page, ref, tabState.refs);
             }
-            if (!locator) { const maxRef = tabState.refs.size > 0 ? `e${tabState.refs.size}` : 'none'; throw new StaleRefsError(ref, maxRef, tabState.refs.size); }
+            if (!locator) {
+              const maxRef =
+                tabState.refs.size > 0 ? `e${tabState.refs.size}` : "none";
+              throw new StaleRefsError(ref, maxRef, tabState.refs.size);
+            }
             await locator.fill(text, { timeout: 10000 });
-            if (submit) await tabState.page.keyboard.press('Enter');
+            if (submit) await tabState.page.keyboard.press("Enter");
           } else {
             await tabState.page.fill(selector, text, { timeout: 10000 });
-            if (submit) await tabState.page.keyboard.press('Enter');
+            if (submit) await tabState.page.keyboard.press("Enter");
           }
           return { ok: true, targetId };
         }
-        
-        case 'press': {
+
+        case "press": {
           const { key } = params;
-          if (!key) throw new Error('key is required');
+          if (!key) throw new Error("key is required");
           await tabState.page.keyboard.press(key);
           return { ok: true, targetId };
         }
-        
-        case 'scroll':
-        case 'scrollIntoView': {
-          const { ref, direction = 'down', amount = 500 } = params;
+
+        case "scroll":
+        case "scrollIntoView": {
+          const { ref, direction = "down", amount = 500 } = params;
           if (ref) {
             let locator = refToLocator(tabState.page, ref, tabState.refs);
             if (!locator) {
               tabState.refs = await buildRefs(tabState.page);
               locator = refToLocator(tabState.page, ref, tabState.refs);
             }
-            if (!locator) { const maxRef = tabState.refs.size > 0 ? `e${tabState.refs.size}` : 'none'; throw new StaleRefsError(ref, maxRef, tabState.refs.size); }
+            if (!locator) {
+              const maxRef =
+                tabState.refs.size > 0 ? `e${tabState.refs.size}` : "none";
+              throw new StaleRefsError(ref, maxRef, tabState.refs.size);
+            }
             await locator.scrollIntoViewIfNeeded({ timeout: 5000 });
           } else {
-            const delta = direction === 'up' ? -amount : amount;
+            const delta = direction === "up" ? -amount : amount;
             await tabState.page.mouse.wheel(0, delta);
           }
           await tabState.page.waitForTimeout(300);
           return { ok: true, targetId };
         }
-        
-        case 'hover': {
+
+        case "hover": {
           const { ref, selector } = params;
-          if (!ref && !selector) throw new Error('ref or selector required');
-          
+          if (!ref && !selector) throw new Error("ref or selector required");
+
           if (ref) {
             let locator = refToLocator(tabState.page, ref, tabState.refs);
             if (!locator) {
               tabState.refs = await buildRefs(tabState.page);
               locator = refToLocator(tabState.page, ref, tabState.refs);
             }
-            if (!locator) { const maxRef = tabState.refs.size > 0 ? `e${tabState.refs.size}` : 'none'; throw new StaleRefsError(ref, maxRef, tabState.refs.size); }
+            if (!locator) {
+              const maxRef =
+                tabState.refs.size > 0 ? `e${tabState.refs.size}` : "none";
+              throw new StaleRefsError(ref, maxRef, tabState.refs.size);
+            }
             await locator.hover({ timeout: 5000 });
           } else {
             await tabState.page.locator(selector).hover({ timeout: 5000 });
           }
           return { ok: true, targetId };
         }
-        
-        case 'wait': {
+
+        case "wait": {
           const { timeMs, text, loadState } = params;
           if (timeMs) {
             await tabState.page.waitForTimeout(timeMs);
           } else if (text) {
-            await tabState.page.waitForSelector(`text=${text}`, { timeout: 30000 });
+            await tabState.page.waitForSelector(`text=${text}`, {
+              timeout: 30000,
+            });
           } else if (loadState) {
             await tabState.page.waitForLoadState(loadState, { timeout: 30000 });
           }
           return { ok: true, targetId, url: tabState.page.url() };
         }
-        
-        case 'close': {
+
+        case "close": {
           await safePageClose(tabState.page);
           found.group.delete(targetId);
-          { const _l = tabLocks.get(targetId); if (_l) _l.drain(); tabLocks.delete(targetId); }
+          {
+            const _l = tabLocks.get(targetId);
+            if (_l) _l.drain();
+            tabLocks.delete(targetId);
+          }
           return { ok: true, targetId };
         }
-        
+
         default:
           throw new Error(`Unsupported action kind: ${kind}`);
       }
     });
-    
+
     res.json(result);
   } catch (err) {
-    log('error', 'act failed', { reqId: req.reqId, kind: req.body?.kind, error: err.message });
+    log("error", "act failed", {
+      reqId: req.reqId,
+      kind: req.body?.kind,
+      error: err.message,
+    });
     handleRouteError(err, req, res);
   }
 });
@@ -2681,7 +3275,7 @@ setInterval(() => {
       totalTabs += group.size;
     }
   }
-  log('info', 'stats', {
+  log("info", "stats", {
     sessions: sessions.size,
     tabs: totalTabs,
     rssBytes: mem.rss,
@@ -2699,37 +3293,45 @@ setInterval(async () => {
   // If it's been >120s since any successful operation, probe anyway —
   // active ops are likely stuck on a frozen browser and will time out eventually.
   if (healthState.activeOps > 0 && timeSinceSuccess < 120000) {
-    log('info', 'health probe skipped, operations active', { activeOps: healthState.activeOps });
+    log("info", "health probe skipped, operations active", {
+      activeOps: healthState.activeOps,
+    });
     return;
   }
   if (timeSinceSuccess < 120000) return;
-  
+
   if (healthState.activeOps > 0) {
-    log('warn', 'health probe forced despite active ops', { activeOps: healthState.activeOps, timeSinceSuccessMs: timeSinceSuccess });
+    log("warn", "health probe forced despite active ops", {
+      activeOps: healthState.activeOps,
+      timeSinceSuccessMs: timeSinceSuccess,
+    });
   }
-  
+
   let testContext;
   try {
     testContext = await browser.newContext();
     const page = await testContext.newPage();
-    await page.goto('about:blank', { timeout: 5000 });
+    await page.goto("about:blank", { timeout: 5000 });
     await page.close();
     await testContext.close();
     healthState.lastSuccessfulNav = Date.now();
   } catch (err) {
-    log('warn', 'health probe failed', { error: err.message, timeSinceSuccessMs: timeSinceSuccess });
+    log("warn", "health probe failed", {
+      error: err.message,
+      timeSinceSuccessMs: timeSinceSuccess,
+    });
     if (testContext) await testContext.close().catch(() => {});
-    restartBrowser('health probe failed').catch(() => {});
+    restartBrowser("health probe failed").catch(() => {});
   }
 }, 60_000);
 
 // Crash logging
-process.on('uncaughtException', (err) => {
-  log('error', 'uncaughtException', { error: err.message, stack: err.stack });
+process.on("uncaughtException", (err) => {
+  log("error", "uncaughtException", { error: err.message, stack: err.stack });
   process.exit(1);
 });
-process.on('unhandledRejection', (reason) => {
-  log('error', 'unhandledRejection', { reason: String(reason) });
+process.on("unhandledRejection", (reason) => {
+  log("error", "unhandledRejection", { reason: String(reason) });
 });
 
 // Graceful shutdown
@@ -2738,10 +3340,10 @@ let shuttingDown = false;
 async function gracefulShutdown(signal) {
   if (shuttingDown) return;
   shuttingDown = true;
-  log('info', 'shutting down', { signal });
+  log("info", "shutting down", { signal });
 
   const forceTimeout = setTimeout(() => {
-    log('error', 'shutdown timed out, forcing exit');
+    log("error", "shutdown timed out, forcing exit");
     process.exit(1);
   }, 10000);
   forceTimeout.unref();
@@ -2756,31 +3358,37 @@ async function gracefulShutdown(signal) {
   process.exit(0);
 }
 
-process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
-process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));
 
 const PORT = CONFIG.port;
-const server = app.listen(PORT, async () => {
+const server = app.listen(PORT, "0.0.0.0", async () => {
   startMemoryReporter();
   refreshActiveTabsGauge();
   refreshTabLockQueueDepth();
-  log('info', 'server started', { port: PORT, pid: process.pid, nodeVersion: process.version });
+  log("info", "server started", {
+    port: PORT,
+    pid: process.pid,
+    nodeVersion: process.version,
+  });
   // Pre-warm browser so first request doesn't eat a 6-7s cold start
   try {
     const start = Date.now();
     await ensureBrowser();
-    log('info', 'browser pre-warmed', { ms: Date.now() - start });
+    log("info", "browser pre-warmed", { ms: Date.now() - start });
     scheduleBrowserIdleShutdown();
   } catch (err) {
-    log('error', 'browser pre-warm failed (will retry on first request)', { error: err.message });
+    log("error", "browser pre-warm failed (will retry on first request)", {
+      error: err.message,
+    });
   }
 });
 
-server.on('error', (err) => {
-  if (err.code === 'EADDRINUSE') {
-    log('error', 'port in use', { port: PORT });
+server.on("error", (err) => {
+  if (err.code === "EADDRINUSE") {
+    log("error", "port in use", { port: PORT });
     process.exit(1);
   }
-  log('error', 'server error', { error: err.message });
+  log("error", "server error", { error: err.message });
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

- **Bind server to `0.0.0.0`** — without an explicit host, Node.js may bind to IPv6 loopback only, silently dropping connections forwarded from the Docker bridge network
- **Fix multi-arch `TARGETARCH` mapping** — Docker buildx injects `TARGETARCH` as `amd64`/`arm64`, but Camoufox release filenames use `x86_64`/`aarch64`. The previous `ARG` interpolation produced invalid URLs (`lin.arm64.zip`, `lin.amd64.zip`) on both `linux/arm64` and `linux/amd64` when using `--platform`. A `case` statement now maps arch names correctly at build time.

## Changes

- `server.js`: `app.listen(PORT, '0.0.0.0', ...)` — explicit host binding for Docker
- `Dockerfile`: Replace `ARG CAMOUFOX_URL` interpolation with a `RUN case` statement that maps `amd64→x86_64` and `arm64→aarch64`

## Test Plan

- [ ] `docker build .` (no `--platform`) pulls `lin.x86_64.zip` — defaults correctly
- [ ] `docker buildx build --platform linux/arm64 .` pulls `lin.aarch64.zip`
- [ ] `docker buildx build --platform linux/amd64 .` pulls `lin.x86_64.zip`
- [ ] `docker run -p 3000:3000` — server reachable from host