### PR TITLE
fix(Dockerfile): restore `CAMOFOX_PORT` to `9377`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ COPY server.js ./
 COPY lib/ ./lib/
 
 ENV NODE_ENV=production
-ENV CAMOFOX_PORT=3000
+ENV CAMOFOX_PORT=9377
 
 EXPOSE 9377
 


### PR DESCRIPTION
I noticed in the submit a3e64d3e29c6ba2dc128fe434b29c61d02aa1d82, `EXPOSE` in the Dockerfile changes from `3000` to `9377`, but the environment variable `CAMOFOX_PORT` still equal `3000`. This results in the inability to access the Camofox browser service by configuring `-p 9377:9377` unless environment `CAMOFOX_PORT=9377` is explicitly declared when start the container.

This issue can be reproduced by pulling the current version (v1.5.2) of the source code, build image and run the container, execute commands like:

```bash
$ docker ps | grep camofox
33e1903dc825   camofox-browser:135.0.1-aarch64   "docker-entrypoint.s…"   5 minutes ago   Up 5 minutes   0.0.0.0:9377->9377/tcp, [::]:9377->9377/tcp   camofox-browser
$ curl 0.0.0.0:9377 
curl: (56) Recv failure: Connection reset by peer
```

Related issues: #52, #60