### PR TITLE
feat: Add optional persistence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,17 @@ endif
 IMAGE        := camofox-browser:$(VERSION)-$(ARCH)
 CAMOUFOX_ZIP := dist/camoufox-$(ARCH).zip
 YTDLP_BIN    := dist/yt-dlp-$(ARCH)
+COOKIES_DIR  ?= $(HOME)/.camofox/cookies
+PROFILE_DIR  ?= $(HOME)/.camofox/profiles
+
+PERSISTENCE  ?=
+ifeq ($(filter 1 true yes on,$(PERSISTENCE)),)
+  PERSISTENCE_ENV   :=
+  PERSISTENCE_MOUNT :=
+else
+  PERSISTENCE_ENV   := -e CAMOFOX_PERSISTENCE=1 -e CAMOFOX_PROFILE_DIR="$(PROFILE_DIR)"
+  PERSISTENCE_MOUNT := -v "$(PROFILE_DIR):$(PROFILE_DIR)"
+endif
 
 CAMOUFOX_URL := https://github.com/daijro/camoufox/releases/download/v$(VERSION)-$(RELEASE)/camoufox-$(VERSION)-$(RELEASE)-lin.$(CAMOUFOX_ARCH).zip
 YTDLP_URL    := https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux$(YTDLP_ARCH)
@@ -63,7 +74,22 @@ up:
 	@if ! docker image inspect $(IMAGE) > /dev/null 2>&1; then \
 	  $(MAKE) build; \
 	fi
-	docker run -d --restart unless-stopped --name camofox-browser -p 9377:9377 $(IMAGE)
+ifeq ($(filter 1 true yes on,$(PERSISTENCE)),)
+	docker run -d --restart unless-stopped --name camofox-browser \
+	  -p 9377:9377 \
+	  $(IMAGE)
+else
+	@test -n "$$CAMOFOX_API_KEY" || (echo "ERROR: CAMOFOX_API_KEY must be set for PERSISTENCE mode" && exit 1)
+	@mkdir -p "$(COOKIES_DIR)" "$(PROFILE_DIR)"
+	docker run -d --restart unless-stopped --name camofox-browser \
+	  -p 9377:9377 \
+	  -e CAMOFOX_API_KEY="$$CAMOFOX_API_KEY" \
+	  -e CAMOFOX_COOKIES_DIR="$(COOKIES_DIR)" \
+	  $(PERSISTENCE_ENV) \
+	  -v "$(COOKIES_DIR):$(COOKIES_DIR):ro" \
+	  $(PERSISTENCE_MOUNT) \
+	  $(IMAGE)
+endif
 
 down:
 	docker stop camofox-browser && docker rm camofox-browser

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ make fetch
 # Override arch or version explicitly
 make up ARCH=x86_64
 make up VERSION=135.0.1 RELEASE=beta.24
+
+# Enable optional per-user storage state persistence
+make up PERSISTENCE=1
 ```
 
 Note: `make fetch` (or `make build`) must be run first — the Dockerfile expects pre-downloaded binaries in `dist/`.
@@ -363,7 +366,9 @@ Reddit macros return JSON directly (no HTML parsing needed):
 | `PORT` | Server port (fallback, for platforms like Fly.io) | `9377` |
 | `CAMOFOX_API_KEY` | Enable cookie import endpoint (disabled if unset) | - |
 | `CAMOFOX_ADMIN_KEY` | Required for `POST /stop` | - |
-| `CAMOFOX_COOKIES_DIR` | Directory for cookie files | `~/.camofox/cookies` |
+| `CAMOFOX_PERSISTENCE` | Enable per-user storage state persistence (requires `CAMOFOX_PROFILE_DIR`). `1`/`true` to opt in | - |
+| `CAMOFOX_PROFILE_DIR` | Root directory for per-user persisted browser storage state (cookies + localStorage). Only used when `CAMOFOX_PERSISTENCE=1` | - |
+| `CAMOFOX_COOKIES_DIR` | Directory for Netscape cookie files | `~/.camofox/cookies` |
 | `MAX_SESSIONS` | Max concurrent browser sessions | `50` |
 | `MAX_TABS_PER_SESSION` | Max tabs per session | `10` |
 | `SESSION_TIMEOUT_MS` | Session inactivity timeout | `1800000` (30min) |
@@ -396,6 +401,8 @@ Browser Instance (Camoufox)
 ```
 
 Sessions auto-expire after 30 minutes of inactivity. The browser itself shuts down after 5 minutes with no active sessions, and relaunches on the next request.
+
+**Optional per-user persistence** — when `CAMOFOX_PERSISTENCE=1` is set and `CAMOFOX_PROFILE_DIR` points at a writable directory, each `userId` gets a deterministic storage directory under that root. On session creation the server restores any saved Playwright `storageState`; on cookie import and session teardown it checkpoints cookies/localStorage back to disk. Persistence is disabled by default; both the flag and the profile dir must be set to enable it.
 
 When a session's tab limit is reached, the oldest/least-used tab is automatically recycled instead of returning an error — so long-running agent sessions don't hit dead ends.
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -36,7 +36,15 @@ function inferProxyStrategy(explicitStrategy) {
   return 'round_robin';
 }
 
+function isFlagEnabled(value) {
+  if (!value) return false;
+  const normalized = String(value).trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
 function loadConfig() {
+  const profileDir = process.env.CAMOFOX_PROFILE_DIR || '';
+  const persistenceFlag = isFlagEnabled(process.env.CAMOFOX_PERSISTENCE);
   return {
     port: parseInt(process.env.CAMOFOX_PORT || process.env.PORT || '9377', 10),
     nodeEnv: process.env.NODE_ENV || 'development',
@@ -45,6 +53,8 @@ function loadConfig() {
     flyApiToken: process.env.FLY_API_TOKEN || '',
     adminKey: process.env.CAMOFOX_ADMIN_KEY || '',
     apiKey: process.env.CAMOFOX_API_KEY || '',
+    profileDir,
+    persistenceEnabled: persistenceFlag && !!profileDir,
     cookiesDir: process.env.CAMOFOX_COOKIES_DIR || join(os.homedir(), '.camofox', 'cookies'),
     handlerTimeoutMs: parseInt(process.env.HANDLER_TIMEOUT_MS) || 30000,
     maxConcurrentPerUser: parseInt(process.env.MAX_CONCURRENT_PER_USER) || 3,
@@ -80,6 +90,8 @@ function loadConfig() {
       NODE_ENV: process.env.NODE_ENV,
       CAMOFOX_ADMIN_KEY: process.env.CAMOFOX_ADMIN_KEY,
       CAMOFOX_API_KEY: process.env.CAMOFOX_API_KEY,
+      CAMOFOX_PROFILE_DIR: process.env.CAMOFOX_PROFILE_DIR,
+      CAMOFOX_PERSISTENCE: process.env.CAMOFOX_PERSISTENCE,
       CAMOFOX_COOKIES_DIR: process.env.CAMOFOX_COOKIES_DIR,
       PROXY_STRATEGY: process.env.PROXY_STRATEGY,
       PROXY_PROVIDER: process.env.PROXY_PROVIDER,

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -79,4 +79,41 @@ async function readCookieFile({ cookiesDir, cookiesPath, domainSuffix, maxBytes 
   }));
 }
 
-export { parseNetscapeCookieFile, readCookieFile };
+/**
+ * Import all cookies from the default bootstrap cookie file into a Playwright context.
+ * Intended for first-run session seeding before any persistent storage state exists.
+ * Missing file is treated as a no-op.
+ * @param {object} opts
+ * @param {string} opts.cookiesDir - Base directory for cookie files
+ * @param {object} opts.context - Playwright BrowserContext
+ * @param {string} [opts.cookiesPath='cookies.txt'] - Relative cookie file path within cookiesDir
+ * @param {object} [opts.logger=console] - Logger with warn()
+ * @returns {Promise<{imported: number, source: string|null}>}
+ */
+async function importBootstrapCookies({ cookiesDir, context, cookiesPath = 'cookies.txt', logger = console }) {
+  if (!cookiesDir || !context) {
+    return { imported: 0, source: null };
+  }
+
+  const resolved = path.resolve(cookiesDir, cookiesPath);
+
+  try {
+    const cookies = await readCookieFile({ cookiesDir, cookiesPath });
+    if (cookies.length === 0) {
+      return { imported: 0, source: resolved };
+    }
+    await context.addCookies(cookies);
+    return { imported: cookies.length, source: resolved };
+  } catch (err) {
+    if (err?.code === 'ENOENT') {
+      return { imported: 0, source: null };
+    }
+    logger?.warn?.('failed to import bootstrap cookies', {
+      cookiesPath: resolved,
+      error: err?.message || String(err),
+    });
+    return { imported: 0, source: resolved };
+  }
+}
+
+export { parseNetscapeCookieFile, readCookieFile, importBootstrapCookies };

--- a/lib/inflight.js
+++ b/lib/inflight.js
@@ -1,0 +1,16 @@
+async function coalesceInflight(map, key, factory) {
+  const existing = map.get(key);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    try {
+      return await factory();
+    } finally {
+      map.delete(key);
+    }
+  })();
+  map.set(key, promise);
+  return promise;
+}
+
+export { coalesceInflight };

--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -1,0 +1,89 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+function getUserPersistencePaths(profileDir, userId) {
+  const rootDir = path.resolve(profileDir);
+  const safeUserDir = crypto
+    .createHash('sha256')
+    .update(String(userId))
+    .digest('hex')
+    .slice(0, 32);
+
+  const userDir = path.join(rootDir, safeUserDir);
+  return {
+    rootDir,
+    userDir,
+    storageStatePath: path.join(userDir, 'storage-state.json'),
+    metaPath: path.join(userDir, 'meta.json'),
+  };
+}
+
+async function loadPersistedStorageState(profileDir, userId, logger = console) {
+  if (!profileDir) return undefined;
+
+  const { storageStatePath } = getUserPersistencePaths(profileDir, userId);
+
+  try {
+    const raw = await fs.readFile(storageStatePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return undefined;
+    if (!Array.isArray(parsed.cookies)) return undefined;
+    if (parsed.origins !== undefined && !Array.isArray(parsed.origins)) return undefined;
+    return storageStatePath;
+  } catch (err) {
+    if (err?.code === 'ENOENT') return undefined;
+    logger?.warn?.('failed to load persisted storage state', {
+      userId: String(userId),
+      storageStatePath,
+      error: err?.message || String(err),
+    });
+    return undefined;
+  }
+}
+
+async function persistStorageState({ profileDir, userId, context, logger = console }) {
+  if (!profileDir || !context) {
+    return { persisted: false, reason: 'disabled' };
+  }
+
+  const { userDir, storageStatePath, metaPath } = getUserPersistencePaths(profileDir, userId);
+  const suffix = `.tmp-${process.pid}-${Date.now()}`;
+  const tmpStoragePath = `${storageStatePath}${suffix}`;
+  const tmpMetaPath = `${metaPath}${suffix}`;
+
+  try {
+    await fs.mkdir(userDir, { recursive: true });
+    await context.storageState({ path: tmpStoragePath });
+    await fs.rename(tmpStoragePath, storageStatePath);
+    await fs.writeFile(
+      tmpMetaPath,
+      JSON.stringify(
+        {
+          userId: String(userId),
+          updatedAt: new Date().toISOString(),
+          storageStatePath,
+        },
+        null,
+        2
+      )
+    );
+    await fs.rename(tmpMetaPath, metaPath);
+    return { persisted: true, userDir, storageStatePath, metaPath };
+  } catch (err) {
+    await fs.unlink(tmpStoragePath).catch(() => {});
+    await fs.unlink(tmpMetaPath).catch(() => {});
+    logger?.warn?.('failed to persist storage state', {
+      userId: String(userId),
+      storageStatePath,
+      error: err?.message || String(err),
+    });
+    return { persisted: false, reason: 'error', error: err };
+  }
+}
+
+export {
+  getUserPersistencePaths,
+  loadPersistedStorageState,
+  persistStorageState,
+};

--- a/server.js
+++ b/server.js
@@ -23,6 +23,9 @@ import {
   startMemoryReporter, stopMemoryReporter,
 } from './lib/metrics.js';
 import { actionFromReq, classifyError } from './lib/request-utils.js';
+import { loadPersistedStorageState, persistStorageState } from './lib/persistence.js';
+import { importBootstrapCookies } from './lib/cookies.js';
+import { coalesceInflight } from './lib/inflight.js';
 
 const CONFIG = loadConfig();
 
@@ -236,6 +239,7 @@ app.post('/sessions/:userId/cookies', express.json({ limit: '512kb' }), async (r
 
     const session = await getSession(userId);
     await session.context.addCookies(sanitized);
+    await checkpointSessionState(userId, session, 'cookie_import');
     const result = { ok: true, userId: String(userId), count: sanitized.length };
     log('info', 'cookies imported', { reqId: req.reqId, userId: String(userId), count: sanitized.length });
     res.json(result);
@@ -251,6 +255,7 @@ let browser = null;
 // TabState = { page, refs: Map<refId, {role, name, nth}>, visitedUrls: Set, downloads: Array, toolCalls: number }
 // Note: sessionKey was previously called listItemId - both are accepted for backward compatibility
 const sessions = new Map();
+const sessionCreations = new Map();
 
 const SESSION_TIMEOUT_MS = CONFIG.sessionTimeoutMs;
 const MAX_SNAPSHOT_NODES = 500;
@@ -487,10 +492,7 @@ async function restartBrowser(reason) {
   browserRestartsTotal.labels(reason).inc();
   log('error', 'restarting browser', { reason, failures: healthState.consecutiveNavFailures });
   try {
-    for (const [, session] of sessions) {
-      await session.context.close().catch(() => {});
-    }
-    sessions.clear();
+    await closeAllSessions(`browser_restart:${reason}`, { persist: true, clearDownloads: true, clearLocks: true });
     if (browser) {
       await browser.close().catch(() => {});
       browser = null;
@@ -671,10 +673,7 @@ async function ensureBrowser() {
     log('warn', 'browser disconnected, clearing dead sessions and relaunching', {
       deadSessions: sessions.size,
     });
-    for (const [userId, session] of sessions) {
-      await session.context.close().catch(() => {});
-    }
-    sessions.clear();
+    await closeAllSessions('browser_disconnected', { persist: false, clearDownloads: true, clearLocks: true });
     // Clean up virtual display from dead browser before relaunching
     if (virtualDisplay) {
       virtualDisplay.kill();
@@ -698,6 +697,78 @@ function normalizeUserId(userId) {
   return String(userId);
 }
 
+async function checkpointSessionState(userId, session, reason) {
+  if (!CONFIG.persistenceEnabled || !session?.context) return { persisted: false, reason: 'disabled' };
+
+  const result = await persistStorageState({
+    profileDir: CONFIG.profileDir,
+    userId,
+    context: session.context,
+    logger: {
+      warn: (msg, fields = {}) => log('warn', msg, fields),
+    },
+  });
+
+  if (result.persisted) {
+    log('info', 'session state persisted', {
+      userId,
+      reason,
+      storageStatePath: result.storageStatePath,
+    });
+  }
+
+  return result;
+}
+
+function clearSessionLocks(session) {
+  if (!session?.tabGroups) return;
+  for (const [, group] of session.tabGroups) {
+    for (const tabId of group.keys()) {
+      const lock = tabLocks.get(tabId);
+      if (lock) {
+        lock.drain();
+        tabLocks.delete(tabId);
+      }
+    }
+  }
+  refreshTabLockQueueDepth();
+}
+
+async function closeSession(userId, session, {
+  reason = 'session_closed',
+  persist = true,
+  clearDownloads = true,
+  clearLocks = true,
+} = {}) {
+  if (!session) return;
+
+  const key = normalizeUserId(userId);
+
+  if (clearDownloads) {
+    await clearSessionDownloads(session).catch(() => {});
+  }
+
+  if (persist) {
+    await checkpointSessionState(key, session, reason);
+  }
+
+  await session.context.close().catch(() => {});
+  sessions.delete(key);
+
+  if (clearLocks) {
+    clearSessionLocks(session);
+  }
+
+  refreshActiveTabsGauge();
+}
+
+async function closeAllSessions(reason, { persist = true, clearDownloads = true, clearLocks = true } = {}) {
+  const openSessions = Array.from(sessions.entries());
+  for (const [userId, session] of openSessions) {
+    await closeSession(userId, session, { reason, persist, clearDownloads, clearLocks });
+  }
+}
+
 async function getSession(userId) {
   const key = normalizeUserId(userId);
   let session = sessions.get(key);
@@ -709,47 +780,73 @@ async function getSession(userId) {
       session.context.pages();
     } catch (err) {
       log('warn', 'session context dead, recreating', { userId: key, error: err.message });
-      session.context.close().catch(() => {});
-      sessions.delete(key);
+      await closeSession(key, session, { reason: 'dead_context', persist: false, clearDownloads: true, clearLocks: true });
       session = null;
     }
   }
   
   if (!session) {
-    if (sessions.size >= MAX_SESSIONS) {
-      throw new Error('Maximum concurrent sessions reached');
-    }
-    const b = await ensureBrowser();
-    const contextOptions = {
-      viewport: { width: 1280, height: 720 },
-      permissions: ['geolocation'],
-    };
-    // When geoip is active (proxy configured), camoufox auto-configures
-    // locale/timezone/geolocation from the proxy IP. Without proxy, use defaults.
-    if (!CONFIG.proxy.host) {
-      contextOptions.locale = 'en-US';
-      contextOptions.timezoneId = 'America/Los_Angeles';
-      contextOptions.geolocation = { latitude: 37.7749, longitude: -122.4194 };
-    }
-    let sessionProxy = null;
-    if (proxyPool?.canRotateSessions) {
-      sessionProxy = proxyPool.getNext(`ctx-${key}-${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`);
-      contextOptions.proxy = normalizePlaywrightProxy(sessionProxy);
-      log('info', 'session proxy assigned', { userId: key, sessionId: sessionProxy.sessionId });
-    } else if (proxyPool) {
-      sessionProxy = proxyPool.getNext();
-      contextOptions.proxy = normalizePlaywrightProxy(sessionProxy);
-      log('info', 'session proxy assigned', { userId: key, proxy: sessionProxy.server });
-    }
-    const context = await b.newContext(contextOptions);
-    
-    session = { context, tabGroups: new Map(), lastAccess: Date.now(), proxySessionId: sessionProxy?.sessionId || null };
-    sessions.set(key, session);
-    log('info', 'session created', {
-      userId: key,
-      proxyMode: proxyPool?.mode || null,
-      proxyServer: sessionProxy?.server || browserLaunchProxy?.server || null,
-      proxySession: sessionProxy?.sessionId || browserLaunchProxy?.sessionId || null,
+    session = await coalesceInflight(sessionCreations, key, async () => {
+      if (sessions.size >= MAX_SESSIONS) {
+        throw new Error('Maximum concurrent sessions reached');
+      }
+      const b = await ensureBrowser();
+      const contextOptions = {
+        viewport: { width: 1280, height: 720 },
+        permissions: ['geolocation'],
+      };
+      const storageStatePath = CONFIG.persistenceEnabled
+        ? await loadPersistedStorageState(CONFIG.profileDir, key, {
+            warn: (msg, fields = {}) => log('warn', msg, fields),
+          })
+        : undefined;
+      if (storageStatePath) {
+        contextOptions.storageState = storageStatePath;
+      }
+      // When geoip is active (proxy configured), camoufox auto-configures
+      // locale/timezone/geolocation from the proxy IP. Without proxy, use defaults.
+      if (!CONFIG.proxy.host) {
+        contextOptions.locale = 'en-US';
+        contextOptions.timezoneId = 'America/Los_Angeles';
+        contextOptions.geolocation = { latitude: 37.7749, longitude: -122.4194 };
+      }
+      let sessionProxy = null;
+      if (proxyPool?.canRotateSessions) {
+        sessionProxy = proxyPool.getNext(`ctx-${key}-${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`);
+        contextOptions.proxy = normalizePlaywrightProxy(sessionProxy);
+        log('info', 'session proxy assigned', { userId: key, sessionId: sessionProxy.sessionId });
+      } else if (proxyPool) {
+        sessionProxy = proxyPool.getNext();
+        contextOptions.proxy = normalizePlaywrightProxy(sessionProxy);
+        log('info', 'session proxy assigned', { userId: key, proxy: sessionProxy.server });
+      }
+      const context = await b.newContext(contextOptions);
+      const bootstrapImport = await importBootstrapCookies({
+        cookiesDir: CONFIG.cookiesDir,
+        context,
+        logger: { warn: (msg, fields = {}) => log('warn', msg, fields) },
+      });
+      const bootstrapCookiesImported = bootstrapImport.imported;
+      const bootstrapCookieSource = bootstrapImport.source;
+
+      const created = { context, tabGroups: new Map(), lastAccess: Date.now(), proxySessionId: sessionProxy?.sessionId || null };
+      sessions.set(key, created);
+
+      if (bootstrapCookiesImported > 0) {
+        await checkpointSessionState(key, created, 'bootstrap_cookies_import');
+      }
+
+      log('info', 'session created', {
+        userId: key,
+        proxyMode: proxyPool?.mode || null,
+        proxyServer: sessionProxy?.server || browserLaunchProxy?.server || null,
+        proxySession: sessionProxy?.sessionId || browserLaunchProxy?.sessionId || null,
+        restoredStorageState: !!storageStatePath,
+        storageStatePath: storageStatePath || null,
+        bootstrapCookiesImported,
+        bootstrapCookieSource,
+      });
+      return created;
     });
   }
   session.lastAccess = Date.now();
@@ -904,8 +1001,8 @@ function destroySession(userId) {
   const session = sessions.get(key);
   if (!session) return;
   log('warn', 'destroying dead session', { userId: key });
-  session.context.close().catch(() => {});
   sessions.delete(key);
+  closeSession(key, session, { reason: 'destroy_session', persist: true, clearDownloads: true, clearLocks: true }).catch(() => {});
 }
 
 function findTab(session, tabId) {
@@ -949,8 +1046,7 @@ async function rotateGoogleTab(userId, sessionKey, tabId, previousTabState, reas
   const key = normalizeUserId(userId);
   const oldSession = sessions.get(key);
   if (oldSession) {
-    await oldSession.context.close().catch(() => {});
-    sessions.delete(key);
+    await closeSession(key, oldSession, { reason: 'google_rotate_context', persist: true, clearDownloads: true, clearLocks: true });
   }
   const session = await getSession(userId);
   const group = getTabGroup(session, sessionKey);
@@ -1622,8 +1718,7 @@ async function browserTranscript(reqId, url, videoId, lang) {
         let totalTabs = 0;
         for (const g of ytSession.tabGroups.values()) totalTabs += g.size;
         if (totalTabs === 0) {
-          ytSession.context.close().catch(() => {});
-          sessions.delete(normalizeUserId('__yt_transcript__'));
+          await closeSession('__yt_transcript__', ytSession, { reason: 'yt_transcript_empty', persist: false, clearDownloads: true, clearLocks: true });
         }
       }
     }
@@ -1646,14 +1741,15 @@ app.get('/health', (req, res) => {
       ...(FLY_MACHINE_ID ? { machineId: FLY_MACHINE_ID } : {}),
     });
   }
-  res.json({ 
-    ok: true, 
+  res.json({
+    ok: true,
     engine: 'camoufox',
     browserConnected: running,
     browserRunning: running,
     activeTabs: getTotalTabCount(),
     activeSessions: sessions.size,
     consecutiveFailures: healthState.consecutiveNavFailures,
+    persistenceEnabled: CONFIG.persistenceEnabled,
     ...(FLY_MACHINE_ID ? { machineId: FLY_MACHINE_ID } : {}),
   });
 });
@@ -1796,8 +1892,7 @@ app.post('/tabs/:tabId/navigate', async (req, res) => {
           const key = normalizeUserId(userId);
           const oldSession = sessions.get(key);
           if (oldSession) {
-            await oldSession.context.close().catch(() => {});
-            sessions.delete(key);
+            await closeSession(key, oldSession, { reason: 'google_blocked_context_rotate', persist: true, clearDownloads: true, clearLocks: true });
           }
           session = await getSession(userId);
           const group = getTabGroup(session, currentSessionKey);
@@ -2599,21 +2694,7 @@ app.delete('/sessions/:userId', async (req, res) => {
     const userId = normalizeUserId(req.params.userId);
     const session = sessions.get(userId);
     if (session) {
-      await clearSessionDownloads(session);
-      await session.context.close();
-      sessions.delete(userId);
-      // Remove any lingering tab locks for the session
-      for (const [listItemId, group] of session.tabGroups) {
-        for (const tabId of group.keys()) {
-          const lock = tabLocks.get(tabId);
-          if (lock) {
-            lock.drain();
-            tabLocks.delete(tabId);
-          }
-        }
-      }
-      refreshTabLockQueueDepth();
-      refreshActiveTabsGauge();
+      await closeSession(userId, session, { reason: 'api_delete_session', persist: true, clearDownloads: true, clearLocks: true });
       log('info', 'session closed', { userId });
     }
     if (sessions.size === 0) scheduleBrowserIdleShutdown();
@@ -2627,13 +2708,10 @@ app.delete('/sessions/:userId', async (req, res) => {
 // Cleanup stale sessions
 setInterval(() => {
   const now = Date.now();
-  for (const [userId, session] of sessions) {
+  for (const [userId, session] of Array.from(sessions.entries())) {
     if (now - session.lastAccess > SESSION_TIMEOUT_MS) {
       sessionsExpiredTotal.inc();
-      clearSessionDownloads(session).catch(() => {});
-      session.context.close().catch(() => {});
-      sessions.delete(userId);
-      refreshActiveTabsGauge();
+      closeSession(userId, session, { reason: 'session_timeout', persist: true, clearDownloads: true, clearLocks: true }).catch(() => {});
       log('info', 'session expired', { userId });
     }
   }
@@ -2678,11 +2756,8 @@ setInterval(() => {
     // Clean up sessions with zero tabs remaining — free browser context memory
     if (session.tabGroups.size === 0) {
       log('info', 'session empty after tab reaper, closing', { userId });
-      clearSessionDownloads(session).catch(() => {});
-      session.context.close().catch(() => {});
-      sessions.delete(userId);
+      closeSession(userId, session, { reason: 'tab_reaper_empty_session', persist: true, clearDownloads: true, clearLocks: true }).catch(() => {});
       sessionsExpiredTotal.inc();
-      refreshActiveTabsGauge();
     }
   }
   if (sessions.size === 0) scheduleBrowserIdleShutdown();
@@ -2696,13 +2771,14 @@ setInterval(() => {
 // GET / - Status (passive — does not launch browser)
 app.get('/', (req, res) => {
   const running = browser !== null && (browser.isConnected?.() ?? false);
-  res.json({ 
+  res.json({
     ok: true,
     enabled: true,
     running,
     engine: 'camoufox',
     browserConnected: running,
     browserRunning: running,
+    persistenceEnabled: CONFIG.persistenceEnabled,
   });
 });
 
@@ -3232,9 +3308,12 @@ async function gracefulShutdown(signal) {
   server.close();
   stopMemoryReporter();
 
-  for (const [userId, session] of sessions) {
-    await session.context.close().catch(() => {});
-  }
+  await closeAllSessions(`shutdown:${signal}`, {
+    persist: true,
+    clearDownloads: false,
+    clearLocks: false,
+  });
+
   if (browser) await browser.close().catch(() => {});
   process.exit(0);
 }

--- a/tests/unit/autoCookieImport.test.js
+++ b/tests/unit/autoCookieImport.test.js
@@ -1,0 +1,67 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { jest } from '@jest/globals';
+import { importBootstrapCookies } from '../../lib/cookies.js';
+
+describe('importBootstrapCookies', () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'camofox-bootstrap-cookies-'));
+  });
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('returns zero without calling addCookies when cookies.txt is missing', async () => {
+    const context = { addCookies: jest.fn() };
+    const logger = { warn: jest.fn() };
+
+    const result = await importBootstrapCookies({ cookiesDir: tmpDir, context, logger });
+
+    expect(result.imported).toBe(0);
+    expect(result.source).toBe(null);
+    expect(context.addCookies).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test('imports all cookies from the default cookies.txt file', async () => {
+    const cookieText = [
+      '# Netscape HTTP Cookie File',
+      '.example.com\tTRUE\t/\tTRUE\t1700000000\tlogged_in\tyes',
+      'app.example.org\tFALSE\t/\tTRUE\t1700000000\t__cflb\tabc123',
+    ].join('\n');
+    await fs.writeFile(path.join(tmpDir, 'cookies.txt'), cookieText);
+
+    const context = { addCookies: jest.fn(async () => {}) };
+
+    const result = await importBootstrapCookies({ cookiesDir: tmpDir, context, logger: { warn: jest.fn() } });
+
+    expect(result.imported).toBe(2);
+    expect(result.source.endsWith(path.join(tmpDir, 'cookies.txt'))).toBe(true);
+    expect(context.addCookies).toHaveBeenCalledTimes(1);
+    expect(context.addCookies.mock.calls[0][0]).toEqual([
+      expect.objectContaining({ domain: '.example.com', name: 'logged_in', value: 'yes' }),
+      expect.objectContaining({ domain: 'app.example.org', name: '__cflb', value: 'abc123' }),
+    ]);
+  });
+
+  test('logs and returns zero when addCookies throws', async () => {
+    await fs.writeFile(
+      path.join(tmpDir, 'cookies.txt'),
+      '.example.com\tTRUE\t/\tTRUE\t1700000000\tlogged_in\tyes\n'
+    );
+
+    const context = { addCookies: jest.fn(async () => { throw new Error('boom'); }) };
+    const logger = { warn: jest.fn() };
+
+    const result = await importBootstrapCookies({ cookiesDir: tmpDir, context, logger });
+
+    expect(result.imported).toBe(0);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/inflight.test.js
+++ b/tests/unit/inflight.test.js
@@ -1,0 +1,69 @@
+import { coalesceInflight } from '../../lib/inflight.js';
+
+describe('coalesceInflight', () => {
+  test('concurrent calls for the same key invoke the factory once', async () => {
+    const map = new Map();
+    let calls = 0;
+    const factory = async () => {
+      calls += 1;
+      await new Promise((r) => setTimeout(r, 10));
+      return { id: calls };
+    };
+
+    const [a, b, c] = await Promise.all([
+      coalesceInflight(map, 'user-1', factory),
+      coalesceInflight(map, 'user-1', factory),
+      coalesceInflight(map, 'user-1', factory),
+    ]);
+
+    expect(calls).toBe(1);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  test('different keys run independently', async () => {
+    const map = new Map();
+    const factoryFor = (label) => async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      return label;
+    };
+
+    const [a, b] = await Promise.all([
+      coalesceInflight(map, 'user-a', factoryFor('A')),
+      coalesceInflight(map, 'user-b', factoryFor('B')),
+    ]);
+
+    expect(a).toBe('A');
+    expect(b).toBe('B');
+  });
+
+  test('map entry is cleared after resolve, so a later call creates fresh', async () => {
+    const map = new Map();
+    let calls = 0;
+    const factory = async () => ({ id: ++calls });
+
+    const first = await coalesceInflight(map, 'user-1', factory);
+    expect(map.has('user-1')).toBe(false);
+
+    const second = await coalesceInflight(map, 'user-1', factory);
+    expect(map.has('user-1')).toBe(false);
+
+    expect(calls).toBe(2);
+    expect(first).not.toBe(second);
+  });
+
+  test('map entry is cleared after reject and the rejection propagates to all awaiters', async () => {
+    const map = new Map();
+    const factory = async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      throw new Error('boom');
+    };
+
+    const first = coalesceInflight(map, 'user-1', factory);
+    const second = coalesceInflight(map, 'user-1', factory);
+
+    await expect(first).rejects.toThrow('boom');
+    await expect(second).rejects.toThrow('boom');
+    expect(map.has('user-1')).toBe(false);
+  });
+});

--- a/tests/unit/persistence.test.js
+++ b/tests/unit/persistence.test.js
@@ -1,0 +1,117 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { jest } from '@jest/globals';
+import {
+  getUserPersistencePaths,
+  loadPersistedStorageState,
+  persistStorageState,
+} from '../../lib/persistence.js';
+
+describe('profile persistence helpers', () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'camofox-persistence-'));
+  });
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('getUserPersistencePaths is deterministic and stays under root', () => {
+    const first = getUserPersistencePaths(tmpDir, 'agent/profile:default');
+    const second = getUserPersistencePaths(tmpDir, 'agent/profile:default');
+
+    expect(first).toEqual(second);
+    expect(first.userDir.startsWith(tmpDir)).toBe(true);
+    expect(first.storageStatePath.startsWith(first.userDir)).toBe(true);
+    expect(first.metaPath.startsWith(first.userDir)).toBe(true);
+    expect(path.basename(first.userDir)).not.toContain('/');
+    expect(path.basename(first.userDir)).not.toContain(':');
+  });
+
+  test('loadPersistedStorageState returns undefined when no state exists', async () => {
+    await expect(loadPersistedStorageState(tmpDir, 'user-1')).resolves.toBeUndefined();
+  });
+
+  test('persistStorageState writes storage state and metadata, then load returns the storage path', async () => {
+    const storageState = {
+      cookies: [{ name: 'session', value: 'abc', domain: '.example.com', path: '/' }],
+      origins: [{ origin: 'https://app.example.com', localStorage: [{ name: 'foo', value: 'bar' }] }],
+    };
+
+    const context = {
+      storageState: jest.fn(async ({ path: targetPath }) => {
+        await fs.writeFile(targetPath, JSON.stringify(storageState, null, 2));
+      }),
+    };
+
+    const result = await persistStorageState({
+      profileDir: tmpDir,
+      userId: 'user-1',
+      context,
+      logger: { warn: jest.fn() },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(context.storageState).toHaveBeenCalledTimes(1);
+
+    const loadedPath = await loadPersistedStorageState(tmpDir, 'user-1');
+    expect(loadedPath).toBe(result.storageStatePath);
+
+    const meta = JSON.parse(await fs.readFile(result.metaPath, 'utf8'));
+    expect(meta.userId).toBe('user-1');
+    expect(meta.storageStatePath).toBe(result.storageStatePath);
+  });
+
+  test('loadPersistedStorageState ignores invalid JSON files', async () => {
+    const { storageStatePath } = getUserPersistencePaths(tmpDir, 'user-2');
+    await fs.mkdir(path.dirname(storageStatePath), { recursive: true });
+    await fs.writeFile(storageStatePath, '{not-json');
+
+    await expect(loadPersistedStorageState(tmpDir, 'user-2', { warn: jest.fn() })).resolves.toBeUndefined();
+  });
+
+  test('a failed persist leaves the previous storage-state intact and cleans up tmp files', async () => {
+    const originalState = {
+      cookies: [{ name: 'orig', value: 'v1', domain: '.example.com', path: '/' }],
+    };
+    const goodContext = {
+      storageState: jest.fn(async ({ path: targetPath }) => {
+        await fs.writeFile(targetPath, JSON.stringify(originalState, null, 2));
+      }),
+    };
+    const first = await persistStorageState({
+      profileDir: tmpDir,
+      userId: 'user-3',
+      context: goodContext,
+      logger: { warn: jest.fn() },
+    });
+    expect(first.persisted).toBe(true);
+
+    const failingContext = {
+      storageState: jest.fn(async () => {
+        throw new Error('simulated crash mid-write');
+      }),
+    };
+    const second = await persistStorageState({
+      profileDir: tmpDir,
+      userId: 'user-3',
+      context: failingContext,
+      logger: { warn: jest.fn() },
+    });
+    expect(second.persisted).toBe(false);
+
+    const { userDir, storageStatePath } = getUserPersistencePaths(tmpDir, 'user-3');
+    const loaded = await loadPersistedStorageState(tmpDir, 'user-3');
+    expect(loaded).toBe(storageStatePath);
+    const parsed = JSON.parse(await fs.readFile(storageStatePath, 'utf8'));
+    expect(parsed).toEqual(originalState);
+
+    const leftovers = (await fs.readdir(userDir)).filter((name) => name.includes('.tmp-'));
+    expect(leftovers).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds opt-in per-user browser storage state persistence (cookies + localStorage) so agent sessions survive container restarts, deploys, and idle timeouts, without re-importing cookies every time.

**Disabled by default.** Existing deployments are unaffected unless both env vars are set.

## How it works

- On session create: if a persisted `storageState` exists for the `userId`, Playwright restores it.
- On cookie import and session teardown (and SIGTERM shutdown): checkpoint cookies/localStorage to disk via atomic tmp-write + rename.
- Each `userId` maps to a deterministic SHA256-hashed subdirectory under `CAMOFOX_PROFILE_DIR`, so arbitrary userIds are path-safe.

## Configuration

| Env var | Purpose |
|---|---|
| `CAMOFOX_PERSISTENCE` | `1` / `true` to opt in |
| `CAMOFOX_PROFILE_DIR` | Root dir for persisted state (required when flag is on) |

Both must be set, either alone is a no-op. The Makefile gains a `PERSISTENCE=1` shortcut for Docker users that wires up the env vars and a volume mount.

## What's in the PR

- `lib/persistence.js` — `getUserPersistencePaths`, `loadPersistedStorageState`, `persistStorageState` (atomic writes, cleanup on failure)
- `lib/inflight.js` — `coalesceInflight` primitive so concurrent `getSession` calls for the same userId share one creation promise (prevents races that could clobber persisted state)
- `lib/config.js` — `persistenceEnabled` + `profileDir` surfaced on config; env vars added to the whitelist
- `lib/cookies.js` — `importBootstrapCookies` helper extracted for testability
- `server.js` — restore on create, persist on import/destroy, persist-on-shutdown via `closeAllSessions({ persist: true })`, `getSession` wrapped in `coalesceInflight`
- Tests: 12 new unit tests across `persistence`, `inflight`, `autoCookieImport`
- README: new env vars documented, short persistence section
- Makefile: optional `PERSISTENCE=1` target