### PR TITLE
fix: clean up orphaned camoufox temp files on startup

### DIFF
--- a/lib/tmp-cleanup.js
+++ b/lib/tmp-cleanup.js
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import path from 'path';
+
+const ORPHAN_PATTERNS = [
+  /^\.fea5[a-f0-9]+\.so$/,
+  /^\.5ef7[a-f0-9]+\.node$/,
+];
+
+export function cleanupOrphanedTempFiles({ tmpDir, minAgeMs = 5 * 60 * 1000, now = Date.now() } = {}) {
+  const result = { scanned: 0, removed: 0, bytes: 0, skipped: 0 };
+  if (!tmpDir) return result;
+
+  let entries;
+  try {
+    entries = fs.readdirSync(tmpDir);
+  } catch {
+    return result;
+  }
+
+  for (const name of entries) {
+    if (!ORPHAN_PATTERNS.some((re) => re.test(name))) continue;
+    result.scanned++;
+    const full = path.join(tmpDir, name);
+    try {
+      const st = fs.statSync(full);
+      if (!st.isFile()) continue;
+      if (now - st.mtimeMs < minAgeMs) {
+        result.skipped++;
+        continue;
+      }
+      fs.unlinkSync(full);
+      result.removed++;
+      result.bytes += st.size;
+    } catch {
+      // file vanished, permission denied, or race with another process - skip silently
+    }
+  }
+
+  return result;
+}

--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@ import {
   startMemoryReporter, stopMemoryReporter,
 } from './lib/metrics.js';
 import { actionFromReq, classifyError } from './lib/request-utils.js';
+import { cleanupOrphanedTempFiles } from './lib/tmp-cleanup.js';
 
 const CONFIG = loadConfig();
 
@@ -3256,6 +3257,10 @@ const server = app.listen(PORT, async () => {
     log('info', 'server started (fly)', { port: PORT, pid: process.pid, machineId: FLY_MACHINE_ID, nodeVersion: process.version });
   } else {
     log('info', 'server started', { port: PORT, pid: process.pid, nodeVersion: process.version });
+  }
+  const tmpCleanup = cleanupOrphanedTempFiles({ tmpDir: os.tmpdir() });
+  if (tmpCleanup.removed > 0) {
+    log('info', 'cleaned up orphaned camoufox temp files', tmpCleanup);
   }
   // Pre-warm browser so first request doesn't eat a 6-7s cold start
   try {

--- a/tests/unit/tmpCleanup.test.js
+++ b/tests/unit/tmpCleanup.test.js
@@ -1,0 +1,92 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { cleanupOrphanedTempFiles } from '../../lib/tmp-cleanup.js';
+
+describe('lib/tmp-cleanup', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'camofox-tmp-cleanup-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeFile(name, { sizeBytes = 16, ageMs = 0 } = {}) {
+    const full = path.join(tmpDir, name);
+    fs.writeFileSync(full, Buffer.alloc(sizeBytes));
+    if (ageMs > 0) {
+      const past = (Date.now() - ageMs) / 1000;
+      fs.utimesSync(full, past, past);
+    }
+    return full;
+  }
+
+  test('removes orphaned .fea5*.so and .5ef7*.node files older than threshold', () => {
+    writeFile('.fea5abc123.so', { sizeBytes: 4300000, ageMs: 60 * 60 * 1000 });
+    writeFile('.5ef7deadbeef.node', { sizeBytes: 0, ageMs: 60 * 60 * 1000 });
+
+    const result = cleanupOrphanedTempFiles({ tmpDir, minAgeMs: 5 * 60 * 1000 });
+
+    expect(result.scanned).toBe(2);
+    expect(result.removed).toBe(2);
+    expect(result.bytes).toBe(4300000);
+    expect(fs.existsSync(path.join(tmpDir, '.fea5abc123.so'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, '.5ef7deadbeef.node'))).toBe(false);
+  });
+
+  test('leaves files younger than threshold (concurrent-instance guard)', () => {
+    writeFile('.fea5beef01.so', { sizeBytes: 100, ageMs: 60 * 1000 });
+
+    const result = cleanupOrphanedTempFiles({ tmpDir, minAgeMs: 5 * 60 * 1000 });
+
+    expect(result.scanned).toBe(1);
+    expect(result.removed).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(fs.existsSync(path.join(tmpDir, '.fea5beef01.so'))).toBe(true);
+  });
+
+  test('leaves files that do not match the orphan patterns', () => {
+    writeFile('normal.so', { ageMs: 60 * 60 * 1000 });
+    writeFile('.fea5.so', { ageMs: 60 * 60 * 1000 });
+    writeFile('.fea5abc.txt', { ageMs: 60 * 60 * 1000 });
+    writeFile('camofox-download-abc.pdf', { ageMs: 60 * 60 * 1000 });
+
+    const result = cleanupOrphanedTempFiles({ tmpDir, minAgeMs: 5 * 60 * 1000 });
+
+    expect(result.scanned).toBe(0);
+    expect(result.removed).toBe(0);
+    expect(fs.readdirSync(tmpDir).length).toBe(4);
+  });
+
+  test('returns zeros when tmpDir does not exist', () => {
+    const missing = path.join(tmpDir, 'does-not-exist');
+
+    const result = cleanupOrphanedTempFiles({ tmpDir: missing });
+
+    expect(result).toEqual({ scanned: 0, removed: 0, bytes: 0, skipped: 0 });
+  });
+
+  test('uses injected now for deterministic age comparison', () => {
+    writeFile('.fea5abc.so', { sizeBytes: 10, ageMs: 0 });
+    const filePath = path.join(tmpDir, '.fea5abc.so');
+    const mtimeMs = fs.statSync(filePath).mtimeMs;
+
+    const fresh = cleanupOrphanedTempFiles({
+      tmpDir,
+      minAgeMs: 5 * 60 * 1000,
+      now: mtimeMs + 60 * 1000,
+    });
+    expect(fresh.removed).toBe(0);
+    expect(fresh.skipped).toBe(1);
+
+    const stale = cleanupOrphanedTempFiles({
+      tmpDir,
+      minAgeMs: 5 * 60 * 1000,
+      now: mtimeMs + 10 * 60 * 1000,
+    });
+    expect(stale.removed).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes #58.

When the server is killed with SIGKILL or the kernel OOMs the process, userland cleanup never runs and camoufox's internal `.fea5*.so` and `.5ef7*.node` temp files survive in `os.tmpdir()`. They accumulate. The reporter saw 27,852 files totaling 115 GB on a production host before the disk filled.

`SIGTERM` / `SIGINT` already trigger `gracefulShutdown` -> `browser.close()`, which removes the files via camoufox's own cleanup. The only gap is the non-graceful exit path, which can't be fixed in userland (SIGKILL is uncatchable). A startup sweep is the right place to reclaim the leftovers.

## Changes

- `lib/tmp-cleanup.js`. Exports `cleanupOrphanedTempFiles({ tmpDir, minAgeMs, now })`. Pure Node: `fs.readdirSync` + `fs.statSync` + `fs.unlinkSync`. No `process.env`, no `child_process`, no network. Scanner-safe per `AGENTS.md`.
- `server.js`. Calls it once from the `app.listen` callback at startup, before the browser pre-warm. Logs a summary line only when files are removed.
- `tests/unit/tmpCleanup.test.js`. 5 unit tests using `fs.mkdtempSync` so they don't touch the real `/tmp`.

The 5-minute age threshold prevents deleting files from a concurrently-running instance. Patterns are restricted to the two known orphan shapes (`.fea5[hex]+.so` and `.5ef7[hex]+.node`); non-matching entries are left alone.

## Not in scope

- No changes to `gracefulShutdown` (already correct for SIGTERM/SIGINT).
- No new env vars or config surface.
- No per-process temp directory (would require a change in `camoufox-js` upstream).

## Testing

`npm test` passes 172/172 unit tests (14 suites). The 5 new tests cover: removal of aged files, skipping fresh files, leaving non-matching names, graceful handling of a missing `tmpDir`, and deterministic age comparison via an injected `now`.

This contribution was developed with AI assistance (Claude Code).
