### PR TITLE
feat: VNC interactive login + storage_state export endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,16 @@ RUN apt-get update && apt-get install -y \
     # Utils
     ca-certificates \
     unzip \
+    curl \
     # yt-dlp runtime dependency
     python3-minimal \
+    # VNC stack (only used at runtime when ENABLE_VNC=1; small footprint)
+    # x11vnc attaches to the existing Xvfb; novnc + websockify expose it over http
+    x11vnc \
+    novnc \
+    python3-websockify \
+    net-tools \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Pre-bake Camoufox browser binary into image via bind mount (downloaded by Makefile)
@@ -61,10 +69,20 @@ RUN npm install --production
 
 COPY server.js ./
 COPY lib/ ./lib/
+COPY scripts/ ./scripts/
+
+# Patch Camoufox's built-in Xvfb launcher to use a usable resolution
+# (default is 1x1 which is useless for VNC; anti-detection doesn't depend on resolution)
+RUN sed -i 's/"1x1x24"/"1920x1080x24"/g' \
+    /app/node_modules/camoufox-js/dist/virtdisplay.js \
+    && grep -q '1920x1080x24' /app/node_modules/camoufox-js/dist/virtdisplay.js \
+    && echo "Xvfb resolution patched to 1920x1080"
 
 ENV NODE_ENV=production
 ENV CAMOFOX_PORT=3000
 
-EXPOSE 9377
+# 9377: Camofox HTTP API
+# 6080: noVNC web interface (only active when ENABLE_VNC=1)
+EXPOSE 9377 6080
 
-CMD ["sh", "-c", "node --max-old-space-size=${MAX_OLD_SPACE_SIZE:-128} server.js"]
+CMD ["sh", "/app/scripts/start.sh"]

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# camofox-browser container entrypoint
+#
+# Responsibilities:
+#   1. Optionally start a VNC stack (x11vnc + noVNC) attached to Camoufox's Xvfb.
+#      This lets a human log into sites interactively, then storageState can be
+#      exported and reused — sidestepping fingerprint-based session invalidation.
+#   2. Exec the Node server in the foreground (PID 1-ish, signals propagate).
+#
+# Controlled by env vars (all optional):
+#   ENABLE_VNC       "1" to start the VNC stack. Default: off.
+#   VNC_PASSWORD     If set, x11vnc requires this password. If unset and
+#                    ENABLE_VNC=1, VNC is started WITHOUT a password — only safe
+#                    when the port is bound to 127.0.0.1 on the host (use SSH
+#                    tunnel to access).
+#   VIEW_ONLY        "1" to start x11vnc in view-only mode. Default: off.
+#
+# Design note: Camoufox's VirtualDisplay.js picks a random free display number
+# at browser-launch time and skips any with existing lock files. We can't
+# pre-start Xvfb on a known display because that would force Camoufox to pick
+# a different one, and x11vnc would show a blank screen. Instead, we spawn a
+# watcher that detects the Xvfb process Camoufox creates, then attaches x11vnc
+# to that exact display. Same trick works across browser restarts.
+
+set -e
+
+log() { printf '[start.sh] %s\n' "$*" >&2; }
+
+# Background watcher: attach x11vnc to whichever DISPLAY Camoufox's Xvfb uses.
+vnc_watcher() {
+  CURRENT_DISPLAY=""
+  X11VNC_PID=""
+
+  # Prepare password file once if requested
+  PASSFILE=""
+  if [ -n "${VNC_PASSWORD:-}" ]; then
+    mkdir -p /root/.vnc
+    x11vnc -storepasswd "$VNC_PASSWORD" /root/.vnc/passwd >/dev/null 2>&1
+    PASSFILE="/root/.vnc/passwd"
+    log "x11vnc: password protected"
+  else
+    log "x11vnc: NO password (bind 6080 to 127.0.0.1 on host + SSH tunnel)"
+  fi
+
+  # Start noVNC (websockify) up front — it proxies to 127.0.0.1:5900 regardless
+  # of whether x11vnc is running yet. The websocket will just fail until x11vnc
+  # appears, which is fine for the user (reload the page once you see VNC alive).
+  NOVNC_DIR="/usr/share/novnc"
+  if [ ! -d "$NOVNC_DIR" ]; then
+    log "ERROR: $NOVNC_DIR not found; noVNC cannot start"
+    return 1
+  fi
+  log "Starting noVNC (websockify) on 0.0.0.0:6080 -> 127.0.0.1:5900 ..."
+  websockify --web "$NOVNC_DIR" 0.0.0.0:6080 127.0.0.1:5900 >/var/log/novnc.log 2>&1 &
+
+  log "VNC watcher started — will attach x11vnc when Camoufox's Xvfb appears"
+
+  while true; do
+    # Find Xvfb process launched with -screen X 1920x1080x24 (our patched resolution)
+    # Extract the display arg (:NN) from its cmdline.
+    FOUND=$(ps -eo args= 2>/dev/null | awk '
+      /\/Xvfb :[0-9]+/ && /1920x1080x24/ {
+        for (i=1;i<=NF;i++) if ($i ~ /^:[0-9]+$/) { print $i; exit }
+      }
+    ' | head -1)
+
+    if [ -n "$FOUND" ] && [ "$FOUND" != "$CURRENT_DISPLAY" ]; then
+      # New display appeared (or replaced an old one). Attach x11vnc.
+      if [ -n "$X11VNC_PID" ] && kill -0 "$X11VNC_PID" 2>/dev/null; then
+        log "Camoufox display changed ($CURRENT_DISPLAY -> $FOUND), restarting x11vnc"
+        kill "$X11VNC_PID" 2>/dev/null || true
+        sleep 0.5
+      fi
+
+      CURRENT_DISPLAY="$FOUND"
+      log "Attaching x11vnc to DISPLAY=$CURRENT_DISPLAY"
+
+      X11VNC_ARGS="-display $CURRENT_DISPLAY -forever -shared -rfbport 5900 -noxdamage -quiet -bg -o /var/log/x11vnc.log"
+      [ "${VIEW_ONLY:-0}" = "1" ] && X11VNC_ARGS="$X11VNC_ARGS -viewonly"
+      if [ -n "$PASSFILE" ]; then
+        X11VNC_ARGS="$X11VNC_ARGS -rfbauth $PASSFILE"
+      else
+        X11VNC_ARGS="$X11VNC_ARGS -nopw"
+      fi
+
+      # -bg daemonises x11vnc. We track its PID via a pidfile.
+      # shellcheck disable=SC2086
+      x11vnc $X11VNC_ARGS
+      sleep 1
+      X11VNC_PID=$(pgrep -f "x11vnc.*-display $CURRENT_DISPLAY" | head -1)
+      log "x11vnc running (pid=$X11VNC_PID) — open http://<host>:6080/vnc.html"
+    elif [ -z "$FOUND" ] && [ -n "$X11VNC_PID" ]; then
+      # Xvfb disappeared (browser closed); leave x11vnc running until replaced
+      :
+    fi
+
+    sleep 2
+  done
+}
+
+if [ "${ENABLE_VNC:-0}" = "1" ]; then
+  vnc_watcher &
+fi
+
+# Exec the Node server in the foreground so signals (docker stop) propagate
+exec node --max-old-space-size="${MAX_OLD_SPACE_SIZE:-128}" server.js

--- a/server.js
+++ b/server.js
@@ -246,6 +246,54 @@ app.post('/sessions/:userId/cookies', express.json({ limit: '512kb' }), async (r
   }
 });
 
+// GET /sessions/:userId/storage_state
+// Export the full Playwright storageState (cookies + localStorage) for the user's
+// browser context. Intended use: after a human logs into a site via VNC, call
+// this endpoint to capture the resulting auth state, save it to disk, and re-inject
+// on future runs. This survives fingerprint-based session invalidation because
+// the cookies were minted by the same Camoufox fingerprint that will re-use them.
+//
+// Auth: same policy as POST /sessions/:userId/cookies (CAMOFOX_API_KEY or loopback).
+app.get('/sessions/:userId/storage_state', async (req, res) => {
+  try {
+    if (CONFIG.apiKey) {
+      const apiKey = CONFIG.apiKey;
+      const auth = String(req.headers['authorization'] || '');
+      const match = auth.match(/^Bearer\s+(.+)$/i);
+      if (!match || !timingSafeCompare(match[1], apiKey)) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+    } else {
+      const remoteAddress = req.socket?.remoteAddress || '';
+      const allowUnauthedLocal = CONFIG.nodeEnv !== 'production' && isLoopbackAddress(remoteAddress);
+      if (!allowUnauthedLocal) {
+        return res.status(403).json({
+          error:
+            'storage_state export is disabled without CAMOFOX_API_KEY except for loopback requests in non-production environments.',
+        });
+      }
+    }
+
+    const userId = req.params.userId;
+    const session = sessions.get(String(userId));
+    if (!session) {
+      return res.status(404).json({ error: `No active session for userId="${userId}"` });
+    }
+
+    const state = await session.context.storageState();
+    log('info', 'storage_state exported', {
+      reqId: req.reqId,
+      userId: String(userId),
+      cookies: state.cookies?.length || 0,
+      origins: state.origins?.length || 0,
+    });
+    res.json(state);
+  } catch (err) {
+    log('error', 'storage_state export failed', { reqId: req.reqId, error: err.message });
+    res.status(500).json({ error: safeError(err) });
+  }
+});
+
 let browser = null;
 // userId -> { context, tabGroups: Map<sessionKey, Map<tabId, TabState>>, lastAccess }
 // TabState = { page, refs: Map<refId, {role, name, nth}>, visitedUrls: Set, downloads: Array, toolCalls: number }


### PR DESCRIPTION
## Summary

Adds interactive VNC login support + a `storage_state` export endpoint so operators can authenticate fingerprint-sensitive sites (LinkedIn, banks, etc.) by hand inside the same Camoufox fingerprint that will later replay the session.

### Why

Cookie-injection login fails on sites with fingerprint-correlated session validation — cookies minted in Chrome, imported into Camoufox, get killed within minutes. The fix is to mint the cookies inside Camoufox itself via a real human login, then persist the resulting `storageState`. That needs two pieces:

1. A way for a human to interact with the headless browser → VNC.
2. A way to snapshot the resulting auth state → `GET /sessions/:userId/storage_state`.

Both are off-by-default and preserve existing behavior.

### Changes

**Docker (VNC stack, runtime-gated)**
- Install `x11vnc`, `novnc`, `python3-websockify`, `net-tools`, `procps`, `curl`.
- Patch `camoufox-js` VirtualDisplay default Xvfb resolution `1x1x24` → `1920x1080x24`. Fingerprint-neutral — resolution isn't in Camoufox's fingerprint surface — but `1x1` is useless for an interactive login.
- New `scripts/start.sh` entrypoint:
  - When `ENABLE_VNC=1`, spawns a watcher that finds the Xvfb Camoufox starts on a random free display and attaches `x11vnc` to that exact display. noVNC/`websockify` runs on `0.0.0.0:6080` as the HTTP proxy.
  - Works across browser restarts (re-attaches when the display number changes).
  - Optional `VNC_PASSWORD`, `VIEW_ONLY=1`.
- `EXPOSE 9377 6080`.

When `ENABLE_VNC` is unset (default) the watcher never starts — zero overhead.

**server.js**
- `GET /sessions/:userId/storage_state` returns the Playwright `storageState()` JSON (cookies + origins with localStorage).
- Same auth as `POST /sessions/:userId/cookies`: Bearer `CAMOFOX_API_KEY` in production, loopback allowed in non-production.

### Intended workflow

```bash
# Host
ENABLE_VNC=1 docker run -p 127.0.0.1:6080:6080 -p 9377:9377 camofox-browser

# Operator machine
ssh -L 6080:127.0.0.1:6080 host
# open http://localhost:6080/vnc.html, log into the target site

# Agent
curl -H "Authorization: Bearer $KEY" http://localhost:9377/sessions/agent1/storage_state > state.json
# later: re-inject cookies via POST /sessions/:userId/cookies
```

### Compatibility

- `ENABLE_VNC` defaults to off — no new ports listen, no new processes start, no behavior change for existing users.
- `storage_state` endpoint is behind the same auth gate as cookie import.
- Default CMD still ends up running `node server.js` in foreground (via `scripts/start.sh exec node ...`) so `docker stop` signal propagation is preserved.

### Tested

- Built image locally, ran with `ENABLE_VNC=1` + SSH tunnel.
- Logged into LinkedIn interactively via noVNC.
- Exported storage_state (34 cookies incl. `li_at` + `JSESSIONID`, 3 origins with localStorage).
- Re-injected cookies after container restart → LinkedIn authenticated successfully.
