### PR TITLE
ci: add GitHub Actions workflow for unit tests (fixes #73)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install CI reporter
+        run: npm install --no-save jest-junit
+
+      - name: Run unit tests
+        run: |
+          NODE_OPTIONS='--experimental-vm-modules' npx jest --runInBand --forceExit \
+            --testPathIgnorePatterns="e2e|live|cookies.test|security.test|tabRecycling.test"
+        env:
+          CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ build/
 .DS_Store
 Thumbs.db
 
-.github/
+# .github/ — removed to allow CI workflow tracking
 fly.toml
 railway.toml
 


### PR DESCRIPTION
## Problem

PRs #68, #69, #70 have no CI status checks — no automated test feedback before merge.

## Changes

**`.github/workflows/ci.yml`** — new GitHub Actions workflow:
- Triggers on push/PR to `master`
- Node 18 + 20 matrix
- `npm ci --ignore-scripts` for clean installs (skips browser fetch during install)
- Installs `jest-junit` for CI-compatible test reporting
- Runs all unit tests that don't require a running camoufox instance (246 tests, 21 suites)
- Excludes server-dependent tests: `cookies.test`, `security.test`, `tabRecycling.test` (these need a live browser, suitable for a future e2e job)

**`.gitignore`** — removed `.github/` entry to allow workflow files to be tracked. (Existing Dependabot/Copilot workflows run via GitHub UI config and are unaffected.)

## Verification

Ran the full test suite locally with `CI=true`:

```
Test Suites: 21 passed, 21 total
Tests:       246 passed, 246 total
Time:        ~1s
```

The 3 excluded test suites (cookies, security, tabRecycling) start a local server and require a camoufox binary — those would need a more complex CI setup (headless Firefox + Xvfb) and are better suited for a separate e2e workflow in a follow-up.

## Notes

- The `jest.config.cjs` references `jest-junit` when `CI=true` but it's not listed in `devDependencies`. The workflow installs it at runtime to avoid modifying the package manifest. Happy to add it to `devDependencies` instead if preferred.
- Branch protection for `master` (requiring the check to pass) would need to be enabled in repo settings — this PR just provides the check.

Fixes #73