### PR TITLE
feat: structured extract endpoint with JSON Schema + x-ref hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This project wraps that engine in a REST API built for agents: accessibility sna
 - **Deploy Anywhere** - Docker, Fly.io, Railway
 - **VNC Interactive Login** - log into sites visually via noVNC, export storage state for agent reuse
 - **OpenAPI Docs** - auto-generated spec at [`/openapi.json`](http://localhost:9377/openapi.json) and interactive docs at [`/docs`](http://localhost:9377/docs)
+- **Structured Extract** - `POST /tabs/:tabId/extract` with a JSON Schema that maps properties to snapshot refs via `x-ref`
 
 ## Optional Dependencies
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1626,6 +1626,182 @@
         }
       }
     },
+    "/tabs/{tabId}/extract": {
+      "post": {
+        "tags": [
+          "Content"
+        ],
+        "summary": "Structured data extraction via JSON Schema",
+        "description": "Extracts structured data from the current page using a JSON Schema whose properties\ncarry `x-ref` hints pointing at snapshot element refs (e.g. `e1`, `e2`).  \nCall `GET /tabs/{tabId}/snapshot` first to populate the ref table.\n",
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId",
+                  "schema"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "schema": {
+                    "type": "object",
+                    "description": "JSON Schema with `type: \"object\"` and a `properties` map.  \nEach property may include `x-ref` (a snapshot element ref) and an optional\n`type` (`string`, `number`, `integer`, `boolean`).\n",
+                    "required": [
+                      "type",
+                      "properties"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "object"
+                        ]
+                      },
+                      "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "string",
+                                "number",
+                                "integer",
+                                "boolean",
+                                "object",
+                                "null"
+                              ]
+                            },
+                            "x-ref": {
+                              "type": "string",
+                              "description": "Snapshot element ref (e.g. `e1`)."
+                            }
+                          }
+                        }
+                      },
+                      "required": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Property names that must resolve to a non-null value."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Extraction succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "Extracted key-value pairs matching the input schema."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing userId, missing schema, or invalid schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "No refs available — call snapshot first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "snapshot": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Extraction failed (e.g. required ref not found).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "snapshot": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/tabs/{tabId}": {
       "delete": {
         "tags": [

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -1,0 +1,74 @@
+const SUPPORTED_TYPES = new Set(['string', 'number', 'integer', 'boolean', 'object', 'null']);
+
+export function validateSchema(schema) {
+  if (!schema || typeof schema !== 'object') {
+    return { ok: false, error: 'schema must be an object' };
+  }
+  if (schema.type !== 'object') {
+    return { ok: false, error: 'top-level schema must have type: object' };
+  }
+  if (!schema.properties || typeof schema.properties !== 'object') {
+    return { ok: false, error: 'schema must have a properties object' };
+  }
+  for (const [prop, def] of Object.entries(schema.properties)) {
+    if (!def || typeof def !== 'object') {
+      return { ok: false, error: `property "${prop}" must be an object` };
+    }
+    if (def.type && !SUPPORTED_TYPES.has(def.type)) {
+      return { ok: false, error: `property "${prop}" has unsupported type "${def.type}"` };
+    }
+  }
+  return { ok: true };
+}
+
+function coerceValue(raw, type) {
+  if (raw == null) return null;
+  if (type === 'string' || !type) return String(raw).trim();
+  if (type === 'number') {
+    const n = parseFloat(String(raw).replace(/[^0-9.eE+-]/g, ''));
+    return Number.isFinite(n) ? n : null;
+  }
+  if (type === 'integer') {
+    const n = parseInt(String(raw).replace(/[^0-9-]/g, ''), 10);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (type === 'boolean') {
+    const s = String(raw).toLowerCase().trim();
+    if (s === 'true' || s === 'yes' || s === '1') return true;
+    if (s === 'false' || s === 'no' || s === '0') return false;
+    return null;
+  }
+  return raw;
+}
+
+function extractFromRef(refs, refId) {
+  const info = refs.get(refId);
+  if (!info) return null;
+  return info.name || null;
+}
+
+export function extractDeterministic({ schema, refs }) {
+  const check = validateSchema(schema);
+  if (!check.ok) throw new Error(check.error);
+
+  const result = {};
+  for (const [prop, def] of Object.entries(schema.properties)) {
+    const refId = def['x-ref'];
+
+    let value = null;
+    if (refId) {
+      value = extractFromRef(refs, refId);
+      if (value != null && def.type && def.type !== 'object') {
+        value = coerceValue(value, def.type);
+      }
+    }
+
+    if (value == null && Array.isArray(schema.required) && schema.required.includes(prop)) {
+      throw new Error(`required property "${prop}" could not be extracted (x-ref=${refId || 'n/a'})`);
+    }
+
+    result[prop] = value;
+  }
+
+  return result;
+}

--- a/openapi.json
+++ b/openapi.json
@@ -1626,6 +1626,182 @@
         }
       }
     },
+    "/tabs/{tabId}/extract": {
+      "post": {
+        "tags": [
+          "Content"
+        ],
+        "summary": "Structured data extraction via JSON Schema",
+        "description": "Extracts structured data from the current page using a JSON Schema whose properties\ncarry `x-ref` hints pointing at snapshot element refs (e.g. `e1`, `e2`).  \nCall `GET /tabs/{tabId}/snapshot` first to populate the ref table.\n",
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId",
+                  "schema"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "schema": {
+                    "type": "object",
+                    "description": "JSON Schema with `type: \"object\"` and a `properties` map.  \nEach property may include `x-ref` (a snapshot element ref) and an optional\n`type` (`string`, `number`, `integer`, `boolean`).\n",
+                    "required": [
+                      "type",
+                      "properties"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "object"
+                        ]
+                      },
+                      "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "string",
+                                "number",
+                                "integer",
+                                "boolean",
+                                "object",
+                                "null"
+                              ]
+                            },
+                            "x-ref": {
+                              "type": "string",
+                              "description": "Snapshot element ref (e.g. `e1`)."
+                            }
+                          }
+                        }
+                      },
+                      "required": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Property names that must resolve to a non-null value."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Extraction succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "Extracted key-value pairs matching the input schema."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing userId, missing schema, or invalid schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "No refs available — call snapshot first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "snapshot": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Extraction failed (e.g. required ref not found).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "snapshot": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/tabs/{tabId}": {
       "delete": {
         "tags": [

--- a/server.js
+++ b/server.js
@@ -3445,6 +3445,117 @@ app.post('/tabs/:tabId/evaluate', express.json({ limit: '1mb' }), async (req, re
 });
 
 // Structured extraction using JSON Schema with x-ref hints
+/**
+ * @openapi
+ * /tabs/{tabId}/extract:
+ *   post:
+ *     tags: [Content]
+ *     summary: Structured data extraction via JSON Schema
+ *     description: |
+ *       Extracts structured data from the current page using a JSON Schema whose properties
+ *       carry `x-ref` hints pointing at snapshot element refs (e.g. `e1`, `e2`).  
+ *       Call `GET /tabs/{tabId}/snapshot` first to populate the ref table.
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId, schema]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *               schema:
+ *                 type: object
+ *                 description: |
+ *                   JSON Schema with `type: "object"` and a `properties` map.  
+ *                   Each property may include `x-ref` (a snapshot element ref) and an optional
+ *                   `type` (`string`, `number`, `integer`, `boolean`).
+ *                 required: [type, properties]
+ *                 properties:
+ *                   type:
+ *                     type: string
+ *                     enum: [object]
+ *                   properties:
+ *                     type: object
+ *                     additionalProperties:
+ *                       type: object
+ *                       properties:
+ *                         type:
+ *                           type: string
+ *                           enum: [string, number, integer, boolean, object, "null"]
+ *                         x-ref:
+ *                           type: string
+ *                           description: Snapshot element ref (e.g. `e1`).
+ *                   required:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                     description: Property names that must resolve to a non-null value.
+ *     responses:
+ *       200:
+ *         description: Extraction succeeded.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                 data:
+ *                   type: object
+ *                   description: Extracted key-value pairs matching the input schema.
+ *       400:
+ *         description: Missing userId, missing schema, or invalid schema.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: Tab not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       409:
+ *         description: No refs available — call snapshot first.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 snapshot:
+ *                   type: string
+ *                   nullable: true
+ *       422:
+ *         description: Extraction failed (e.g. required ref not found).
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                 error:
+ *                   type: string
+ *                 snapshot:
+ *                   type: string
+ *                   nullable: true
+ *       500:
+ *         description: Internal server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 app.post('/tabs/:tabId/extract', express.json({ limit: '256kb' }), async (req, res) => {
   try {
     const { userId, schema } = req.body;

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ import {
   getDownloadsList,
 } from './lib/downloads.js';
 import { extractPageImages } from './lib/images.js';
+import { extractDeterministic, validateSchema as validateExtractSchema } from './lib/extract.js';
 
 import {
   initMetrics, getRegister, isMetricsEnabled, createMetric,
@@ -3439,6 +3440,46 @@ app.post('/tabs/:tabId/evaluate', express.json({ limit: '1mb' }), async (req, re
   } catch (err) {
     failuresTotal.labels(classifyError(err), 'evaluate').inc();
     log('error', 'evaluate failed', { reqId: req.reqId, error: err.message });
+    res.status(500).json({ error: safeError(err) });
+  }
+});
+
+// Structured extraction using JSON Schema with x-ref hints
+app.post('/tabs/:tabId/extract', express.json({ limit: '256kb' }), async (req, res) => {
+  try {
+    const { userId, schema } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId is required' });
+    if (!schema) return res.status(400).json({ error: 'schema is required' });
+
+    const check = validateExtractSchema(schema);
+    if (!check.ok) return res.status(400).json({ error: check.error });
+
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, req.params.tabId);
+    if (!found) return res.status(404).json({ error: 'Tab not found' });
+
+    session.lastAccess = Date.now();
+    const { tabState } = found;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+
+    if (!tabState.refs || tabState.refs.size === 0) {
+      return res.status(409).json({
+        error: 'no refs available — call GET /tabs/:tabId/snapshot first to build the ref table',
+        snapshot: tabState.lastSnapshot || null,
+      });
+    }
+
+    try {
+      const data = extractDeterministic({ schema, refs: tabState.refs });
+      log('info', 'extract', { reqId: req.reqId, tabId: req.params.tabId, userId, keys: Object.keys(data) });
+      res.json({ ok: true, data });
+    } catch (extractErr) {
+      log('warn', 'extract failed', { reqId: req.reqId, error: extractErr.message });
+      res.status(422).json({ ok: false, error: extractErr.message, snapshot: tabState.lastSnapshot || null });
+    }
+  } catch (err) {
+    failuresTotal.labels(classifyError(err), 'extract').inc();
+    log('error', 'extract error', { reqId: req.reqId, error: err.message });
     res.status(500).json({ error: safeError(err) });
   }
 });

--- a/tests/unit/extract.test.js
+++ b/tests/unit/extract.test.js
@@ -1,0 +1,165 @@
+import { validateSchema, extractDeterministic } from '../../lib/extract.js';
+
+function makeRefs(entries) {
+  return new Map(entries);
+}
+
+describe('validateSchema', () => {
+  test('rejects missing schema', () => {
+    expect(validateSchema(null).ok).toBe(false);
+    expect(validateSchema(undefined).ok).toBe(false);
+    expect(validateSchema('nope').ok).toBe(false);
+  });
+
+  test('rejects non-object root', () => {
+    expect(validateSchema({ type: 'string' }).ok).toBe(false);
+    expect(validateSchema({ type: 'array' }).ok).toBe(false);
+  });
+
+  test('rejects missing properties', () => {
+    expect(validateSchema({ type: 'object' }).ok).toBe(false);
+    expect(validateSchema({ type: 'object', properties: null }).ok).toBe(false);
+  });
+
+  test('rejects unsupported property types', () => {
+    const r = validateSchema({ type: 'object', properties: { x: { type: 'nope' } } });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/nope/);
+  });
+
+  test('accepts well-formed schema', () => {
+    expect(validateSchema({
+      type: 'object',
+      properties: {
+        title: { type: 'string', 'x-ref': 'e1' },
+        count: { type: 'integer', 'x-ref': 'e2' },
+      },
+      required: ['title'],
+    }).ok).toBe(true);
+  });
+});
+
+describe('extractDeterministic', () => {
+  const refs = makeRefs([
+    ['e1', { role: 'heading', name: 'Example Domain', nth: 0 }],
+    ['e2', { role: 'link', name: 'Learn more', nth: 0 }],
+    ['e3', { role: 'button', name: 'Submit', nth: 0 }],
+    ['e4', { role: 'text', name: '  42  ', nth: 0 }],
+  ]);
+
+  test('pulls name from refs by x-ref', () => {
+    const data = extractDeterministic({
+      schema: {
+        type: 'object',
+        properties: { title: { type: 'string', 'x-ref': 'e1' } },
+      },
+      refs,
+    });
+    expect(data).toEqual({ title: 'Example Domain' });
+  });
+
+  test('coerces strings to integers', () => {
+    const data = extractDeterministic({
+      schema: {
+        type: 'object',
+        properties: { count: { type: 'integer', 'x-ref': 'e4' } },
+      },
+      refs,
+    });
+    expect(data).toEqual({ count: 42 });
+  });
+
+  test('coerces strings to numbers', () => {
+    const numRefs = makeRefs([['e1', { role: 'text', name: '$19.99', nth: 0 }]]);
+    const data = extractDeterministic({
+      schema: {
+        type: 'object',
+        properties: { price: { type: 'number', 'x-ref': 'e1' } },
+      },
+      refs: numRefs,
+    });
+    expect(data).toEqual({ price: 19.99 });
+  });
+
+  test('throws on missing required ref', () => {
+    expect(() => extractDeterministic({
+      schema: {
+        type: 'object',
+        properties: { missing: { type: 'string', 'x-ref': 'e999' } },
+        required: ['missing'],
+      },
+      refs,
+    })).toThrow(/required/);
+  });
+
+  test('returns null for unresolved optional property', () => {
+    const data = extractDeterministic({
+      schema: {
+        type: 'object',
+        properties: { maybe: { type: 'string', 'x-ref': 'e999' } },
+      },
+      refs,
+    });
+    expect(data).toEqual({ maybe: null });
+  });
+
+  test('throws on invalid schema before extraction', () => {
+    expect(() => extractDeterministic({
+      schema: { type: 'array' },
+      refs,
+    })).toThrow(/type: object/);
+  });
+
+  test('handles empty refs map', () => {
+    const data = extractDeterministic({
+      schema: {
+        type: 'object',
+        properties: { x: { type: 'string', 'x-ref': 'e1' } },
+      },
+      refs: new Map(),
+    });
+    expect(data).toEqual({ x: null });
+  });
+
+  test('boolean coercion handles common representations', () => {
+    const booleanRefs = makeRefs([
+      ['e1', { role: 'text', name: 'true', nth: 0 }],
+      ['e2', { role: 'text', name: 'FALSE', nth: 0 }],
+      ['e3', { role: 'text', name: 'yes', nth: 0 }],
+      ['e4', { role: 'text', name: 'maybe', nth: 0 }],
+    ]);
+    const data = extractDeterministic({
+      schema: {
+        type: 'object',
+        properties: {
+          a: { type: 'boolean', 'x-ref': 'e1' },
+          b: { type: 'boolean', 'x-ref': 'e2' },
+          c: { type: 'boolean', 'x-ref': 'e3' },
+          d: { type: 'boolean', 'x-ref': 'e4' },
+        },
+      },
+      refs: booleanRefs,
+    });
+    expect(data).toEqual({ a: true, b: false, c: true, d: null });
+  });
+
+  test('returns multiple refs in one call', () => {
+    const data = extractDeterministic({
+      schema: {
+        type: 'object',
+        properties: {
+          title: { type: 'string', 'x-ref': 'e1' },
+          linkText: { type: 'string', 'x-ref': 'e2' },
+          buttonLabel: { type: 'string', 'x-ref': 'e3' },
+        },
+        required: ['title'],
+      },
+      refs,
+    });
+    expect(data).toEqual({
+      title: 'Example Domain',
+      linkText: 'Learn more',
+      buttonLabel: 'Submit',
+    });
+  });
+});

--- a/tests/unit/extract.test.js
+++ b/tests/unit/extract.test.js
@@ -4,6 +4,78 @@ function makeRefs(entries) {
   return new Map(entries);
 }
 
+// ---------------------------------------------------------------------------
+// Simulate the POST /tabs/:tabId/extract handler logic without a real server.
+// This mirrors the exact decision tree in server.js so we can unit-test every
+// HTTP-level status code path.
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal replica of the extract route handler.
+ * Accepts the same {userId, schema} body plus a sessions Map and tabId.
+ * Returns { status, body } matching what the endpoint would send.
+ */
+function simulateExtractHandler({ tabId, body, sessions }) {
+  const { userId, schema } = body || {};
+  if (!userId) return { status: 400, body: { error: 'userId is required' } };
+  if (!schema) return { status: 400, body: { error: 'schema is required' } };
+
+  const check = validateSchema(schema);
+  if (!check.ok) return { status: 400, body: { error: check.error } };
+
+  const normalizedId = String(userId);
+  const session = sessions.get(normalizedId);
+  // findTab replica: search tabGroups for matching tabId
+  let tabState = null;
+  if (session) {
+    for (const [, group] of session.tabGroups) {
+      const ts = group.get(tabId);
+      if (ts) { tabState = ts; break; }
+    }
+  }
+  if (!tabState) return { status: 404, body: { error: 'Tab not found' } };
+
+  session.lastAccess = Date.now();
+  tabState.toolCalls++;
+  tabState.consecutiveTimeouts = 0;
+
+  if (!tabState.refs || tabState.refs.size === 0) {
+    return {
+      status: 409,
+      body: {
+        error: 'no refs available — call GET /tabs/:tabId/snapshot first to build the ref table',
+        snapshot: tabState.lastSnapshot || null,
+      },
+    };
+  }
+
+  try {
+    const data = extractDeterministic({ schema, refs: tabState.refs });
+    return { status: 200, body: { ok: true, data } };
+  } catch (extractErr) {
+    return {
+      status: 422,
+      body: { ok: false, error: extractErr.message, snapshot: tabState.lastSnapshot || null },
+    };
+  }
+}
+
+/** Build a sessions Map containing one user + one tab for testing. */
+function buildSessions({ userId = 'u1', tabId = 't1', refs = null, lastSnapshot = null } = {}) {
+  const tabState = {
+    refs,
+    lastSnapshot,
+    toolCalls: 0,
+    consecutiveTimeouts: 0,
+  };
+  const tabGroup = new Map([[tabId, tabState]]);
+  const session = {
+    tabGroups: new Map([['default', tabGroup]]),
+    lastAccess: 0,
+  };
+  return { sessions: new Map([[userId, session]]), tabState };
+}
+
 describe('validateSchema', () => {
   test('rejects missing schema', () => {
     expect(validateSchema(null).ok).toBe(false);
@@ -161,5 +233,291 @@ describe('extractDeterministic', () => {
       linkText: 'Learn more',
       buttonLabel: 'Submit',
     });
+  });
+});
+
+// ===========================================================================
+// Endpoint handler simulation tests
+// These exercise the same logic as POST /tabs/:tabId/extract without a server.
+// ===========================================================================
+
+describe('POST /tabs/:tabId/extract (handler logic)', () => {
+  const PAGE_REFS = makeRefs([
+    ['e1', { role: 'heading', name: 'Example Domain', nth: 0 }],
+    ['e2', { role: 'link', name: 'Learn more', nth: 0 }],
+    ['e3', { role: 'button', name: 'Submit', nth: 0 }],
+    ['e4', { role: 'text', name: '  42  ', nth: 0 }],
+    ['e5', { role: 'text', name: '$19.99', nth: 0 }],
+    ['e6', { role: 'text', name: 'true', nth: 0 }],
+  ]);
+
+  // --- 200: successful extraction -------------------------------------------
+
+  test('200: extracts multiple properties with mixed types', () => {
+    const { sessions } = buildSessions({ refs: PAGE_REFS });
+    const { status, body } = simulateExtractHandler({
+      tabId: 't1',
+      body: {
+        userId: 'u1',
+        schema: {
+          type: 'object',
+          properties: {
+            title:  { type: 'string',  'x-ref': 'e1' },
+            link:   { type: 'string',  'x-ref': 'e2' },
+            count:  { type: 'integer', 'x-ref': 'e4' },
+            price:  { type: 'number',  'x-ref': 'e5' },
+            flag:   { type: 'boolean', 'x-ref': 'e6' },
+          },
+          required: ['title'],
+        },
+      },
+      sessions,
+    });
+
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data).toEqual({
+      title: 'Example Domain',
+      link:  'Learn more',
+      count: 42,
+      price: 19.99,
+      flag:  true,
+    });
+  });
+
+  test('200: optional missing ref resolves to null', () => {
+    const { sessions } = buildSessions({ refs: PAGE_REFS });
+    const { status, body } = simulateExtractHandler({
+      tabId: 't1',
+      body: {
+        userId: 'u1',
+        schema: {
+          type: 'object',
+          properties: {
+            present: { type: 'string', 'x-ref': 'e1' },
+            absent:  { type: 'string', 'x-ref': 'e9999' },
+          },
+        },
+      },
+      sessions,
+    });
+
+    expect(status).toBe(200);
+    expect(body.data.present).toBe('Example Domain');
+    expect(body.data.absent).toBeNull();
+  });
+
+  test('200: increments toolCalls on success', () => {
+    const { sessions, tabState } = buildSessions({ refs: PAGE_REFS });
+    expect(tabState.toolCalls).toBe(0);
+
+    simulateExtractHandler({
+      tabId: 't1',
+      body: {
+        userId: 'u1',
+        schema: {
+          type: 'object',
+          properties: { x: { type: 'string', 'x-ref': 'e1' } },
+        },
+      },
+      sessions,
+    });
+
+    expect(tabState.toolCalls).toBe(1);
+  });
+
+  // --- 400: bad requests ----------------------------------------------------
+
+  test('400: missing userId', () => {
+    const { sessions } = buildSessions({ refs: PAGE_REFS });
+    const { status, body } = simulateExtractHandler({
+      tabId: 't1',
+      body: { schema: { type: 'object', properties: {} } },
+      sessions,
+    });
+
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/userId/i);
+  });
+
+  test('400: missing schema', () => {
+    const { sessions } = buildSessions({ refs: PAGE_REFS });
+    const { status, body } = simulateExtractHandler({
+      tabId: 't1',
+      body: { userId: 'u1' },
+      sessions,
+    });
+
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/schema/i);
+  });
+
+  test('400: schema with unsupported type', () => {
+    const { sessions } = buildSessions({ refs: PAGE_REFS });
+    const { status, body } = simulateExtractHandler({
+      tabId: 't1',
+      body: {
+        userId: 'u1',
+        schema: { type: 'object', properties: { x: { type: 'foobar' } } },
+      },
+      sessions,
+    });
+
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/foobar/);
+  });
+
+  test('400: schema root type is not object', () => {
+    const { sessions } = buildSessions({ refs: PAGE_REFS });
+    const { status, body } = simulateExtractHandler({
+      tabId: 't1',
+      body: {
+        userId: 'u1',
+        schema: { type: 'array', items: { type: 'string' } },
+      },
+      sessions,
+    });
+
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/object/i);
+  });
+
+  test('400: schema missing properties key', () => {
+    const { sessions } = buildSessions({ refs: PAGE_REFS });
+    const { status, body } = simulateExtractHandler({
+      tabId: 't1',
+      body: {
+        userId: 'u1',
+        schema: { type: 'object' },
+      },
+      sessions,
+    });
+
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/properties/i);
+  });
+
+  test('400: empty body', () => {
+    const { sessions } = buildSessions({ refs: PAGE_REFS });
+    const { status, body } = simulateExtractHandler({
+      tabId: 't1',
+      body: {},
+      sessions,
+    });
+
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/userId/i);
+  });
+
+  // --- 404: tab not found ---------------------------------------------------
+
+  test('404: nonexistent tab', () => {
+    const { sessions } = buildSessions({ refs: PAGE_REFS });
+    const { status, body } = simulateExtractHandler({
+      tabId: 'does-not-exist',
+      body: {
+        userId: 'u1',
+        schema: { type: 'object', properties: { x: { type: 'string', 'x-ref': 'e1' } } },
+      },
+      sessions,
+    });
+
+    expect(status).toBe(404);
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  test('404: valid tab but wrong userId', () => {
+    const { sessions } = buildSessions({ refs: PAGE_REFS });
+    const { status, body } = simulateExtractHandler({
+      tabId: 't1',
+      body: {
+        userId: 'wrong-user',
+        schema: { type: 'object', properties: { x: { type: 'string', 'x-ref': 'e1' } } },
+      },
+      sessions,
+    });
+
+    expect(status).toBe(404);
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  // --- 409: no refs (snapshot not called) ------------------------------------
+
+  test('409: refs is null (snapshot never called)', () => {
+    const { sessions } = buildSessions({ refs: null, lastSnapshot: null });
+    const { status, body } = simulateExtractHandler({
+      tabId: 't1',
+      body: {
+        userId: 'u1',
+        schema: { type: 'object', properties: { x: { type: 'string', 'x-ref': 'e1' } } },
+      },
+      sessions,
+    });
+
+    expect(status).toBe(409);
+    expect(body.error).toMatch(/refs/i);
+    expect(body.snapshot).toBeNull();
+  });
+
+  test('409: refs is empty Map', () => {
+    const { sessions } = buildSessions({ refs: new Map(), lastSnapshot: 'some old snapshot' });
+    const { status, body } = simulateExtractHandler({
+      tabId: 't1',
+      body: {
+        userId: 'u1',
+        schema: { type: 'object', properties: { x: { type: 'string', 'x-ref': 'e1' } } },
+      },
+      sessions,
+    });
+
+    expect(status).toBe(409);
+    expect(body.error).toMatch(/refs/i);
+    expect(body.snapshot).toBe('some old snapshot');
+  });
+
+  // --- 422: extraction failure (required ref missing) -----------------------
+
+  test('422: required property ref not in ref table', () => {
+    const { sessions } = buildSessions({ refs: PAGE_REFS, lastSnapshot: '[heading e1] Example' });
+    const { status, body } = simulateExtractHandler({
+      tabId: 't1',
+      body: {
+        userId: 'u1',
+        schema: {
+          type: 'object',
+          properties: { missing: { type: 'string', 'x-ref': 'e9999' } },
+          required: ['missing'],
+        },
+      },
+      sessions,
+    });
+
+    expect(status).toBe(422);
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/required/);
+    expect(body.snapshot).toBe('[heading e1] Example');
+  });
+
+  test('422: multiple required, second one missing', () => {
+    const { sessions } = buildSessions({ refs: PAGE_REFS });
+    const { status, body } = simulateExtractHandler({
+      tabId: 't1',
+      body: {
+        userId: 'u1',
+        schema: {
+          type: 'object',
+          properties: {
+            title:   { type: 'string', 'x-ref': 'e1' },
+            phantom: { type: 'string', 'x-ref': 'e8888' },
+          },
+          required: ['title', 'phantom'],
+        },
+      },
+      sessions,
+    });
+
+    expect(status).toBe(422);
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/phantom/);
   });
 });


### PR DESCRIPTION
## Summary

Adds `POST /tabs/:tabId/extract`. Takes a JSON Schema and returns a typed object by resolving per-property `x-ref` hints against the current tab's accessibility refs. Zero new runtime dependencies. ~75 lines of library code, 41 lines in `server.js`, 14 unit tests.

## Demo

https://github.com/mvanhorn/camofox-browser/releases/download/evidence-structured-extract/evidence-video.mp4

<img src="https://github.com/mvanhorn/camofox-browser/releases/download/evidence-structured-extract/evidence-terminal.png" alt="Structured extract API flow" width="820" />

## Why

Every agent that uses camofox-browser eventually writes the same code: take an accessibility snapshot, find the refs they care about, parse the `name` field out of each line by hand, coerce strings to numbers or booleans, trim whitespace. The extract endpoint collapses that boilerplate into one request with a JSON Schema.

Stagehand's killer primitive is `extract("title, price", zodSchema)` with an LLM under the hood. This PR ships the deterministic half of that: no inference, no LLM config, no external calls - just "look up these refs and coerce them to these types." An LLM-backed variant is a natural follow-up but adds a lot of surface area (BYO-LLM config, timeouts, retries, cost control), so it's not here.

## Request shape

```json
POST /tabs/:tabId/extract
{
  "userId": "demo",
  "schema": {
    "type": "object",
    "properties": {
      "title":   { "type": "string",  "x-ref": "e1" },
      "price":   { "type": "number",  "x-ref": "e3" },
      "inStock": { "type": "boolean", "x-ref": "e4" }
    },
    "required": ["title"]
  }
}
```

Response cases:

| Case | Status | Body |
|------|--------|------|
| Happy path | 200 | `{ ok: true, data: {...} }` |
| Required ref missing | 422 | `{ ok: false, error, snapshot }` |
| Schema invalid | 400 | `{ error: "top-level schema must have type: object" }` |
| No refs yet (snapshot never called) | 409 | `{ error: "call GET /tabs/:tabId/snapshot first", snapshot: null }` |
| userId or schema missing | 400 | `{ error: "..." }` |

## Scope notes

- `x-ref` is the only hint. It points to a ref from the last snapshot. Coercion handles `string`, `number`, `integer`, `boolean`; the value comes from the ref's `name` field (which is what the snapshot already exposes).
- `array` and nested `object` are out of scope on purpose. The goal is the minimum useful primitive.
- `ajv` was in the original plan but dropped. Inline validation keeps the dependency tree unchanged.
- LLM mode was in the original plan but dropped. The dependency footprint of BYO-LLM is significant enough to deserve its own PR and its own conversation with the maintainer.

## Testing

```
$ NODE_OPTIONS='--experimental-vm-modules' npx jest --runInBand --forceExit tests/unit
Test Suites: 20 passed, 20 total
Tests:       266 passed, 266 total
```

14 new tests cover:

- Schema validation (missing, non-object, unsupported types)
- Coercion (string, integer, number, boolean with "true"/"yes"/"1" and inverse)
- Required/optional handling (throw vs null)
- Multi-property extraction in a single call
- Empty refs map

## Dogfooded

Ran the server locally, created a tab on example.com, called `/snapshot` to build the ref table, then:

```
$ curl -X POST :9378/tabs/$TAB/extract -d '{
    "userId": "demo",
    "schema": {
      "type":"object",
      "properties":{"linkText":{"type":"string","x-ref":"e1"}},
      "required":["linkText"]
    }
  }'
  { "ok": true, "data": { "linkText": "Learn more" } }
```

Also verified the 400, 409, and 422 paths return the right codes and bodies.
