### PR TITLE
feat: SSL/proxy interception support + cookie/header export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,6 @@ playwright-report/
 DUAL-PROXIES.md
 SSL-FIXES.md
 ca.crt
-manage-direct.sh
-manage.sh
 mv_cert.sh
 mzer0-test.sh
 .claude/

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,13 @@ railway.toml
 # Test artifacts
 test-results/
 playwright-report/
+
+# Local test scripts and notes
+DUAL-PROXIES.md
+SSL-FIXES.md
+ca.crt
+manage-direct.sh
+manage.sh
+mv_cert.sh
+mzer0-test.sh
+.claude/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ This project wraps that engine in a REST API built for agents: accessibility sna
 - **Download Capture** - capture browser downloads and fetch them via API (optional inline base64)
 - **DOM Image Extraction** - list `<img>` src/alt and optionally return inline data URLs
 - **Deploy Anywhere** - Docker, Fly.io, Railway
+- **Custom CA / Proxy Interception** - trust custom CA certs via `NODE_EXTRA_CA_CERTS` for MITM proxies (Caido, Burp Suite, mitmproxy)
+- **Cookie & Header Export** - extract session cookies and HTTP response headers from snapshots for import into external tools
+- **PM2 Management Scripts** - `manage.sh` and `manage-direct.sh` for easy start/stop/restart via PM2
 
 ## Optional Dependencies
 
@@ -303,12 +306,12 @@ curl -X POST http://localhost:9377/tabs/TAB_ID/navigate \
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/tabs/:id/snapshot` | Accessibility snapshot with element refs. Query params: `includeScreenshot=true` (add base64 PNG), `offset=N` (paginate large snapshots) |
+| `GET` | `/tabs/:id/snapshot` | Accessibility snapshot with element refs. Query params: `includeScreenshot=true` (add base64 PNG), `offset=N` (paginate large snapshots), `includeCookies=false` (omit session cookies, included by default) |
 | `POST` | `/tabs/:id/click` | Click element by ref or CSS selector |
 | `POST` | `/tabs/:id/type` | Type text into element |
 | `POST` | `/tabs/:id/press` | Press a keyboard key |
 | `POST` | `/tabs/:id/scroll` | Scroll page (up/down/left/right) |
-| `POST` | `/tabs/:id/navigate` | Navigate to URL or search macro |
+| `POST` | `/tabs/:id/navigate` | Navigate to URL or search macro. Response includes `responseStatus`, `responseStatusText`, and `responseHeaders` |
 | `POST` | `/tabs/:id/wait` | Wait for selector or timeout |
 | `GET` | `/tabs/:id/links` | Extract all links on page |
 | `GET` | `/tabs/:id/images` | List `<img>` elements. Query params: `includeData=true` (return inline data URLs), `maxBytes=N`, `limit=N` |
@@ -382,6 +385,55 @@ Reddit macros return JSON directly (no HTML parsing needed):
 | `PROXY_COUNTRY` | Target country for proxy geo-targeting | - |
 | `PROXY_STATE` | Target state/region for proxy geo-targeting | - |
 | `TAB_INACTIVITY_MS` | Close tabs idle longer than this | `300000` (5min) |
+| `NODE_EXTRA_CA_CERTS` | Path to a PEM CA certificate to trust (for intercepting proxies) | - |
+
+## Running with an Intercepting Proxy
+
+Route browser traffic through Caido, Burp Suite, or mitmproxy for request inspection and modification.
+
+**1. Set environment variables:**
+
+```bash
+export PROXY_HOST=127.0.0.1       # Your proxy listen address
+export PROXY_PORT=8080             # Your proxy listen port
+export NODE_EXTRA_CA_CERTS=/path/to/proxy-ca.crt  # Proxy CA certificate (PEM)
+```
+
+**2. Start the server.** All browser traffic will route through the proxy. The custom CA cert is trusted at both the Node.js level (for server-side HTTPS requests) and the Firefox level (via `security.enterprise_roots.enabled`), so HTTPS interception works without certificate errors.
+
+**3. Extract cookies and headers** from any snapshot for replay in your proxy:
+
+```bash
+# Cookies and response headers are included by default
+curl "http://localhost:9377/tabs/TAB_ID/snapshot?userId=agent1"
+# → { ..., "cookies": [...], "responseStatus": 200, "responseHeaders": {...} }
+
+# Omit cookies if not needed
+curl "http://localhost:9377/tabs/TAB_ID/snapshot?userId=agent1&includeCookies=false"
+```
+
+Navigate responses also include `responseStatus`, `responseStatusText`, and `responseHeaders`.
+
+## PM2 Management
+
+Two convenience scripts for running CamoFox under PM2:
+
+| Script | Purpose | Default Port |
+|--------|---------|-------------|
+| `manage.sh` | Run with proxy (Caido/Burp) | `8177` |
+| `manage-direct.sh` | Run without proxy (direct) | `8178` |
+
+```bash
+./manage.sh start     # Start with proxy config
+./manage.sh stop      # Stop and remove from PM2
+./manage.sh restart   # Restart
+./manage.sh status    # Show PM2 process info
+./manage.sh logs      # Tail logs
+
+./manage-direct.sh start   # Start direct (no proxy) instance
+```
+
+Edit the configuration block at the top of each script to set your ports, API keys, and proxy settings.
 
 ## Architecture
 

--- a/manage-direct.sh
+++ b/manage-direct.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# ==========================================
+# Configuration
+# ==========================================
+APP_NAME="camofox-direct"
+
+export CAMOFOX_PORT="8178"
+export CAMOFOX_API_KEY="camof0x-api"
+export CAMOFOX_ADMIN_KEY="camof0x-admin"
+# No PROXY_HOST, PROXY_PORT, or NODE_EXTRA_CA_CERTS — direct (no proxy) instance
+
+export CAMOUFOX_DEBUG=1
+
+# ==========================================
+# Functions
+# ==========================================
+
+start() {
+    echo "Starting $APP_NAME (direct, no proxy)..."
+    echo "API port: $CAMOFOX_PORT"
+    pm2 start npm --name "$APP_NAME" -- start
+    pm2 save
+}
+
+stop() {
+    echo "Stopping $APP_NAME..."
+    pm2 stop "$APP_NAME"
+    pm2 delete "$APP_NAME"
+}
+
+delete() {
+    echo "Deleting $APP_NAME..."
+    pm2 delete "$APP_NAME"
+}
+
+restart() {
+    echo "Restarting $APP_NAME..."
+    pm2 restart "$APP_NAME"
+}
+
+status() {
+    echo "Checking status of $APP_NAME..."
+    pm2 describe "$APP_NAME"
+}
+
+logs() {
+    echo "Tailing logs for $APP_NAME (Press Ctrl+C to exit)..."
+    pm2 logs "$APP_NAME"
+}
+
+# ==========================================
+# Command Routing
+# ==========================================
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    delete)
+        delete
+        ;;
+    restart)
+        restart
+        ;;
+    status)
+        status
+        ;;
+    logs)
+        logs
+        ;;
+    *)
+        echo "Usage: ./manage-direct.sh {start|stop|delete|restart|status|logs}"
+        exit 1
+        ;;
+esac

--- a/manage.sh
+++ b/manage.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# ==========================================
+# Configuration
+# ==========================================
+# Change this to whatever you want to call your app in PM2
+APP_NAME="camofox-browser"
+
+export CAMOFOX_PORT="8177"
+export CAMOFOX_API_KEY="camof0x-api"
+export CAMOFOX_ADMIN_KEY="camof0x-admin"
+
+export PROXY_HOST="127.0.0.1"
+export PROXY_PORT="8179"
+
+export NODE_EXTRA_CA_CERTS="/home/bbp/ca.crt"
+
+export CAMOUFOX_DEBUG=1
+
+# ==========================================
+# Functions
+# ==========================================
+
+start() {
+    echo "Starting $APP_NAME..."
+    echo "API port: $CAMOFOX_PORT"
+    echo "Proxy: $PROXY_HOST:$PROXY_PORT"
+    # This runs 'npm start' and names the process in PM2
+    pm2 start npm --name "$APP_NAME" -- start
+    
+    # Saves the PM2 process list so it can restart on system boot (optional but recommended)
+    pm2 save
+}
+
+stop() {
+    echo "Stopping $APP_NAME..."
+    pm2 stop "$APP_NAME"
+    pm2 delete "$APP_NAME"
+}
+
+delete() {
+    echo "Deleting $APP_NAME..."
+    pm2 delete "$APP_NAME"
+}
+
+restart() {
+    echo "Restarting $APP_NAME..."
+    pm2 restart "$APP_NAME"
+}
+
+status() {
+    echo "Checking status of $APP_NAME..."
+    pm2 describe "$APP_NAME"
+}
+
+logs() {
+    echo "Tailing logs for $APP_NAME (Press Ctrl+C to exit)..."
+    pm2 logs "$APP_NAME"
+}
+
+# ==========================================
+# Command Routing
+# ==========================================
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    delete)
+        delete
+        ;;
+    restart)
+        restart
+        ;;
+    status)
+        status
+        ;;
+    logs)
+        logs
+        ;;
+    *)
+        echo "Usage: ./manage.sh {start|stop|delete|restart|status|logs}"
+        exit 1
+        ;;
+esac
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askjo/camofox-browser",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askjo/camofox-browser",
-      "version": "1.5.0",
+      "version": "1.5.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -572,27 +572,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -830,9 +809,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3366,9 +3345,9 @@
       }
     },
     "node_modules/jest-config/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3697,9 +3676,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4197,18 +4176,39 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/minimist": {
@@ -5230,9 +5230,9 @@
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -5772,9 +5772,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/plugin.ts
+++ b/plugin.ts
@@ -241,22 +241,27 @@ export default function register(api: PluginApi) {
     description:
       "Get accessibility snapshot of a Camoufox page with element refs (e1, e2, etc.) for interaction, plus a visual screenshot. " +
       "Large pages are truncated with pagination links preserved at the bottom. " +
-      "If the response includes hasMore=true and nextOffset, call again with that offset to see more content.",
+      "If the response includes hasMore=true and nextOffset, call again with that offset to see more content. " +
+      "Pass includeCookies: true to include browser session cookies and response headers (useful for importing into Caido or other proxies).",
     parameters: {
       type: "object",
       properties: {
         tabId: { type: "string", description: "Tab identifier" },
         offset: { type: "number", description: "Character offset for paginated snapshots. Use nextOffset from a previous truncated response." },
+        includeCookies: { type: "boolean", description: "Include browser session cookies in the response (for Caido or proxy import). Defaults to true — pass false to omit." },
       },
       required: ["tabId"],
     },
     async execute(_id, params) {
-      const { tabId, offset } = params as { tabId: string; offset?: number };
+      const { tabId, offset, includeCookies } = params as { tabId: string; offset?: number; includeCookies?: boolean };
       const userId = ctx.agentId || fallbackUserId;
-      const qs = offset ? `&offset=${offset}` : '';
-      const result = await fetchApi(baseUrl, `/tabs/${tabId}/snapshot?userId=${userId}&includeScreenshot=true${qs}`) as Record<string, unknown>;
+      const qs = [
+        offset ? `offset=${offset}` : '',
+        includeCookies === false ? 'includeCookies=false' : '',
+      ].filter(Boolean).join('&');
+      const result = await fetchApi(baseUrl, `/tabs/${tabId}/snapshot?userId=${userId}&includeScreenshot=true${qs ? `&${qs}` : ''}`) as Record<string, unknown>;
       const content: ToolResult["content"] = [
-        { type: "text", text: JSON.stringify({ url: result.url, refsCount: result.refsCount, snapshot: result.snapshot, truncated: result.truncated, totalChars: result.totalChars, hasMore: result.hasMore, nextOffset: result.nextOffset }, null, 2) },
+        { type: "text", text: JSON.stringify({ url: result.url, refsCount: result.refsCount, snapshot: result.snapshot, truncated: result.truncated, totalChars: result.totalChars, hasMore: result.hasMore, nextOffset: result.nextOffset, responseStatus: result.responseStatus, responseStatusText: result.responseStatusText, responseHeaders: result.responseHeaders, cookies: result.cookies }, null, 2) },
       ];
       const screenshot = result.screenshot as { data?: string; mimeType?: string } | undefined;
       if (screenshot?.data) {
@@ -317,7 +322,8 @@ export default function register(api: PluginApi) {
   api.registerTool((ctx: ToolContext) => ({
     name: "camofox_navigate",
     description:
-      "Navigate a Camoufox tab to a URL or use a search macro (@google_search, @youtube_search, etc.). Preferred over Chrome for sites with bot detection.",
+      "Navigate a Camoufox tab to a URL or use a search macro (@google_search, @youtube_search, etc.). Preferred over Chrome for sites with bot detection. " +
+      "Response includes responseStatus, responseStatusText, and responseHeaders from the navigation (useful for Caido/proxy import).",
     parameters: {
       type: "object",
       properties: {

--- a/server.js
+++ b/server.js
@@ -4,6 +4,22 @@ import { firefox } from 'playwright-core';
 import express from 'express';
 import crypto from 'crypto';
 import os from 'os';
+import fs from 'fs';
+import https from 'https';
+
+// Trust custom CA cert for all Node.js HTTPS requests (e.g. proxy geoip lookups through Caido)
+const EXTRA_CA_CERT = process.env.NODE_EXTRA_CA_CERTS;
+if (EXTRA_CA_CERT) {
+  try {
+    const ca = fs.readFileSync(EXTRA_CA_CERT);
+    https.globalAgent.options.ca = ca;
+    process.stdout.write(JSON.stringify({ ts: new Date().toISOString(), level: 'info', msg: 'custom CA cert loaded', path: EXTRA_CA_CERT, bytes: ca.length }) + '\n');
+  } catch (e) {
+    process.stderr.write(JSON.stringify({ ts: new Date().toISOString(), level: 'error', msg: 'failed to load NODE_EXTRA_CA_CERTS', path: EXTRA_CA_CERT, error: e.message }) + '\n');
+  }
+} else {
+  process.stdout.write(JSON.stringify({ ts: new Date().toISOString(), level: 'warn', msg: 'NODE_EXTRA_CA_CERTS not set — custom CA cert not loaded' }) + '\n');
+}
 import { expandMacro } from './lib/macros.js';
 import { loadConfig } from './lib/config.js';
 import { normalizePlaywrightProxy, createProxyPool, buildProxyUrl } from './lib/proxy.js';
@@ -529,6 +545,7 @@ async function probeGoogleSearch(candidateBrowser) {
     context = await candidateBrowser.newContext({
       viewport: { width: 1280, height: 720 },
       permissions: ['geolocation'],
+      ignoreHTTPSErrors: true,
     });
     const page = await context.newPage();
     await page.goto('https://www.google.com/', { waitUntil: 'domcontentloaded', timeout: 30000 });
@@ -606,6 +623,9 @@ async function launchBrowserInstance() {
         proxy: launchProxy,
         geoip: !!launchProxy,
         virtual_display: vdDisplay,
+        firefox_user_prefs: {
+          'security.enterprise_roots.enabled': true,
+        },
       });
       options.proxy = normalizePlaywrightProxy(options.proxy);
 
@@ -723,6 +743,7 @@ async function getSession(userId) {
     const contextOptions = {
       viewport: { width: 1280, height: 720 },
       permissions: ['geolocation'],
+      ignoreHTTPSErrors: true,
     };
     // When geoip is active (proxy configured), camoufox auto-configures
     // locale/timezone/geolocation from the proxy IP. Without proxy, use defaults.
@@ -1776,9 +1797,14 @@ app.post('/tabs/:tabId/navigate', async (req, res) => {
 
         const navigateCurrentPage = async () => {
           tabState.lastRequestedUrl = targetUrl;
-          await withPageLoadDuration('navigate', () => tabState.page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 30000 }));
+          const navResponse = await withPageLoadDuration('navigate', () => tabState.page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 30000 }));
           tabState.visitedUrls.add(targetUrl);
           tabState.lastSnapshot = null;
+          if (navResponse) {
+            tabState.lastNavStatus = navResponse.status();
+            tabState.lastNavStatusText = navResponse.statusText();
+            tabState.lastNavHeaders = navResponse.headers();
+          }
         };
 
         const prewarmGoogleHome = async () => {
@@ -1832,15 +1858,15 @@ app.post('/tabs/:tabId/navigate', async (req, res) => {
         // call will wait for and extract them.
         if (isGoogleSerp(tabState.page.url())) {
           tabState.refs = new Map();
-          return { ok: true, tabId, url: tabState.page.url(), refsAvailable: false, googleSerp: true };
+          return { ok: true, tabId, url: tabState.page.url(), refsAvailable: false, googleSerp: true, responseStatus: tabState.lastNavStatus, responseStatusText: tabState.lastNavStatusText, responseHeaders: tabState.lastNavHeaders };
         }
 
         if (isGoogleSearch && await isGoogleSearchBlocked(tabState.page)) {
-          return { ok: false, tabId, url: tabState.page.url(), refsAvailable: false, googleBlocked: true };
+          return { ok: false, tabId, url: tabState.page.url(), refsAvailable: false, googleBlocked: true, responseStatus: tabState.lastNavStatus, responseStatusText: tabState.lastNavStatusText, responseHeaders: tabState.lastNavHeaders };
         }
-        
+
         tabState.refs = await buildRefs(tabState.page);
-        return { ok: true, tabId, url: tabState.page.url(), refsAvailable: tabState.refs.size > 0 };
+        return { ok: true, tabId, url: tabState.page.url(), refsAvailable: tabState.refs.size > 0, responseStatus: tabState.lastNavStatus, responseStatusText: tabState.lastNavStatusText, responseHeaders: tabState.lastNavHeaders };
       }, requestTimeoutMs());
     })(), requestTimeoutMs(), 'navigate'));
     
@@ -1863,6 +1889,7 @@ app.get('/tabs/:tabId/snapshot', async (req, res) => {
     if (!userId) return res.status(400).json({ error: 'userId required' });
     const format = req.query.format || 'text';
     const offset = parseInt(req.query.offset) || 0;
+    const includeCookies = req.query.includeCookies !== 'false';
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, req.params.tabId);
     if (!found) return res.status(404).json({ error: 'Tab not found' });
@@ -1874,9 +1901,13 @@ app.get('/tabs/:tabId/snapshot', async (req, res) => {
     if (offset > 0 && tabState.lastSnapshot) {
       const win = windowSnapshot(tabState.lastSnapshot, offset);
       const response = { url: tabState.page.url(), snapshot: win.text, refsCount: tabState.refs.size, truncated: win.truncated, totalChars: win.totalChars, hasMore: win.hasMore, nextOffset: win.nextOffset };
+      if (tabState.lastNavStatus != null) { response.responseStatus = tabState.lastNavStatus; response.responseStatusText = tabState.lastNavStatusText; response.responseHeaders = tabState.lastNavHeaders; }
       if (req.query.includeScreenshot === 'true') {
         const pngBuffer = await tabState.page.screenshot({ type: 'png' });
         response.screenshot = { data: pngBuffer.toString('base64'), mimeType: 'image/png' };
+      }
+      if (includeCookies) {
+        response.cookies = await session.context.cookies();
       }
       log('info', 'snapshot (cached offset)', { reqId: req.reqId, tabId: req.params.tabId, offset, totalChars: win.totalChars });
       return res.json(response);
@@ -1920,13 +1951,17 @@ app.get('/tabs/:tabId/snapshot', async (req, res) => {
           hasMore: win.hasMore,
           nextOffset: win.nextOffset,
         };
+        if (tabState.lastNavStatus != null) { response.responseStatus = tabState.lastNavStatus; response.responseStatusText = tabState.lastNavStatusText; response.responseHeaders = tabState.lastNavHeaders; }
         if (req.query.includeScreenshot === 'true') {
           const pngBuffer = await tabState.page.screenshot({ type: 'png' });
           response.screenshot = { data: pngBuffer.toString('base64'), mimeType: 'image/png' };
         }
+        if (includeCookies) {
+          response.cookies = await session.context.cookies();
+        }
         return response;
       }
-      
+
       tabState.refs = await refreshTabRefs(tabState, { reason: 'snapshot' });
       const ariaYaml = await getAriaSnapshot(tabState.page);
       
@@ -1977,9 +2012,13 @@ app.get('/tabs/:tabId/snapshot', async (req, res) => {
         nextOffset: win.nextOffset,
       };
 
+      if (tabState.lastNavStatus != null) { response.responseStatus = tabState.lastNavStatus; response.responseStatusText = tabState.lastNavStatusText; response.responseHeaders = tabState.lastNavHeaders; }
       if (req.query.includeScreenshot === 'true') {
         const pngBuffer = await tabState.page.screenshot({ type: 'png' });
         response.screenshot = { data: pngBuffer.toString('base64'), mimeType: 'image/png' };
+      }
+      if (includeCookies) {
+        response.cookies = await session.context.cookies();
       }
 
       return response;


### PR DESCRIPTION
## Summary

- **Custom CA cert support** — loads a PEM certificate from `NODE_EXTRA_CA_CERTS` at startup so all browser traffic can flow through an intercepting proxy (Caido, Burp Suite, mitmproxy) without HTTPS errors. Sets `ignoreHTTPSErrors` on browser contexts and enables Firefox `security.enterprise_roots.enabled` pref.
- **Cookie & header export** — `/tabs/:id/snapshot` now returns session cookies (via `includeCookies` param, default true) and HTTP response status/headers from the last navigation. `/tabs/:id/navigate` also surfaces `responseStatus`, `responseStatusText`, and `responseHeaders` in its response. Useful for importing browser state into external proxy tools.
- **PM2 management scripts** — `manage.sh` (proxy mode, port 8177) and `manage-direct.sh` (direct mode, port 8178) for easy start/stop/restart/logs via PM2.
- **Updated README** — new sections for proxy interception setup, cookie/header export usage, PM2 management, and `NODE_EXTRA_CA_CERTS` env var.

## Changed files

| File | Change |
|------|--------|
| `server.js` | CA cert loading, ignoreHTTPSErrors, Firefox enterprise root pref, navigation response capture, includeCookies on snapshot |
| `plugin.ts` | includeCookies param + response headers/cookies in snapshot and navigate tool definitions |
| `README.md` | Proxy interception, cookie export, PM2 management docs, env var table update |
| `manage.sh` | PM2 wrapper — proxy mode (port 8177) |
| `manage-direct.sh` | PM2 wrapper — direct mode (port 8178) |
| `package-lock.json` | Dependency updates |

## Test plan

- [ ] Start with NODE_EXTRA_CA_CERTS pointing to a proxy CA cert — verify log line confirms cert loaded
- [ ] Start without NODE_EXTRA_CA_CERTS — verify warning log, no crash
- [ ] Navigate to an HTTPS site through an intercepting proxy — verify no certificate errors
- [ ] Call /snapshot — verify cookies array and responseStatus/responseHeaders are present
- [ ] Call /snapshot?includeCookies=false — verify cookies are omitted
- [ ] Call /navigate — verify responseStatus, responseStatusText, responseHeaders in response
- [ ] Run manage.sh start / manage.sh stop — verify PM2 lifecycle works
