### PR TITLE
feat: OpenAPI 3.0 spec at /openapi.json + HTML docs at /docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This project wraps that engine in a REST API built for agents: accessibility sna
 - **DOM Image Extraction** - list `<img>` src/alt and optionally return inline data URLs
 - **Deploy Anywhere** - Docker, Fly.io, Railway
 - **VNC Interactive Login** - log into sites visually via noVNC, export storage state for agent reuse
+- **OpenAPI Spec** - machine-readable API description at `/openapi.json`, rendered HTML viewer at `/docs`
 
 ## Optional Dependencies
 
@@ -80,6 +81,8 @@ npm start  # downloads Camoufox on first run (~300MB)
 ```
 
 Default port is `9377`. See [Environment Variables](#environment-variables) for all options.
+
+Once running, open `http://localhost:9377/docs` for interactive API docs, or fetch the raw spec at `http://localhost:9377/openapi.json`.
 
 ### Docker
 

--- a/lib/openapi-spec.js
+++ b/lib/openapi-spec.js
@@ -1,0 +1,518 @@
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
+
+const userIdQuery = { name: 'userId', in: 'query', required: true, schema: { type: 'string' }, description: 'Session owner identifier.' };
+const userIdBody = { type: 'string', description: 'Session owner identifier.' };
+const tabIdPath = { name: 'tabId', in: 'path', required: true, schema: { type: 'string' }, description: 'Tab identifier returned by POST /tabs.' };
+
+const errorResponse = { description: 'Error response.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } };
+const okResponse = { description: 'Success.', content: { 'application/json': { schema: { type: 'object', properties: { ok: { type: 'boolean', example: true } } } } } };
+
+export function buildOpenApiSpec() {
+  return {
+    openapi: '3.0.3',
+    info: {
+      title: 'camofox-browser',
+      version: pkg.version,
+      description: 'Anti-detection browser automation server for AI agents, powered by Camoufox. Accessibility snapshots, element refs, session isolation, cookie import, proxy + GeoIP, and structured logs.',
+      license: { name: 'MIT', url: 'https://opensource.org/licenses/MIT' },
+      contact: { name: 'Jo Inc', url: 'https://askjo.ai', email: 'oss@askjo.ai' },
+    },
+    servers: [
+      { url: 'http://localhost:9377', description: 'Local development' },
+    ],
+    tags: [
+      { name: 'System', description: 'Server health and metrics.' },
+      { name: 'Tabs', description: 'Create, inspect, and destroy browser tabs.' },
+      { name: 'Interaction', description: 'Click, type, scroll, and navigate within a tab.' },
+      { name: 'Content', description: 'Accessibility snapshots, screenshots, links, images.' },
+      { name: 'Sessions', description: 'Per-userId session state (cookies, teardown).' },
+      { name: 'Browser', description: 'Global browser lifecycle (start, stop, restart).' },
+      { name: 'Legacy', description: 'Pre-tabId endpoints kept for backward compatibility.' },
+    ],
+    components: {
+      securitySchemes: {
+        BearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          description: 'Bearer token matching CAMOFOX_API_KEY. Required for cookie import and other privileged operations.',
+        },
+      },
+      schemas: {
+        Error: { type: 'object', properties: { error: { type: 'string' } }, required: ['error'] },
+        Health: {
+          type: 'object',
+          properties: {
+            ok: { type: 'boolean' },
+            engine: { type: 'string', example: 'camoufox' },
+            browserConnected: { type: 'boolean' },
+            browserRunning: { type: 'boolean' },
+            activeTabs: { type: 'integer' },
+            activeSessions: { type: 'integer' },
+            consecutiveFailures: { type: 'integer' },
+          },
+        },
+        Tab: {
+          type: 'object',
+          properties: {
+            tabId: { type: 'string' },
+            url: { type: 'string' },
+            title: { type: 'string' },
+          },
+        },
+        TabCreate: {
+          type: 'object',
+          required: ['userId', 'sessionKey'],
+          properties: {
+            userId: userIdBody,
+            sessionKey: { type: 'string', description: 'Tab group identifier (alias: listItemId).' },
+            listItemId: { type: 'string', description: 'Legacy alias for sessionKey.' },
+            url: { type: 'string', description: 'Optional initial URL.' },
+          },
+        },
+        TabList: {
+          type: 'object',
+          properties: {
+            running: { type: 'boolean' },
+            tabs: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  tabId: { type: 'string' },
+                  targetId: { type: 'string' },
+                  url: { type: 'string' },
+                  title: { type: 'string' },
+                  listItemId: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+        Snapshot: {
+          type: 'object',
+          properties: {
+            url: { type: 'string' },
+            snapshot: { type: 'string', description: 'Accessibility tree with element refs e1, e2, ...' },
+            refsCount: { type: 'integer' },
+            totalChars: { type: 'integer' },
+            truncated: { type: 'boolean' },
+          },
+        },
+        Navigate: {
+          type: 'object',
+          required: ['userId'],
+          properties: {
+            userId: userIdBody,
+            url: { type: 'string' },
+            macro: { type: 'string', description: 'Search macro such as @google_search.' },
+            query: { type: 'string' },
+          },
+        },
+        Click: {
+          type: 'object',
+          required: ['userId'],
+          properties: {
+            userId: userIdBody,
+            ref: { type: 'string', description: 'Element ref from the latest snapshot (e.g. "e1").' },
+            selector: { type: 'string', description: 'CSS selector (alternative to ref).' },
+          },
+        },
+        Type: {
+          type: 'object',
+          required: ['userId', 'text'],
+          properties: {
+            userId: userIdBody,
+            ref: { type: 'string' },
+            selector: { type: 'string' },
+            text: { type: 'string' },
+            pressEnter: { type: 'boolean' },
+            mode: { type: 'string', enum: ['fill', 'keyboard'] },
+          },
+        },
+        Press: {
+          type: 'object',
+          required: ['userId', 'key'],
+          properties: {
+            userId: userIdBody,
+            key: { type: 'string', description: 'Playwright key name (e.g. Enter, Escape, Tab).' },
+          },
+        },
+        Scroll: {
+          type: 'object',
+          required: ['userId'],
+          properties: {
+            userId: userIdBody,
+            direction: { type: 'string', enum: ['up', 'down', 'top', 'bottom'] },
+            amount: { type: 'integer' },
+          },
+        },
+        Wait: {
+          type: 'object',
+          required: ['userId'],
+          properties: {
+            userId: userIdBody,
+            ms: { type: 'integer' },
+            selector: { type: 'string' },
+          },
+        },
+        Evaluate: {
+          type: 'object',
+          required: ['userId', 'expression'],
+          properties: {
+            userId: userIdBody,
+            expression: { type: 'string', description: 'JavaScript expression to evaluate in page context.' },
+          },
+        },
+        EvaluateResult: {
+          type: 'object',
+          properties: { ok: { type: 'boolean' }, result: {} },
+        },
+        Links: {
+          type: 'object',
+          properties: {
+            links: { type: 'array', items: { type: 'object', properties: { url: { type: 'string' }, text: { type: 'string' } } } },
+            pagination: {
+              type: 'object',
+              properties: {
+                total: { type: 'integer' }, offset: { type: 'integer' },
+                limit: { type: 'integer' }, hasMore: { type: 'boolean' },
+              },
+            },
+          },
+        },
+        Images: {
+          type: 'object',
+          properties: {
+            images: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  src: { type: 'string' }, alt: { type: 'string' },
+                  inline: { type: 'string', description: 'Optional base64 data URL.' },
+                },
+              },
+            },
+          },
+        },
+        Downloads: {
+          type: 'object',
+          properties: {
+            downloads: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string' }, filename: { type: 'string' },
+                  url: { type: 'string' }, sizeBytes: { type: 'integer' },
+                  inline: { type: 'string', description: 'Optional base64 content.' },
+                },
+              },
+            },
+          },
+        },
+        Stats: {
+          type: 'object',
+          properties: {
+            tabId: { type: 'string' }, sessionKey: { type: 'string' },
+            listItemId: { type: 'string' }, url: { type: 'string' },
+            visitedUrls: { type: 'array', items: { type: 'string' } },
+            downloadsCount: { type: 'integer' },
+            toolCalls: { type: 'integer' }, refsCount: { type: 'integer' },
+          },
+        },
+        CookieImport: {
+          type: 'object',
+          required: ['cookies'],
+          properties: {
+            cookies: {
+              type: 'array',
+              items: {
+                type: 'object',
+                required: ['name', 'value', 'domain', 'path'],
+                properties: {
+                  name: { type: 'string' }, value: { type: 'string' },
+                  domain: { type: 'string' }, path: { type: 'string' },
+                  expires: { type: 'number' }, httpOnly: { type: 'boolean' },
+                  secure: { type: 'boolean' }, sameSite: { type: 'string', enum: ['Strict', 'Lax', 'None'] },
+                },
+              },
+            },
+          },
+        },
+        CookieImportResult: {
+          type: 'object',
+          properties: { ok: { type: 'boolean' }, added: { type: 'integer' } },
+        },
+      },
+    },
+    paths: {
+      '/openapi.json': {
+        get: {
+          tags: ['System'],
+          summary: 'Machine-readable API description.',
+          description: 'OpenAPI 3.0 document covering every core server route. Plugin routes (e.g. /youtube/transcript, /sessions/:userId/storage_state) are not included here — they depend on which bundled plugins are enabled.',
+          responses: { 200: { description: 'OpenAPI document.', content: { 'application/json': { schema: { type: 'object' } } } } },
+        },
+      },
+      '/docs': {
+        get: {
+          tags: ['System'],
+          summary: 'Self-contained HTML API viewer (Redoc).',
+          description: 'Serves a minimal HTML page that renders /openapi.json using Redoc via CDN.',
+          responses: { 200: { description: 'HTML page.', content: { 'text/html': { schema: { type: 'string' } } } } },
+        },
+      },
+      '/': {
+        get: {
+          tags: ['System'],
+          summary: 'Server status ping.',
+          description: 'Lightweight status probe suitable for process supervisors.',
+          responses: { 200: { description: 'Running.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Health' } } } } },
+        },
+      },
+      '/health': {
+        get: {
+          tags: ['System'],
+          summary: 'Health check.',
+          description: 'Returns engine, browser connection state, and active session counts.',
+          responses: { 200: { description: 'Healthy.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Health' } } } } },
+        },
+      },
+      '/metrics': {
+        get: {
+          tags: ['System'],
+          summary: 'Prometheus metrics.',
+          description: 'Disabled unless PROMETHEUS_ENABLED=1 is set at startup.',
+          responses: {
+            200: { description: 'Prometheus exposition format.', content: { 'text/plain': { schema: { type: 'string' } } } },
+            404: errorResponse,
+          },
+        },
+      },
+      '/tabs': {
+        get: {
+          tags: ['Tabs'],
+          summary: 'List active tabs.',
+          parameters: [{ name: 'userId', in: 'query', required: false, schema: { type: 'string' } }],
+          responses: { 200: { description: 'Tab list.', content: { 'application/json': { schema: { $ref: '#/components/schemas/TabList' } } } } },
+        },
+        post: {
+          tags: ['Tabs'],
+          summary: 'Create a tab.',
+          description: 'Opens a new browser page for the given userId + sessionKey. Optional url navigates before returning.',
+          requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/TabCreate' } } } },
+          responses: {
+            200: { description: 'Tab created.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Tab' } } } },
+            400: errorResponse, 429: errorResponse,
+          },
+        },
+      },
+      '/tabs/open': {
+        post: {
+          tags: ['Tabs'],
+          summary: 'Alias for POST /tabs (OpenClaw format).',
+          requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/TabCreate' } } } },
+          responses: { 200: { description: 'Tab created.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Tab' } } } } },
+        },
+      },
+      '/tabs/{tabId}': {
+        delete: {
+          tags: ['Tabs'],
+          summary: 'Close a tab.',
+          parameters: [tabIdPath, userIdQuery],
+          responses: { 200: okResponse, 404: errorResponse },
+        },
+      },
+      '/tabs/group/{listItemId}': {
+        delete: {
+          tags: ['Tabs'],
+          summary: 'Close an entire tab group.',
+          parameters: [
+            { name: 'listItemId', in: 'path', required: true, schema: { type: 'string' } },
+            userIdQuery,
+          ],
+          responses: { 200: okResponse },
+        },
+      },
+      '/tabs/{tabId}/navigate': {
+        post: {
+          tags: ['Interaction'],
+          summary: 'Navigate the tab to a URL or macro.',
+          parameters: [tabIdPath],
+          requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/Navigate' } } } },
+          responses: {
+            200: { description: 'Navigated.', content: { 'application/json': { schema: { type: 'object', properties: { ok: { type: 'boolean' }, tabId: { type: 'string' }, url: { type: 'string' } } } } } },
+            400: errorResponse, 404: errorResponse,
+          },
+        },
+      },
+      '/tabs/{tabId}/snapshot': {
+        get: {
+          tags: ['Content'],
+          summary: 'Accessibility snapshot.',
+          description: 'Returns a token-efficient accessibility tree with stable e1/e2/e3 refs. Optional base64 screenshot via screenshot=1.',
+          parameters: [
+            tabIdPath, userIdQuery,
+            { name: 'offset', in: 'query', required: false, schema: { type: 'integer' } },
+            { name: 'limit', in: 'query', required: false, schema: { type: 'integer' } },
+            { name: 'screenshot', in: 'query', required: false, schema: { type: 'string', enum: ['0', '1'] } },
+          ],
+          responses: { 200: { description: 'Snapshot.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Snapshot' } } } } },
+        },
+      },
+      '/tabs/{tabId}/click': {
+        post: {
+          tags: ['Interaction'],
+          summary: 'Click an element by ref or selector.',
+          parameters: [tabIdPath],
+          requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/Click' } } } },
+          responses: { 200: okResponse, 400: errorResponse, 404: errorResponse },
+        },
+      },
+      '/tabs/{tabId}/type': {
+        post: {
+          tags: ['Interaction'],
+          summary: 'Type into a focused element.',
+          parameters: [tabIdPath],
+          requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/Type' } } } },
+          responses: { 200: okResponse, 400: errorResponse },
+        },
+      },
+      '/tabs/{tabId}/press': {
+        post: {
+          tags: ['Interaction'],
+          summary: 'Press a keyboard key.',
+          parameters: [tabIdPath],
+          requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/Press' } } } },
+          responses: { 200: okResponse },
+        },
+      },
+      '/tabs/{tabId}/scroll': {
+        post: {
+          tags: ['Interaction'],
+          summary: 'Scroll the page.',
+          parameters: [tabIdPath],
+          requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/Scroll' } } } },
+          responses: { 200: okResponse },
+        },
+      },
+      '/tabs/{tabId}/back': {
+        post: { tags: ['Interaction'], summary: 'Navigate back.', parameters: [tabIdPath],
+          requestBody: { required: true, content: { 'application/json': { schema: { type: 'object', required: ['userId'], properties: { userId: userIdBody } } } } },
+          responses: { 200: okResponse } },
+      },
+      '/tabs/{tabId}/forward': {
+        post: { tags: ['Interaction'], summary: 'Navigate forward.', parameters: [tabIdPath],
+          requestBody: { required: true, content: { 'application/json': { schema: { type: 'object', required: ['userId'], properties: { userId: userIdBody } } } } },
+          responses: { 200: okResponse } },
+      },
+      '/tabs/{tabId}/refresh': {
+        post: { tags: ['Interaction'], summary: 'Refresh the page.', parameters: [tabIdPath],
+          requestBody: { required: true, content: { 'application/json': { schema: { type: 'object', required: ['userId'], properties: { userId: userIdBody } } } } },
+          responses: { 200: okResponse } },
+      },
+      '/tabs/{tabId}/wait': {
+        post: { tags: ['Interaction'], summary: 'Wait for a duration or selector.', parameters: [tabIdPath],
+          requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/Wait' } } } },
+          responses: { 200: okResponse } },
+      },
+      '/tabs/{tabId}/links': {
+        get: { tags: ['Content'], summary: 'Paginated list of links on the page.',
+          parameters: [
+            tabIdPath, userIdQuery,
+            { name: 'limit', in: 'query', required: false, schema: { type: 'integer' } },
+            { name: 'offset', in: 'query', required: false, schema: { type: 'integer' } },
+          ],
+          responses: { 200: { description: 'Links.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Links' } } } } } },
+      },
+      '/tabs/{tabId}/images': {
+        get: { tags: ['Content'], summary: 'List <img> elements with optional inlined data URLs.',
+          parameters: [
+            tabIdPath, userIdQuery,
+            { name: 'inline', in: 'query', required: false, schema: { type: 'string', enum: ['0', '1'] } },
+          ],
+          responses: { 200: { description: 'Images.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Images' } } } } } },
+      },
+      '/tabs/{tabId}/downloads': {
+        get: { tags: ['Content'], summary: 'List captured downloads for a tab.',
+          parameters: [
+            tabIdPath, userIdQuery,
+            { name: 'inline', in: 'query', required: false, schema: { type: 'string', enum: ['0', '1'] } },
+          ],
+          responses: { 200: { description: 'Downloads.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Downloads' } } } } } },
+      },
+      '/tabs/{tabId}/screenshot': {
+        get: { tags: ['Content'], summary: 'Full-viewport PNG screenshot.',
+          parameters: [tabIdPath, userIdQuery],
+          responses: { 200: { description: 'PNG bytes.', content: { 'image/png': { schema: { type: 'string', format: 'binary' } } } }, 404: errorResponse } },
+      },
+      '/tabs/{tabId}/stats': {
+        get: { tags: ['Tabs'], summary: 'Per-tab operational stats.',
+          parameters: [tabIdPath, userIdQuery],
+          responses: { 200: { description: 'Stats.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Stats' } } } } } },
+      },
+      '/tabs/{tabId}/evaluate': {
+        post: { tags: ['Interaction'], summary: 'Evaluate a JavaScript expression in page context.',
+          parameters: [tabIdPath],
+          requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/Evaluate' } } } },
+          responses: { 200: { description: 'Evaluation result.', content: { 'application/json': { schema: { $ref: '#/components/schemas/EvaluateResult' } } } } } },
+      },
+      '/sessions/{userId}/cookies': {
+        post: {
+          tags: ['Sessions'],
+          summary: 'Import cookies into the session.',
+          description: 'Requires CAMOFOX_API_KEY to be set server-side and passed as Bearer token. Max 500 cookies, 5MB per request.',
+          security: [{ BearerAuth: [] }],
+          parameters: [{ name: 'userId', in: 'path', required: true, schema: { type: 'string' } }],
+          requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/CookieImport' } } } },
+          responses: {
+            200: { description: 'Cookies imported.', content: { 'application/json': { schema: { $ref: '#/components/schemas/CookieImportResult' } } } },
+            400: errorResponse, 403: errorResponse, 413: errorResponse,
+          },
+        },
+      },
+      '/sessions/{userId}': {
+        delete: {
+          tags: ['Sessions'],
+          summary: 'Destroy the session and free all tabs.',
+          parameters: [{ name: 'userId', in: 'path', required: true, schema: { type: 'string' } }],
+          responses: { 200: okResponse },
+        },
+      },
+      '/start': {
+        post: { tags: ['Browser'], summary: 'Start the browser eagerly (bypass lazy launch).',
+          responses: { 200: okResponse } },
+      },
+      '/stop': {
+        post: { tags: ['Browser'], summary: 'Stop the browser and close all sessions.',
+          description: 'Requires CAMOFOX_ADMIN_KEY when set.',
+          security: [{ BearerAuth: [] }],
+          responses: { 200: okResponse, 403: errorResponse } },
+      },
+      '/navigate': {
+        post: { tags: ['Legacy'], summary: 'Navigate the default tab (legacy).',
+          description: 'Kept for backward compatibility with the pre-tabId API. Prefer POST /tabs/:tabId/navigate.',
+          requestBody: { required: false, content: { 'application/json': { schema: { $ref: '#/components/schemas/Navigate' } } } },
+          responses: { 200: okResponse } },
+      },
+      '/snapshot': {
+        get: { tags: ['Legacy'], summary: 'Snapshot the default tab (legacy).',
+          description: 'Kept for backward compatibility. Prefer GET /tabs/:tabId/snapshot.',
+          responses: { 200: { description: 'Snapshot.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Snapshot' } } } } } },
+      },
+      '/act': {
+        post: { tags: ['Legacy'], summary: 'Act on the default tab (legacy combined intent).',
+          description: 'Kept for backward compatibility. Prefer atomic /tabs/:tabId/* endpoints.',
+          responses: { 200: okResponse } },
+      },
+    },
+  };
+}
+
+export const openApiSpec = buildOpenApiSpec();

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ import {
   getDownloadsList,
 } from './lib/downloads.js';
 import { extractPageImages } from './lib/images.js';
+import { openApiSpec } from './lib/openapi-spec.js';
 
 import {
   initMetrics, getRegister, isMetricsEnabled, createMetric,
@@ -2603,6 +2604,30 @@ setInterval(() => {
 // OpenClaw-compatible endpoint aliases
 // These allow camoufox to be used as a profile backend for OpenClaw's browser tool
 // =============================================================================
+
+// GET /openapi.json - Machine-readable API description
+app.get('/openapi.json', (_req, res) => {
+  res.json(openApiSpec);
+});
+
+// GET /docs - HTML viewer for the OpenAPI spec (Redoc via CDN)
+const REDOC_HTML = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>camofox-browser API</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+  <style>body { margin: 0; padding: 0; }</style>
+</head>
+<body>
+  <redoc spec-url="/openapi.json"></redoc>
+  <script src="https://cdn.redocly.com/redoc/latest/bundles/redoc.standalone.js"></script>
+</body>
+</html>`;
+app.get('/docs', (_req, res) => {
+  res.type('html').send(REDOC_HTML);
+});
 
 // GET / - Status (passive — does not launch browser)
 app.get('/', (req, res) => {

--- a/tests/unit/openapi-spec.test.js
+++ b/tests/unit/openapi-spec.test.js
@@ -1,0 +1,89 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { openApiSpec, buildOpenApiSpec } from '../../lib/openapi-spec.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverPath = path.join(__dirname, '..', '..', 'server.js');
+
+function collectServerRoutes() {
+  const source = fs.readFileSync(serverPath, 'utf8');
+  const routeRe = /^app\.(get|post|put|delete|patch)\(['"]([^'"]+)['"]/gm;
+  const routes = new Set();
+  let match;
+  while ((match = routeRe.exec(source)) !== null) {
+    const method = match[1].toUpperCase();
+    const routePath = match[2].replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, '{$1}');
+    routes.add(`${method} ${routePath}`);
+  }
+  return routes;
+}
+
+function collectSpecRoutes() {
+  const routes = new Set();
+  for (const [routePath, methods] of Object.entries(openApiSpec.paths)) {
+    for (const method of Object.keys(methods)) {
+      routes.add(`${method.toUpperCase()} ${routePath}`);
+    }
+  }
+  return routes;
+}
+
+describe('openapi-spec', () => {
+  test('every server.js route appears in the spec', () => {
+    const serverRoutes = collectServerRoutes();
+    const specRoutes = collectSpecRoutes();
+    const missing = [...serverRoutes].filter(r => !specRoutes.has(r));
+    expect({ missingFromSpec: missing }).toEqual({ missingFromSpec: [] });
+  });
+
+  test('no stale routes in the spec that are not in server.js', () => {
+    const serverRoutes = collectServerRoutes();
+    const specRoutes = collectSpecRoutes();
+    const stale = [...specRoutes].filter(r => !serverRoutes.has(r));
+    expect({ staleInSpec: stale }).toEqual({ staleInSpec: [] });
+  });
+
+  test('spec version reads from package.json', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'package.json'), 'utf8'));
+    expect(openApiSpec.info.version).toBe(pkg.version);
+  });
+
+  test('spec is a valid OpenAPI 3.0.x object shape', () => {
+    expect(openApiSpec.openapi).toMatch(/^3\.0\./);
+    expect(openApiSpec.info.title).toBe('camofox-browser');
+    expect(openApiSpec.servers.length).toBeGreaterThan(0);
+    expect(Object.keys(openApiSpec.paths).length).toBeGreaterThan(20);
+    expect(openApiSpec.components.schemas.Error).toBeDefined();
+    expect(openApiSpec.components.securitySchemes.BearerAuth.scheme).toBe('bearer');
+  });
+
+  test('buildOpenApiSpec is pure (returns equivalent object each call)', () => {
+    const a = buildOpenApiSpec();
+    const b = buildOpenApiSpec();
+    expect(a).toEqual(b);
+  });
+
+  test('every path operation has at least one response', () => {
+    for (const [routePath, methods] of Object.entries(openApiSpec.paths)) {
+      for (const [method, op] of Object.entries(methods)) {
+        expect({ routePath, method, hasResponses: Object.keys(op.responses || {}).length > 0 })
+          .toEqual({ routePath, method, hasResponses: true });
+      }
+    }
+  });
+
+  test('every request body $ref points to a defined schema', () => {
+    const schemas = openApiSpec.components.schemas;
+    for (const [routePath, methods] of Object.entries(openApiSpec.paths)) {
+      for (const [method, op] of Object.entries(methods)) {
+        const content = op.requestBody?.content?.['application/json']?.schema;
+        if (content?.$ref) {
+          const refName = content.$ref.replace('#/components/schemas/', '');
+          expect({ routePath, method, refName, defined: refName in schemas })
+            .toEqual({ routePath, method, refName, defined: true });
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Exposes a hand-written OpenAPI 3.0 document at `GET /openapi.json` and a Redoc-rendered HTML viewer at `GET /docs`. The spec documents every core route in `server.js` (32 endpoints after this lands, up from 30 before). No new runtime dependencies, no behavior change for any existing endpoint.

## Demo

https://github.com/mvanhorn/camofox-browser/releases/download/evidence-openapi/evidence-video.mp4

<img src="https://github.com/mvanhorn/camofox-browser/releases/download/evidence-openapi/evidence-terminal.png" alt="OpenAPI spec at /openapi.json" width="820" />

## Why

The project has 31 REST endpoints on master but nothing machine-readable describes them. The `/` endpoint returns a four-field health blob. The only way to discover routes today is to read `server.js` line by line (I used `grep -nE "app\.(get|post|put|delete)\(" server.js` and got 30+ matches across ~2900 lines).

Steel Browser ships the same pattern at `/documentation` and their Python and Node SDKs are generated directly from that spec. Once this lands, anyone can produce SDKs for Python, Ruby, Go, and anything else, and tooling like Postman, MCP bridges, or OpenAI function-calling integrations can consume the spec directly.

## What's here

- `lib/openapi-spec.js` (~520 lines) - A single exported OpenAPI 3.0.3 object. Metadata, tags, security schemes, 20 reusable component schemas, 32 paths with parameters / requestBodies / responses.
- `server.js` (+25 lines) - Two route handlers right above the existing `GET /` handler. `REDOC_HTML` is a 13-line string that loads Redoc via CDN.
- `tests/unit/openapi-spec.test.js` (~90 lines) - The load-bearing piece. See "Drift detection" below.
- `README.md` (+3 lines) - One Features bullet + one Quick Start line pointing at `/docs`.

## Drift detection

The hand-written spec is only useful if it stays accurate. Two tests (`every server.js route appears in the spec` and `no stale routes in the spec that are not in server.js`) parse `server.js` with a regex for `app.<method>(<path>)` and cross-reference against `openApiSpec.paths`. They fail if:

- A new server.js route is added without documenting it
- A route is removed but still in the spec
- A path operation has no responses
- A request body `$ref` points to an undefined schema

Five other tests verify spec validity: OpenAPI 3.0.x shape, `info.version` matches `package.json`, the builder is pure, every operation has responses, every `$ref` resolves.

```
$ NODE_OPTIONS='--experimental-vm-modules' npx jest --runInBand --forceExit tests/unit
Test Suites: 20 passed, 20 total
Tests:       259 passed, 259 total
```

## Notes for reviewers

- **Plugin-contributed routes are not in the spec.** The `youtube` plugin adds `/youtube/transcript`, the `vnc` plugin adds `/sessions/:userId/storage_state`. Those depend on which bundled plugins are enabled at runtime, so the core spec stays deterministic. A follow-up PR could have plugins contribute to the spec at registration time.
- **No new runtime deps.** Redoc is served from `cdn.redocly.com` in the HTML. If you'd rather self-host (which would matter for air-gapped deploys), happy to switch to inlining the ~200KB bundle or vendoring it.
- **Tags are organised for Redoc's sidebar:** System, Tabs, Interaction, Content, Sessions, Browser, Legacy. The `Legacy` bucket holds the pre-tabId `/act`, `/start`, `/stop`, `/navigate`, `/snapshot` endpoints so their backward-compat status is visible in the docs.
- **Security schemes** declare `BearerAuth` matching `CAMOFOX_API_KEY`. Currently only `/sessions/:userId/cookies` and `/stop` use it; the rest are unauthenticated, matching current server behavior.

Dogfooded locally: ran `PORT=9378 node server.js`, hit `/openapi.json`, fed it through `jq '.paths | keys'` to confirm all 32 routes listed, opened `/docs` in a browser to verify Redoc rendered correctly.

