### PR TITLE
fix: session persistence checkpoint before context close

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,13 @@ curl -X POST http://localhost:9377/sessions/agent1/cookies \
 ```bash
 docker run -p 9377:9377 \
   -e CAMOFOX_API_KEY="your-generated-key" \
+  -e CAMOFOX_PROFILE_DIR=/data/profiles \
   -v ~/.camofox/cookies:/home/node/.camofox/cookies:ro \
+  -v ~/.camofox/profiles:/data/profiles \
   camofox-browser
 ```
+
+Mount `CAMOFOX_PROFILE_DIR` to a host volume in Docker; otherwise the default profile directory lives inside the container and is lost when the container is removed.
 
 For Fly.io:
 ```bash

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -17,7 +17,7 @@
  *   SESSION LIFECYCLE
  *     session:creating        { userId, contextOptions }       — mutate context options
  *     session:created         { userId, context }              — after context stored
- *     session:destroyed       { userId, reason }               — after cleanup
+ *     session:destroyed       { userId, reason }               — session removed; context still readable, close follows
  *     session:expired         { userId, idleMs }               — reaper triggered
  *
  *   TAB LIFECYCLE

--- a/plugins/persistence/README.md
+++ b/plugins/persistence/README.md
@@ -39,6 +39,7 @@ When running with Docker, mount the profile directory as a volume:
 ```bash
 docker run -d \
   -p 9377:9377 \
+  -e CAMOFOX_PROFILE_DIR=/data/profiles \
   -v /host/profiles:/data/profiles \
   camofox-browser
 ```

--- a/plugins/persistence/index.js
+++ b/plugins/persistence/index.js
@@ -104,7 +104,7 @@ export async function register(app, ctx, pluginConfig = {}) {
   events.on('session:destroyed', async ({ userId, reason }) => {
     const context = activeSessions.get(userId);
     if (context) {
-      // Context may already be closed — checkpoint will fail gracefully
+      // Core emits before closing the context so final storage can be read.
       await checkpoint(userId, context, reason).catch(() => {});
       activeSessions.delete(userId);
     }

--- a/server.js
+++ b/server.js
@@ -721,14 +721,18 @@ async function closeSession(userId, session, {
   if (!session) return;
 
   const key = normalizeUserId(userId);
+  session._closing = true;
+  sessions.delete(key);
 
   if (clearDownloads) {
     await clearSessionDownloads(session).catch(() => {});
   }
 
-  await session.context.close().catch(() => {});
-  sessions.delete(key);
-  await pluginEvents.emitAsync('session:destroyed', { userId: key, reason });
+  try {
+    await pluginEvents.emitAsync('session:destroyed', { userId: key, reason });
+  } finally {
+    await session.context.close().catch(() => {});
+  }
 
   if (clearLocks) {
     clearSessionLocks(session);

--- a/tests/e2e/sessionPersistence.test.js
+++ b/tests/e2e/sessionPersistence.test.js
@@ -1,0 +1,92 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
+import { getUserPersistencePaths } from '../../lib/persistence.js';
+
+describe('Session Persistence', () => {
+  let serverUrl;
+  let testSiteUrl;
+  let profileDir;
+
+  beforeAll(async () => {
+    profileDir = await fs.mkdtemp(path.join(os.tmpdir(), 'camofox-e2e-profiles-'));
+    await startServer(0, { CAMOFOX_PROFILE_DIR: profileDir });
+    serverUrl = getServerUrl();
+
+    await startTestSite();
+    testSiteUrl = getTestSiteUrl();
+  }, 120000);
+
+  afterAll(async () => {
+    await stopTestSite();
+    await stopServer();
+    if (profileDir) {
+      await fs.rm(profileDir, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  test('DELETE /sessions checkpoints live storage state before closing context', async () => {
+    const client = createClient(serverUrl);
+    client.timeout = 60000;
+
+    const { tabId } = await client.createTab(`${testSiteUrl}/pageA`);
+    const writeResult = await client.request('POST', `/tabs/${tabId}/evaluate`, {
+      userId: client.userId,
+      expression: `(() => {
+        document.cookie = "persisted_cookie=abc123; path=/; SameSite=Lax";
+        localStorage.setItem("persistedLocal", "local-value");
+        return {
+          cookie: document.cookie,
+          local: localStorage.getItem("persistedLocal")
+        };
+      })()`,
+    });
+
+    expect(writeResult.result.cookie).toContain('persisted_cookie=abc123');
+    expect(writeResult.result.local).toBe('local-value');
+
+    await client.closeSession();
+
+    const { storageStatePath } = getUserPersistencePaths(profileDir, client.userId);
+    const saved = JSON.parse(await fs.readFile(storageStatePath, 'utf8'));
+
+    expect(saved.cookies).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'persisted_cookie', value: 'abc123' }),
+      ])
+    );
+    expect(saved.origins).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          origin: testSiteUrl,
+          localStorage: expect.arrayContaining([
+            expect.objectContaining({ name: 'persistedLocal', value: 'local-value' }),
+          ]),
+        }),
+      ])
+    );
+
+    const restoredClient = createClient(serverUrl);
+    restoredClient.userId = client.userId;
+    restoredClient.timeout = 60000;
+
+    try {
+      const restoredTab = await restoredClient.createTab(`${testSiteUrl}/pageA`);
+      const restoredState = await restoredClient.request('POST', `/tabs/${restoredTab.tabId}/evaluate`, {
+        userId: restoredClient.userId,
+        expression: `(() => ({
+          cookie: document.cookie,
+          local: localStorage.getItem("persistedLocal")
+        }))()`,
+      });
+
+      expect(restoredState.result.cookie).toContain('persisted_cookie=abc123');
+      expect(restoredState.result.local).toBe('local-value');
+    } finally {
+      await restoredClient.cleanup();
+    }
+  }, 120000);
+});


### PR DESCRIPTION
## Summary
- Emit `session:destroyed` before closing the Playwright context so persistence plugins can read live storage state.
- Keep sessions unavailable during teardown by marking `_closing` and removing them from the session map before async plugin cleanup.
- Add an E2E regression test covering cookie/localStorage checkpoint and restore after `DELETE /sessions/:userId`.
- Document Docker `CAMOFOX_PROFILE_DIR` volume usage for persistent profiles.

## Test Plan
- `npm test -- --runTestsByPath tests/e2e/sessionPersistence.test.js`
- `npm test -- --runTestsByPath plugins/persistence/plugin.test.js plugins/persistence/persistence.test.js tests/unit/sessionCleanup.test.js`
- `npm test`