### PR TITLE
feat: unified /type endpoint with keyboard mode (Ember/contenteditable support)

### DIFF
--- a/server.js
+++ b/server.js
@@ -2187,7 +2187,7 @@ app.post('/tabs/:tabId/type', async (req, res) => {
   const tabId = req.params.tabId;
   
   try {
-    const { userId, ref, selector, text } = req.body;
+    const { userId, ref, selector, text, mode = 'fill', delay = 30, submit = false, pressEnter = false } = req.body;
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, tabId);
     if (!found) return res.status(404).json({ error: 'Tab not found' });
@@ -2195,23 +2195,47 @@ app.post('/tabs/:tabId/type', async (req, res) => {
     const { tabState } = found;
     tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
     
-    if (!ref && !selector) {
-      return res.status(400).json({ error: 'ref or selector required' });
+    if (mode !== 'fill' && mode !== 'keyboard') {
+      return res.status(400).json({ error: "mode must be 'fill' or 'keyboard'" });
     }
+    if (typeof text !== 'string') {
+      return res.status(400).json({ error: 'text is required' });
+    }
+    // keyboard mode: ref/selector are optional (types into current focus)
+    if (mode === 'fill' && !ref && !selector) {
+      return res.status(400).json({ error: 'ref or selector required for mode=fill' });
+    }
+    const shouldSubmit = submit || pressEnter;
     
     await withTabLock(tabId, async () => {
+      // Resolve and focus the target if ref/selector provided
+      let locator = null;
       if (ref) {
-        let locator = refToLocator(tabState.page, ref, tabState.refs);
+        locator = refToLocator(tabState.page, ref, tabState.refs);
         if (!locator) {
-          log('info', 'auto-refreshing refs before fill', { ref, hadRefs: tabState.refs.size });
+          log('info', 'auto-refreshing refs before type', { ref, hadRefs: tabState.refs.size, mode });
           tabState.refs = await refreshTabRefs(tabState, { reason: 'type' });
           locator = refToLocator(tabState.page, ref, tabState.refs);
         }
         if (!locator) { const maxRef = tabState.refs.size > 0 ? `e${tabState.refs.size}` : 'none'; throw new StaleRefsError(ref, maxRef, tabState.refs.size); }
-        await locator.fill(text, { timeout: 10000 });
-      } else {
-        await tabState.page.fill(selector, text, { timeout: 10000 });
       }
+      
+      if (mode === 'fill') {
+        if (locator) {
+          await locator.fill(text, { timeout: 10000 });
+        } else {
+          await tabState.page.fill(selector, text, { timeout: 10000 });
+        }
+      } else {
+        // keyboard mode — char-by-char real key events (required for Ember/contenteditable)
+        if (locator) {
+          await locator.focus({ timeout: 10000 });
+        } else if (selector) {
+          await tabState.page.focus(selector, { timeout: 10000 });
+        }
+        await tabState.page.keyboard.type(text, { delay });
+      }
+      if (shouldSubmit) await tabState.page.keyboard.press('Enter');
     });
     
     res.json({ ok: true });
@@ -3053,28 +3077,43 @@ app.post('/act', async (req, res) => {
         }
         
         case 'type': {
-          const { ref, selector, text, submit } = params;
-          if (!ref && !selector) {
-            throw new Error('ref or selector required');
+          const { ref, selector, text, submit, mode = 'fill', delay = 30 } = params;
+          if (mode === 'fill' && !ref && !selector) {
+            throw new Error('ref or selector required for mode=fill');
           }
           if (typeof text !== 'string') {
             throw new Error('text is required');
           }
+          if (mode !== 'fill' && mode !== 'keyboard') {
+            throw new Error("mode must be 'fill' or 'keyboard'");
+          }
           
+          let locator = null;
           if (ref) {
-            let locator = refToLocator(tabState.page, ref, tabState.refs);
+            locator = refToLocator(tabState.page, ref, tabState.refs);
             if (!locator) {
-              log('info', 'auto-refreshing refs before type (openclaw)', { ref, hadRefs: tabState.refs.size });
+              log('info', 'auto-refreshing refs before type (openclaw)', { ref, hadRefs: tabState.refs.size, mode });
               tabState.refs = await buildRefs(tabState.page);
               locator = refToLocator(tabState.page, ref, tabState.refs);
             }
             if (!locator) { const maxRef = tabState.refs.size > 0 ? `e${tabState.refs.size}` : 'none'; throw new StaleRefsError(ref, maxRef, tabState.refs.size); }
-            await locator.fill(text, { timeout: 10000 });
-            if (submit) await tabState.page.keyboard.press('Enter');
-          } else {
-            await tabState.page.fill(selector, text, { timeout: 10000 });
-            if (submit) await tabState.page.keyboard.press('Enter');
           }
+          
+          if (mode === 'fill') {
+            if (locator) {
+              await locator.fill(text, { timeout: 10000 });
+            } else {
+              await tabState.page.fill(selector, text, { timeout: 10000 });
+            }
+          } else {
+            if (locator) {
+              await locator.focus({ timeout: 10000 });
+            } else if (selector) {
+              await tabState.page.focus(selector, { timeout: 10000 });
+            }
+            await tabState.page.keyboard.type(text, { delay });
+          }
+          if (submit) await tabState.page.keyboard.press('Enter');
           return { ok: true, targetId };
         }
         


### PR DESCRIPTION
## Summary

Extends `POST /tabs/:tabId/type` (and the openclaw `/act` `type` kind) with a `mode` parameter so the same endpoint handles both Playwright `fill()` and char-by-char keyboard typing. Needed for Ember/React contenteditable forms that reject DOM-mutation input.

### The problem

LinkedIn's DM compose form (`div.msg-form__contenteditable`) is Ember-managed and tracks message text via `beforeinput`/`InputEvent` provenance. Two failure modes when automating with the current `/type`:

1. `locator.fill()` sets text in the DOM but Ember does not register it as user input. No Send button appears. `keyboard.press("Enter")` is a no-op.
2. `document.execCommand("insertText", ...)` — text appears, the `is-active` class flips on, but still no Send button, and synthetic Enter events are ignored.

Only OS-level key events from char-by-char `page.keyboard.type()` satisfy Ember. This is a general pattern — same issue hits most React/Ember rich-text composers (Slack-style mention pickers, Notion-ish editors, etc.).

### API

```
POST /tabs/:tabId/type
{
  userId, ref?, selector?, text,
  mode?: "fill" | "keyboard",   // default "fill"
  delay?: number,               // ms/char in keyboard mode, default 30
  submit?: boolean,             // press Enter after typing, default false
  pressEnter?: boolean          // alias for submit
}
```

- `mode: "fill"` (default) — unchanged behavior: `locator.fill()` or `page.fill()`.
- `mode: "keyboard"` — focuses the target (if ref/selector given) then `page.keyboard.type(text, { delay })`. If neither ref nor selector is provided, types into whatever currently has focus.
- `submit`/`pressEnter` — presses Enter after typing inside the same lock. Saves a roundtrip for click-to-send flows and prevents races where the editor loses focus between calls.

Same additions applied to the openclaw `/act` `type` kind.

### Compatibility

- 100% back-compat. Callers not passing `mode` get identical behavior to before.
- Errors for bad inputs are explicit: `"mode must be 'fill' or 'keyboard'"`, `"ref or selector required for mode=fill"`, `"text is required"`.

### Tested

Smoke tests against Google (plain `<textarea>`):
- `mode:"fill"` (default) → text appears, matches.
- `mode:"keyboard"` with selector → text appears, matches.
- `mode:"keyboard"` with no selector, typing into focused element → text appended.
- `mode:"bogus"` → 400 error.
- `mode:"fill"` without ref/selector → 400 error.

End-to-end on LinkedIn DM compose:
```bash
curl -X POST http://localhost:9377/tabs/$TAB/type -d '{
  "userId":"agent1",
  "selector":"div.msg-form__contenteditable",
  "text":"Hey, sending via keyboard mode.",
  "mode":"keyboard",
  "submit":true
}'
```
Result: editor empties, message lands in thread, last `.msg-s-event-listitem` contains the text. `fill` mode on the same selector leaves the Send button absent.

### Alternatives considered

- **Separate `/keyboard_type` endpoint**: duplicates ref-resolution, auto-refresh, tab-lock, and error-handling plumbing. Rejected in favor of one endpoint with a mode flag.
- **Auto-detect contenteditable and switch modes**: brittle. Explicit `mode` keeps callers in control.
