### PR TITLE
fix: add session:destroying event for persistence checkpoint

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -17,6 +17,7 @@
  *   SESSION LIFECYCLE
  *     session:creating        { userId, contextOptions }       — mutate context options
  *     session:created         { userId, context }              — after context stored
+ *     session:destroying      { userId, reason }               — before context close (context still alive)
  *     session:destroyed       { userId, reason }               — after cleanup
  *     session:expired         { userId, idleMs }               — reaper triggered
  *

--- a/plugins/persistence/index.js
+++ b/plugins/persistence/index.js
@@ -100,14 +100,18 @@ export async function register(app, ctx, pluginConfig = {}) {
     }
   });
 
-  // On session destroy: checkpoint then remove from tracking
-  events.on('session:destroyed', async ({ userId, reason }) => {
+  // On session destroying (pre-close): checkpoint while context is still alive
+  events.on('session:destroying', async ({ userId, reason }) => {
     const context = activeSessions.get(userId);
     if (context) {
-      // Context may already be closed — checkpoint will fail gracefully
       await checkpoint(userId, context, reason).catch(() => {});
       activeSessions.delete(userId);
     }
+  });
+
+  // On session destroyed (post-close): cleanup tracking if not already done
+  events.on('session:destroyed', async ({ userId }) => {
+    activeSessions.delete(userId);
   });
 
   // On shutdown: checkpoint all remaining sessions

--- a/plugins/persistence/plugin.test.js
+++ b/plugins/persistence/plugin.test.js
@@ -68,7 +68,7 @@ describe('persistence plugin', () => {
     expect(saved.cookies[0].name).toBe('x');
   });
 
-  test('checkpoints on session:destroyed', async () => {
+  test('checkpoints on session:destroying', async () => {
     await register(mockApp, ctx, { profileDir: tmpDir });
 
     const mockContext = {
@@ -78,7 +78,7 @@ describe('persistence plugin', () => {
     };
 
     await events.emitAsync('session:created', { userId: 'user-3', context: mockContext });
-    await events.emitAsync('session:destroyed', { userId: 'user-3', reason: 'test' });
+    await events.emitAsync('session:destroying', { userId: 'user-3', reason: 'test' });
 
     expect(mockContext.storageState).toHaveBeenCalled();
   });

--- a/server.js
+++ b/server.js
@@ -726,6 +726,7 @@ async function closeSession(userId, session, {
     await clearSessionDownloads(session).catch(() => {});
   }
 
+  await pluginEvents.emitAsync('session:destroying', { userId: key, reason });
   await session.context.close().catch(() => {});
   sessions.delete(key);
   await pluginEvents.emitAsync('session:destroyed', { userId: key, reason });


### PR DESCRIPTION
## Problem

The persistence plugin fails to save storage state on session close because `session:destroyed` fires **after** `context.close()`. At that point, `context.storageState()` throws:

```
browserContext.storageState: Target page, context or browser has been closed
```

This means cookies and localStorage are never persisted when sessions are destroyed via `DELETE /sessions/:userId`, session timeout, or tab reaper cleanup.

## Fix

Add a new `session:destroying` lifecycle event that fires **before** `context.close()`, while the Playwright context is still alive. Move persistence checkpointing to this event.

```
closeSession() {
  clearDownloads()
+ session:destroying  ← persistence checkpoints here (context alive)
  context.close()
  sessions.delete()
  session:destroyed   ← backward compatible (context dead)
}
```

`session:destroyed` remains after cleanup for backward compatibility with any other plugins that rely on it.

## Changes

- **server.js**: Emit `session:destroying` before `context.close()`
- **lib/plugins.js**: Document the new event
- **plugins/persistence/index.js**: Listen on `session:destroying` for checkpoint, `session:destroyed` for cleanup only
- **plugins/persistence/plugin.test.js**: Update test to use new event

## Testing

- All 10 persistence plugin tests pass
- Manually verified: login → delete session → `storage-state.json` (5391 bytes) with 17 cookies + localStorage persisted correctly