### PR TITLE
feat: anonymized crash/frustration reporter with per-tab health tracking

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -97,6 +97,11 @@ function loadConfig() {
       PROXY_ZIP: process.env.PROXY_ZIP,
       PROXY_SESSION_DURATION_MINUTES: process.env.PROXY_SESSION_DURATION_MINUTES,
     },
+    // Crash reporter (opt-in, anonymized GitHub issues)
+    crashReportEnabled:   process.env.CAMOFOX_CRASH_REPORT_ENABLED !== 'false',
+    crashReportPat:       process.env.CAMOFOX_CRASH_REPORT_PAT || '',
+    crashReportRepo:      process.env.CAMOFOX_CRASH_REPORT_REPO || 'jo-inc/camofox-browser',
+    crashReportRateLimit: parseInt(process.env.CAMOFOX_CRASH_REPORT_RATE_LIMIT, 10) || 10,
   };
 }
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,0 +1,637 @@
+// lib/reporter.js — Crash/hang reporter for camofox-browser
+// Files GitHub issues with paranoid anonymization. No process.env reads (OpenClaw rule).
+// Config passed via createReporter(config) from lib/config.js.
+
+import crypto from 'crypto';
+
+// ============================================================================
+// Anonymization
+// ============================================================================
+
+const SAFE_HOSTS = new Set([
+  'github.com', 'api.github.com', 'npmjs.com', 'registry.npmjs.org',
+  'nodejs.org', 'localhost', '127.0.0.1', '::1',
+]);
+
+const SECRET_PREFIXES = [
+  'ghp_', 'gho_', 'ghu_', 'ghs_', 'ghr_',
+  'sk-', 'sk_live_', 'sk_test_', 'pk_live_', 'pk_test_',
+  'AKIA', 'ASIA',
+  'xox', 'Bearer ', 'Basic ',
+  'eyJ',
+];
+
+/**
+ * Paranoid anonymization of arbitrary text (stack traces, error messages, etc.)
+ * Better to over-strip than leak. Order matters — more specific patterns first.
+ */
+export function anonymize(text) {
+  if (!text || typeof text !== 'string') return text || '';
+
+  let s = text;
+
+  // 1. Strip known secret-prefixed tokens
+  for (const prefix of SECRET_PREFIXES) {
+    const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    s = s.replace(new RegExp(escaped + '[A-Za-z0-9_\\-\\.=+/]{8,}', 'g'), '<token>');
+  }
+
+  // 2. Strip Bearer/Basic auth headers
+  s = s.replace(/(?:Bearer|Basic)\s+[A-Za-z0-9_\-\.=+/]{8,}/gi, '<token>');
+
+  // 3. Strip proxy URLs with credentials (before email — email regex eats user:pass@host)
+  s = s.replace(/(?:https?|socks[45]?):\/\/[^:]+:[^@]+@[^\s]+/gi, '<proxy-url>');
+
+  // 4. Strip email addresses
+  s = s.replace(/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g, '<email>');
+
+  // 5. Strip full URLs (preserve scheme for context)
+  s = s.replace(/(https?|wss?|ftp):\/\/[^\s'",)}\]>]+/g, (match, scheme) => {
+    try {
+      const u = new URL(match);
+      if (SAFE_HOSTS.has(u.hostname)) return match;
+    } catch { /* not a valid URL, strip it */ }
+    return `<${scheme}-url>`;
+  });
+
+  // 6. Strip absolute file paths (Unix + Windows), preserve last filename
+  s = s.replace(
+    /(?:\/(?:Users|home|root|tmp|var|opt|data|app|srv|etc|mnt|run|snap|proc)\/[^\s:;,'")\]}]+|[A-Z]:\\(?:Users|Documents and Settings)\\[^\s:;,'")\]}]+)/g,
+    (match) => {
+      const parts = match.replace(/\\/g, '/').split('/');
+      const filename = parts[parts.length - 1] || parts[parts.length - 2] || 'unknown';
+      return `<path>/${filename}`;
+    }
+  );
+
+  // 7. Strip IPv4 addresses (except localhost)
+  s = s.replace(/\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b/g, (match) => {
+    if (match === '127.0.0.1') return match;
+    return '<ip>';
+  });
+
+  // 8. Strip IPv6 addresses (except ::1)
+  s = s.replace(/\b(?:[0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}\b/g, (match) => {
+    if (match === '::1') return match;
+    return '<ipv6>';
+  });
+  s = s.replace(/::(?:ffff:)?(?:\d{1,3}\.){3}\d{1,3}/g, '<ipv6>');
+
+  // 9. Strip hostnames in connection errors
+  s = s.replace(
+    /(?:ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|EHOSTUNREACH)\s+([a-zA-Z0-9.\-]+):(\d+)/g,
+    (match, host, port) => {
+      if (SAFE_HOSTS.has(host)) return match;
+      return match.replace(host, '<host>');
+    }
+  );
+
+  // 10. Strip Fly machine IDs (14-char hex), Docker container IDs (12+ hex)
+  s = s.replace(/\b[0-9a-f]{12,64}\b/g, '<id>');
+
+  // 11. Strip jo-* app names
+  s = s.replace(/\bjo-(?:machine|browser|whatsapp|discord|bot)[a-z0-9\-]*/gi, '<app>');
+
+  // 12. Strip environment variable assignments
+  s = s.replace(/\b[A-Z][A-Z0-9_]{3,}=[^\s]{4,}/g, '<env-var>');
+
+  // 13. Strip long alphanumeric strings (40+ chars)
+  s = s.replace(/[A-Za-z0-9_\-]{40,}/g, '<redacted>');
+
+  // 14. Strip base64 blobs (20+ chars with mixed case)
+  s = s.replace(/[A-Za-z0-9+/]{20,}={0,3}/g, (match) => {
+    if (/[a-z]/.test(match) && /[A-Z]/.test(match)) return '<redacted>';
+    return match;
+  });
+
+  return s;
+}
+
+/**
+ * Generate a stable signature for dedup. Uses error name + first meaningful
+ * stack frame (file:line, not column — columns shift with minor edits).
+ */
+export function stackSignature(type, error) {
+  const name = error?.name || error?.code || 'unknown';
+  const message = error?.message || String(error || '');
+
+  const stack = error?.stack || '';
+  const frames = stack.split('\n').slice(1);
+  let keyFrame = '';
+  for (const frame of frames) {
+    const trimmed = frame.trim();
+    if (trimmed.startsWith('at ') && !trimmed.includes('node_modules') && !trimmed.includes('node:internal')) {
+      const fileMatch = trimmed.match(/\(([^)]+)\)/) || trimmed.match(/at\s+(.+)$/);
+      if (fileMatch) {
+        const loc = fileMatch[1];
+        const parts = loc.replace(/\\/g, '/').split('/');
+        const last = parts[parts.length - 1];
+        const [file, line] = last.split(':');
+        keyFrame = `${file}:${line || '?'}`;
+        break;
+      }
+    }
+  }
+
+  const raw = `${type}|${name}|${keyFrame || anonymize(message).slice(0, 80)}`;
+  return fnv1a(raw);
+}
+
+/** FNV-1a hash → 8-char hex. Stable bucketing, not crypto. */
+function fnv1a(str) {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = (hash * 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+}
+
+// ============================================================================
+// URL anonymization (per-report salted HMAC for private domains)
+// ============================================================================
+
+// Public infrastructure domains safe to show verbatim in reports.
+// Matched by suffix. NEVER add multi-tenant hosting (herokuapp.com, vercel.app, etc.)
+const PUBLIC_INFRA_DOMAINS = [
+  // CDN & edge
+  'cloudflare.com', 'cloudflare-dns.com', 'cloudflareinsights.com',
+  'fastly.net', 'fastlylb.net',
+  'akamaized.net', 'akamai.net', 'cloudfront.net',
+  'cdn.jsdelivr.net', 'unpkg.com', 'cdnjs.com',
+  // Google
+  'google.com', 'googleapis.com', 'gstatic.com',
+  'googleusercontent.com', 'google-analytics.com', 'googletagmanager.com',
+  'googlesyndication.com', 'doubleclick.net', 'youtube.com', 'ytimg.com',
+  'recaptcha.net',
+  // Microsoft
+  'microsoft.com', 'msecnd.net', 'azureedge.net', 'bing.com',
+  // Meta CDN (not facebook.com itself)
+  'facebook.net', 'fbcdn.net',
+  // X/Twitter CDN
+  'twimg.com',
+  // GitHub
+  'github.com', 'githubusercontent.com', 'githubassets.com',
+  // Reference
+  'wikipedia.org', 'wikimedia.org', 'mozilla.org', 'mozilla.net',
+  // Anti-bot / CAPTCHA
+  'hcaptcha.com',
+  // Fonts
+  'typekit.net', 'fontawesome.com',
+].sort((a, b) => b.length - a.length); // longest-suffix-first
+
+/**
+ * Create a URL anonymizer with a per-report random salt.
+ * Same domain → same hash within one report. No cross-report correlation.
+ */
+export function createUrlAnonymizer() {
+  const salt = crypto.randomBytes(16).toString('hex');
+
+  function isPublicDomain(hostname) {
+    for (const d of PUBLIC_INFRA_DOMAINS) {
+      if (hostname === d || hostname.endsWith('.' + d)) return true;
+    }
+    return false;
+  }
+
+  function hashHost(hostname) {
+    return 'site-' + crypto.createHmac('sha256', salt).update(hostname).digest('hex').slice(0, 8);
+  }
+
+  /**
+   * Anonymize a URL. Preserves: scheme, public infra hostnames, path depth,
+   * query param count, fragment presence. Strips everything else.
+   *
+   * Examples:
+   *   https://challenges.cloudflare.com/•/•/•
+   *   https://site-a1b2c3d4:8443/•/• ?[3] #[frag]
+   */
+  function anonymizeUrl(rawUrl) {
+    if (!rawUrl || typeof rawUrl !== 'string') return '[empty]';
+    if (rawUrl.startsWith('data:')) return '[data-uri]';
+    if (rawUrl.startsWith('blob:')) return '[blob-uri]';
+    if (rawUrl.startsWith('about:')) return rawUrl;
+    if (rawUrl.startsWith('javascript:')) return '[javascript-uri]';
+
+    let url;
+    try { url = new URL(rawUrl); } catch { return '[invalid-url]'; }
+
+    const parts = [url.protocol + '//'];
+    const h = url.hostname.toLowerCase();
+
+    if (h === 'localhost' || h === '127.0.0.1' || h === '::1') {
+      parts.push('localhost');
+    } else if (/^(\d{1,3}\.){3}\d{1,3}$/.test(h) || h.includes(':')) {
+      parts.push(hashHost(h));
+    } else if (isPublicDomain(h)) {
+      parts.push(h);
+    } else {
+      parts.push(hashHost(h));
+    }
+
+    if (url.port) parts.push(':' + url.port);
+
+    const segs = url.pathname.split('/').filter(Boolean);
+    parts.push(segs.length > 0 ? '/' + segs.map(() => '\u2022').join('/') : '/');
+
+    const paramCount = [...url.searchParams].length;
+    if (paramCount > 0) parts.push(` ?[${paramCount}]`);
+    if (url.hash && url.hash.length > 1) parts.push(' #[frag]');
+
+    return parts.join('');
+  }
+
+  function anonymizeChain(urls) {
+    if (!Array.isArray(urls) || urls.length === 0) return '[empty-chain]';
+    return urls.map(u => anonymizeUrl(u)).join(' \u2192 ');
+  }
+
+  return { anonymizeUrl, anonymizeChain };
+}
+
+// ============================================================================
+// Per-tab health tracker (count-only, no content)
+// ============================================================================
+
+/**
+ * Create a health tracker for a tab. Attaches to Playwright page events.
+ * Tracks: crashes, page errors, console errors, request failures,
+ * dialog storms, redirect depth, HTTP status histogram, frame count.
+ * All count-based — no URLs or content stored.
+ */
+export function createTabHealthTracker(page) {
+  const health = {
+    crashes: 0,
+    pageErrors: 0,
+    consoleErrors: 0,
+    requestFailures: 0,
+    dialogCount: 0,
+    maxRedirectDepth: 0,
+    statusCounts: {},     // { 403: 5, 429: 2, ... }
+    frameCount: 0,
+    _redirectDepth: 0,
+  };
+
+  // Renderer crash (OOM, segfault)
+  page.on('crash', () => { health.crashes++; });
+
+  // Uncaught JS exceptions on the page
+  page.on('pageerror', () => { health.pageErrors++; });
+
+  // Console errors (rate, not content)
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') health.consoleErrors++;
+  });
+
+  // Failed requests (blocked, DNS failure, etc.)
+  page.on('requestfailed', () => { health.requestFailures++; });
+
+  // HTTP status tracking (non-2xx only)
+  page.on('response', (resp) => {
+    const s = resp.status();
+    if (s >= 400) health.statusCounts[s] = (health.statusCounts[s] || 0) + 1;
+  });
+
+  // Dialog tracking (alert/confirm/prompt storms)
+  page.on('dialog', async (dialog) => {
+    health.dialogCount++;
+    try { await dialog.dismiss(); } catch { /* page might be closed */ }
+  });
+
+  // Redirect depth per navigation
+  page.on('request', (req) => {
+    if (req.isNavigationRequest()) {
+      if (req.redirectedFrom()) {
+        health._redirectDepth++;
+        if (health._redirectDepth > health.maxRedirectDepth) {
+          health.maxRedirectDepth = health._redirectDepth;
+        }
+      } else {
+        health._redirectDepth = 0; // new navigation, reset
+      }
+    }
+  });
+
+  /** Snapshot current health counters for inclusion in reports. */
+  function snapshot() {
+    try { health.frameCount = page.frames().length; } catch { /* closed */ }
+    const { _redirectDepth, ...clean } = health;
+    return { ...clean };
+  }
+
+  return { health, snapshot };
+}
+
+// ============================================================================
+// Rate limiter (sliding window, 1 hour)
+// ============================================================================
+
+class RateLimiter {
+  constructor(maxPerHour) {
+    this.maxPerHour = maxPerHour;
+    this.timestamps = [];
+  }
+
+  tryAcquire() {
+    const now = Date.now();
+    this.timestamps = this.timestamps.filter(t => t > now - 3600_000);
+    if (this.timestamps.length >= this.maxPerHour) return false;
+    this.timestamps.push(now);
+    return true;
+  }
+}
+
+// ============================================================================
+// GitHub API (all fetches have 5s timeout)
+// ============================================================================
+
+const FETCH_TIMEOUT_MS = 5000;
+const GITHUB_API = 'https://api.github.com';
+
+async function fetchWithTimeout(url, options) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function findExistingIssue(repo, pat, signature) {
+  const query = encodeURIComponent(`repo:${repo} is:issue is:open "[${signature}]" in:title`);
+  const resp = await fetchWithTimeout(`${GITHUB_API}/search/issues?q=${query}&per_page=1`, {
+    headers: {
+      'Authorization': `token ${pat}`,
+      'Accept': 'application/vnd.github.v3+json',
+      'User-Agent': 'camofox-crash-reporter',
+    },
+  });
+  if (!resp.ok) return null;
+  const data = await resp.json();
+  if (data.items?.length > 0) {
+    return { issueNumber: data.items[0].number, issueUrl: data.items[0].html_url };
+  }
+  return null;
+}
+
+async function commentOnIssue(repo, pat, issueNumber, body) {
+  const resp = await fetchWithTimeout(`${GITHUB_API}/repos/${repo}/issues/${issueNumber}/comments`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `token ${pat}`,
+      'Accept': 'application/vnd.github.v3+json',
+      'User-Agent': 'camofox-crash-reporter',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ body }),
+  });
+  return resp.ok;
+}
+
+async function createIssue(repo, pat, title, body, labels) {
+  const resp = await fetchWithTimeout(`${GITHUB_API}/repos/${repo}/issues`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `token ${pat}`,
+      'Accept': 'application/vnd.github.v3+json',
+      'User-Agent': 'camofox-crash-reporter',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ title, body, labels }),
+  });
+  if (!resp.ok) return null;
+  const data = await resp.json();
+  return data.html_url || null;
+}
+
+// ============================================================================
+// Issue formatting
+// ============================================================================
+
+function formatIssueBody(type, detail) {
+  const sections = [
+    '> Auto-reported by camofox-crash-reporter. All data is anonymized.',
+    '',
+    `**Type:** ${type}`,
+    `**Version:** ${detail.version || 'unknown'}`,
+    `**Node:** ${detail.nodeVersion || 'unknown'}`,
+    `**Platform:** ${detail.platform || 'unknown'}`,
+    `**Uptime:** ${detail.uptimeMinutes != null ? detail.uptimeMinutes + ' min' : 'unknown'}`,
+  ];
+
+  if (detail.message) {
+    sections.push('', '### Error', '```', anonymize(detail.message), '```');
+  }
+  if (detail.stack) {
+    sections.push('', '### Stack Trace', '```', anonymize(detail.stack), '```');
+  }
+  if (detail.context) {
+    sections.push('', '### Context', '```', anonymize(JSON.stringify(detail.context, null, 2)), '```');
+  }
+  if (detail.metrics) {
+    sections.push('', '### Metrics', '```json', JSON.stringify(detail.metrics, null, 2), '```');
+  }
+
+  return sections.join('\n');
+}
+
+function formatCommentBody(type, detail) {
+  const ts = new Date().toISOString();
+  const lines = [
+    `**+1** — ${ts}`,
+    `Version: ${detail.version || 'unknown'}, Uptime: ${detail.uptimeMinutes != null ? detail.uptimeMinutes + ' min' : '?'}`,
+  ];
+  if (detail.message) {
+    lines.push('```', anonymize(detail.message).slice(0, 500), '```');
+  }
+  return lines.join('\n');
+}
+
+// ============================================================================
+// Core reporter factory
+// ============================================================================
+
+/**
+ * Create a reporter instance.
+ *
+ * @param {object} config
+ * @param {boolean} config.crashReportEnabled
+ * @param {string}  config.crashReportPat       - GitHub PAT (issues:write only)
+ * @param {string}  config.crashReportRepo      - "owner/repo"
+ * @param {number}  config.crashReportRateLimit  - max reports per hour
+ * @param {string}  [config.version]             - package version
+ */
+export function createReporter(config) {
+  const enabled = config.crashReportEnabled && config.crashReportPat && config.crashReportRepo;
+  const rateLimiter = new RateLimiter(config.crashReportRateLimit || 10);
+  const version = config.version || 'unknown';
+
+  let watchdogInterval = null;
+  let lastTick = Date.now();
+  const inFlight = new Set();
+
+  // No-op when disabled
+  if (!enabled) {
+    return {
+      reportCrash: async () => {},
+      reportHang: async () => {},
+      reportStuckLoop: async () => {},
+      startWatchdog: () => {},
+      stop: () => {},
+      _anonymize: anonymize,
+      _stackSignature: stackSignature,
+    };
+  }
+
+  const pat = config.crashReportPat;
+  const repo = config.crashReportRepo;
+
+  /** Core: file or deduplicate a report. NEVER throws. */
+  async function fileReport(type, label, detail) {
+    if (!rateLimiter.tryAcquire()) return;
+
+    const reportPromise = (async () => {
+      try {
+        const sig = stackSignature(type, detail.error || { message: detail.message, stack: detail.stack });
+        const safeMessage = anonymize(detail.message || detail.error?.message || type);
+        const title = `[${sig}] ${type}: ${safeMessage.slice(0, 120)}`;
+
+        const existing = await findExistingIssue(repo, pat, sig);
+        if (existing) {
+          await commentOnIssue(repo, pat, existing.issueNumber, formatCommentBody(type, {
+            ...detail,
+            version,
+            nodeVersion: typeof process !== 'undefined' ? process.version : 'unknown',
+            platform: typeof process !== 'undefined' ? process.platform : 'unknown',
+          }));
+          return;
+        }
+
+        const body = formatIssueBody(type, {
+          ...detail,
+          version,
+          nodeVersion: typeof process !== 'undefined' ? process.version : 'unknown',
+          platform: typeof process !== 'undefined' ? process.platform : 'unknown',
+        });
+
+        await createIssue(repo, pat, title, body, [label, 'auto-report']);
+      } catch {
+        // Swallow — reporter must never crash the server
+      }
+    })();
+
+    inFlight.add(reportPromise);
+    reportPromise.finally(() => inFlight.delete(reportPromise));
+  }
+
+  async function reportCrash(error, opts = {}) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    const uptimeMinutes = typeof process !== 'undefined'
+      ? Math.round(process.uptime() / 60) : undefined;
+
+    await fileReport(
+      opts.signal ? `signal:${opts.signal}` : (err.name || 'crash'),
+      'crash',
+      {
+        error: err,
+        message: err.message,
+        stack: err.stack,
+        uptimeMinutes,
+        context: opts.context,
+      },
+    );
+  }
+
+  async function reportHang(operation, durationMs, opts = {}) {
+    const uptimeMinutes = typeof process !== 'undefined'
+      ? Math.round(process.uptime() / 60) : undefined;
+
+    // Create per-report URL anonymizer (fresh salt each time)
+    const urlAnon = createUrlAnonymizer();
+    const context = { operation, durationMs, ...opts.context };
+
+    // Anonymize any URLs in the journal
+    if (context.journal) {
+      context.journal = context.journal.map(j => {
+        if (typeof j === 'string') return j; // already "type:action" format
+        return j;
+      });
+    }
+    // Include anonymized URL if provided
+    if (opts.url) context.url = urlAnon.anonymizeUrl(opts.url);
+    if (opts.redirectChain) context.redirectChain = urlAnon.anonymizeChain(opts.redirectChain);
+
+    // Include tab health snapshot if provided
+    if (opts.healthSnapshot) context.health = opts.healthSnapshot;
+
+    await fileReport(
+      `hang:${operation}`,
+      'hang',
+      {
+        message: `Operation "${operation}" hung for ${Math.round(durationMs / 1000)}s`,
+        stack: opts.error?.stack,
+        uptimeMinutes,
+        context,
+      },
+    );
+  }
+
+  async function reportStuckLoop(durationMs, opts = {}) {
+    const uptimeMinutes = typeof process !== 'undefined'
+      ? Math.round(process.uptime() / 60) : undefined;
+
+    await fileReport(
+      'stuck:tab-lock',
+      'stuck',
+      {
+        message: `Tab lock held for ${Math.round(durationMs / 1000)}s (tab destroyed)`,
+        uptimeMinutes,
+        context: { durationMs, ...opts.context },
+      },
+    );
+  }
+
+  function startWatchdog(thresholdMs = 5000) {
+    if (watchdogInterval) return;
+
+    const checkMs = 1000;
+    lastTick = Date.now();
+
+    watchdogInterval = setInterval(() => {
+      const now = Date.now();
+      const drift = now - lastTick - checkMs;
+      lastTick = now;
+
+      if (drift > thresholdMs) {
+        fileReport('stuck:event-loop', 'stuck', {
+          message: `Event loop stalled for ${Math.round(drift / 1000)}s (threshold: ${Math.round(thresholdMs / 1000)}s)`,
+          uptimeMinutes: typeof process !== 'undefined'
+            ? Math.round(process.uptime() / 60) : undefined,
+          context: { driftMs: drift, thresholdMs },
+        });
+      }
+    }, checkMs);
+
+    if (watchdogInterval.unref) watchdogInterval.unref();
+  }
+
+  function stop() {
+    if (watchdogInterval) {
+      clearInterval(watchdogInterval);
+      watchdogInterval = null;
+    }
+    return Promise.allSettled([...inFlight]);
+  }
+
+  return {
+    reportCrash,
+    reportHang,
+    reportStuckLoop,
+    startWatchdog,
+    stop,
+    _anonymize: anonymize,
+    _stackSignature: stackSignature,
+    _rateLimiter: rateLimiter,
+  };
+}

--- a/server.js
+++ b/server.js
@@ -27,8 +27,15 @@ import {
 import { actionFromReq, classifyError } from './lib/request-utils.js';
 import { cleanupOrphanedTempFiles } from './lib/tmp-cleanup.js';
 import { coalesceInflight } from './lib/inflight.js';
+import { createReporter, createTabHealthTracker } from './lib/reporter.js';
 
 const CONFIG = loadConfig();
+
+// --- Crash reporter (opt-in, anonymized GitHub issues) ---
+import { readFileSync } from 'fs';
+const _pkgVersion = (() => { try { return JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')).version; } catch { return 'unknown'; } })();
+const reporter = createReporter({ ...CONFIG, version: _pkgVersion });
+reporter.startWatchdog(5000);
 
 // --- Plugin event bus ---
 const pluginEvents = createPluginEvents();
@@ -889,7 +896,6 @@ function handleRouteError(err, req, res, extraFields = {}) {
   }
   // Lock queue timeout = tab is stuck. Destroy immediately.
   if (userId && isTabLockQueueTimeout(err)) {
-    const tabId = req.body?.tabId || req.query?.tabId || req.params?.tabId;
     const session = sessions.get(normalizeUserId(userId));
     if (session && tabId) {
       destroyTab(session, tabId, 'lock_queue', userId);
@@ -899,6 +905,34 @@ function handleRouteError(err, req, res, extraFields = {}) {
   // Tab was destroyed while this request was queued in the lock
   if (isTabDestroyedError(err)) {
     return res.status(410).json({ error: 'Tab was destroyed. Open a new tab.', ...extraFields });
+  }
+  // --- Frustration detection: report when a tab hits a streak of failures ---
+  // Individual failures are noise. 3+ consecutive = the site is persistently broken.
+  const FRUSTRATION_TYPES = new Set(['timeout', 'dead_context', 'nav_aborted']);
+  if (FRUSTRATION_TYPES.has(failureType) && userId && tabId) {
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, tabId);
+    if (found) {
+      const ts = found.tabState;
+      ts.consecutiveFailures = (ts.consecutiveFailures || 0) + 1;
+      if (!ts.failureJournal) ts.failureJournal = [];
+      ts.failureJournal.push({ type: failureType, action, at: Date.now() });
+      if (ts.failureJournal.length > 20) ts.failureJournal = ts.failureJournal.slice(-20);
+
+      if (ts.consecutiveFailures === 3) {
+        reporter.reportHang(action, req.startTime ? Date.now() - req.startTime : 0, {
+          error: err,
+          url: ts.lastRequestedUrl || undefined,
+          healthSnapshot: ts.healthTracker ? ts.healthTracker.snapshot() : undefined,
+          context: {
+            failureType,
+            consecutiveFailures: ts.consecutiveFailures,
+            toolCalls: ts.toolCalls,
+            journal: ts.failureJournal.map(j => `${j.type}:${j.action}`),
+          },
+        });
+      }
+    }
   }
   sendError(res, err, extraFields);
 }
@@ -980,6 +1014,7 @@ function findTab(session, tabId) {
 }
 
 function createTabState(page) {
+  const healthTracker = createTabHealthTracker(page);
   return {
     page,
     refs: new Map(),
@@ -987,6 +1022,9 @@ function createTabState(page) {
     downloads: [],
     toolCalls: 0,
     consecutiveTimeouts: 0,
+    consecutiveFailures: 0,
+    failureJournal: [],
+    healthTracker,
     lastSnapshot: null,
     lastRequestedUrl: null,
     googleRetryCount: 0,
@@ -1638,7 +1676,7 @@ app.post('/tabs/:tabId/navigate', async (req, res) => {
       } else {
         tabState = found.tabState;
       }
-      tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+      tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
       
       let targetUrl = url;
       if (macro && macro !== '__NO__' && macro !== 'none' && macro !== 'null') {
@@ -1760,7 +1798,7 @@ app.get('/tabs/:tabId/snapshot', async (req, res) => {
     if (!found) return res.status(404).json({ error: 'Tab not found' });
     
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
 
     // Cached chunk retrieval for offset>0 requests
     if (offset > 0 && tabState.lastSnapshot) {
@@ -1918,7 +1956,7 @@ app.post('/tabs/:tabId/click', async (req, res) => {
     if (!found) return res.status(404).json({ error: 'Tab not found' });
     
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
     
     if (!ref && !selector) {
       return res.status(400).json({ error: 'ref or selector required' });
@@ -2089,7 +2127,7 @@ app.post('/tabs/:tabId/type', async (req, res) => {
     if (!found) return res.status(404).json({ error: 'Tab not found' });
     
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
     
     if (mode !== 'fill' && mode !== 'keyboard') {
       return res.status(400).json({ error: "mode must be 'fill' or 'keyboard'" });
@@ -2171,7 +2209,7 @@ app.post('/tabs/:tabId/press', async (req, res) => {
     if (!found) return res.status(404).json({ error: 'Tab not found' });
     
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
     
     await withTabLock(tabId, async () => {
       await tabState.page.keyboard.press(key);
@@ -2194,7 +2232,7 @@ app.post('/tabs/:tabId/scroll', async (req, res) => {
     if (!found) return res.status(404).json({ error: 'Tab not found' });
     
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
     
     const isVertical = direction === 'up' || direction === 'down';
     const delta = (direction === 'up' || direction === 'left') ? -amount : amount;
@@ -2220,7 +2258,7 @@ app.post('/tabs/:tabId/back', async (req, res) => {
     if (!found) return res.status(404).json({ error: 'Tab not found' });
     
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
     
     const result = await withTabLock(tabId, async () => {
       try {
@@ -2256,7 +2294,7 @@ app.post('/tabs/:tabId/forward', async (req, res) => {
     if (!found) return res.status(404).json({ error: 'Tab not found' });
     
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
     
     const result = await withTabLock(tabId, async () => {
       await tabState.page.goForward({ timeout: 10000 });
@@ -2282,7 +2320,7 @@ app.post('/tabs/:tabId/refresh', async (req, res) => {
     if (!found) return res.status(404).json({ error: 'Tab not found' });
     
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
     
     const result = await withTabLock(tabId, async () => {
       await tabState.page.reload({ timeout: 30000 });
@@ -2311,7 +2349,7 @@ app.get('/tabs/:tabId/links', async (req, res) => {
     }
     
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
     
     const allLinks = await tabState.page.evaluate(() => {
       const links = [];
@@ -2451,7 +2489,7 @@ app.post('/tabs/:tabId/evaluate', express.json({ limit: '1mb' }), async (req, re
 
     session.lastAccess = Date.now();
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
 
     pluginEvents.emit('tab:evaluate', { userId, tabId: req.params.tabId, expression });
     const result = await tabState.page.evaluate(expression);
@@ -2749,7 +2787,7 @@ app.post('/navigate', async (req, res) => {
     }
     
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
     
     const result = await withTabLock(targetId, async () => {
       await withPageLoadDuration('navigate', () => tabState.page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 }));
@@ -2789,7 +2827,7 @@ app.get('/snapshot', async (req, res) => {
     }
     
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
 
     // Cached chunk retrieval
     if (offset > 0 && tabState.lastSnapshot) {
@@ -2902,7 +2940,7 @@ app.post('/act', async (req, res) => {
     }
     
     const { tabState } = found;
-    tabState.toolCalls++; tabState.consecutiveTimeouts = 0;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
     
     const result = await withTabLock(targetId, async () => {
       switch (kind) {
@@ -3119,6 +3157,7 @@ setInterval(async () => {
 process.on('uncaughtException', (err) => {
   pluginEvents.emit('browser:error', { error: err });
   log('error', 'uncaughtException', { error: err.message, stack: err.stack });
+  reporter.reportCrash(err);
   process.exit(1);
 });
 process.on('unhandledRejection', (reason) => {

--- a/tests/unit/reporter.test.js
+++ b/tests/unit/reporter.test.js
@@ -1,0 +1,562 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { anonymize, stackSignature, createReporter, createUrlAnonymizer, createTabHealthTracker } from '../../lib/reporter.js';
+
+// ============================================================================
+// Anonymization tests
+// ============================================================================
+
+describe('anonymize', () => {
+
+  // ---- File paths ----
+
+  it('strips Unix home directory paths', () => {
+    const input = 'Error at /Users/pradeep/personal/camofox-browser/server.js:123:45';
+    const result = anonymize(input);
+    assert.ok(!result.includes('pradeep'), `leaked username: ${result}`);
+    assert.ok(!result.includes('/Users/'), `leaked /Users/: ${result}`);
+    assert.ok(result.includes('server.js'), 'should keep filename');
+  });
+
+  it('strips /home/ubuntu paths', () => {
+    const input = 'at Object.<anonymous> (/home/ubuntu/app/lib/browser.js:456:12)';
+    const result = anonymize(input);
+    assert.ok(!result.includes('ubuntu'), `leaked username: ${result}`);
+    assert.ok(result.includes('browser.js'), 'should keep filename');
+  });
+
+  it('strips Windows paths', () => {
+    const input = 'at C:\\Users\\Administrator\\Desktop\\camofox\\server.js:99:10';
+    const result = anonymize(input);
+    assert.ok(!result.includes('Administrator'), `leaked username: ${result}`);
+    assert.ok(result.includes('server.js'), 'should keep filename');
+  });
+
+  it('strips /root paths', () => {
+    assert.ok(!anonymize('/root/.config/secrets/token.txt').includes('.config'));
+  });
+
+  it('strips /tmp paths', () => {
+    const result = anonymize('Reading from /tmp/session-abc123/data.json');
+    assert.ok(!result.includes('session-abc123'), `leaked session dir: ${result}`);
+    assert.ok(result.includes('data.json'), 'should keep filename');
+  });
+
+  it('strips /data paths (Fly volumes)', () => {
+    const result = anonymize('ENOENT /data/conversations/user_1234/ctx.db');
+    assert.ok(!result.includes('user_1234'), `leaked user dir: ${result}`);
+  });
+
+  it('strips /app paths (Docker)', () => {
+    const result = anonymize('Module not found: /app/node_modules/foo/dist/bar.js:10:5');
+    assert.ok(!result.includes('/app/node_modules'), `leaked docker path: ${result}`);
+  });
+
+  // ---- URLs ----
+
+  it('strips browsed URLs', () => {
+    const input = 'Navigate failed for https://secret-internal.corp.example.com/admin/dashboard?token=abc123';
+    const result = anonymize(input);
+    assert.ok(!result.includes('secret-internal'), `leaked URL: ${result}`);
+    assert.ok(!result.includes('corp.example.com'), `leaked host: ${result}`);
+    assert.ok(result.includes('<https-url>'), 'should show placeholder');
+  });
+
+  it('strips WebSocket URLs', () => {
+    const result = anonymize('Connection to wss://broker.internal:8443/ws failed');
+    assert.ok(!result.includes('broker.internal'), `leaked ws host: ${result}`);
+    assert.ok(result.includes('<wss-url>'), 'should show placeholder');
+  });
+
+  it('preserves safe GitHub URLs', () => {
+    assert.ok(anonymize('Fetching https://api.github.com/repos/foo/bar').includes('api.github.com'));
+  });
+
+  it('preserves safe npm URLs', () => {
+    assert.ok(anonymize('GET https://registry.npmjs.org/express 200').includes('registry.npmjs.org'));
+  });
+
+  // ---- IP addresses ----
+
+  it('strips IPv4 addresses', () => {
+    const result = anonymize('connect ECONNREFUSED 10.0.44.5:3001');
+    assert.ok(!result.includes('10.0.44.5'), `leaked IP: ${result}`);
+  });
+
+  it('strips private IPs', () => {
+    const result = anonymize('Proxy at 192.168.1.100:8080 failed');
+    assert.ok(!result.includes('192.168.1.100'), `leaked IP: ${result}`);
+  });
+
+  it('preserves localhost 127.0.0.1', () => {
+    assert.ok(anonymize('Listening on 127.0.0.1:3000').includes('127.0.0.1'));
+  });
+
+  it('strips IPv6 addresses', () => {
+    const result = anonymize('connect to 2001:0db8:85a3:0000:0000:8a2e:0370:7334 failed');
+    assert.ok(!result.includes('2001:0db8'), `leaked IPv6: ${result}`);
+  });
+
+  it('strips IPv4-mapped IPv6', () => {
+    const result = anonymize('from ::ffff:10.0.0.1');
+    assert.ok(!result.includes('10.0.0.1'), `leaked mapped IP: ${result}`);
+  });
+
+  // ---- Tokens & secrets ----
+
+  it('strips GitHub PATs (ghp_)', () => {
+    const result = anonymize('Auth failed with ghp_ABCDEFghijklmnopqrstuvwxyz0123456789AB');
+    assert.ok(!result.includes('ghp_'), `leaked PAT: ${result}`);
+    assert.ok(result.includes('<token>'));
+  });
+
+  it('strips OpenAI keys (sk-)', () => {
+    const result = anonymize('OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz12345678');
+    assert.ok(!result.includes('sk-proj'), `leaked key: ${result}`);
+  });
+
+  it('strips Bearer tokens', () => {
+    const result = anonymize('Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U');
+    assert.ok(!result.includes('eyJ'), `leaked JWT: ${result}`);
+    assert.ok(result.includes('<token>'));
+  });
+
+  it('strips Basic auth', () => {
+    const result = anonymize('Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=');
+    assert.ok(!result.includes('dXNlcm5hbWU'), `leaked basic auth: ${result}`);
+  });
+
+  it('strips AWS access keys', () => {
+    const result = anonymize('key=AKIAIOSFODNN7EXAMPLE');
+    assert.ok(!result.includes('AKIAIOSFODNN7'), `leaked AWS key: ${result}`);
+  });
+
+  it('strips long alphanumeric strings (40+ chars)', () => {
+    const secret = 'aB'.repeat(25); // mixed case avoids hex ID pattern
+    const result = anonymize(`Token: ${secret}`);
+    assert.ok(!result.includes(secret), 'leaked long string');
+    assert.ok(result.includes('<redacted>'));
+  });
+
+  it('strips long lowercase hex strings as IDs', () => {
+    const secret = 'a'.repeat(50);
+    const result = anonymize(`Token: ${secret}`);
+    assert.ok(!result.includes(secret), 'leaked long string');
+    assert.ok(result.includes('<id>'));
+  });
+
+  it('strips Slack tokens', () => {
+    const tok = 'xox' + 'b-123456789012-1234567890123-AbCdEfGhIjKlMnOpQrStUvWx';
+    const result = anonymize('SLACK_TOKEN=' + tok);
+    assert.ok(!result.includes('xoxb'), `leaked slack token: ${result}`);
+  });
+
+  // ---- Fly.io / Docker IDs ----
+
+  it('strips Fly machine IDs (14-char hex)', () => {
+    const result = anonymize('Machine e784079b295268 stopped');
+    assert.ok(!result.includes('e784079b295268'), `leaked machine ID: ${result}`);
+    assert.ok(result.includes('<id>'));
+  });
+
+  it('strips Docker container IDs', () => {
+    const result = anonymize('Container abc123def45678 exited');
+    assert.ok(!result.includes('abc123def45678'), `leaked container ID: ${result}`);
+  });
+
+  it('strips jo-machine app names', () => {
+    const result = anonymize('Connecting to jo-machine-prod-1234');
+    assert.ok(!result.includes('jo-machine-prod-1234'), `leaked app name: ${result}`);
+    assert.ok(result.includes('<app>'));
+  });
+
+  it('strips jo-browser app name', () => {
+    const result = anonymize('Deployed to jo-browser-staging');
+    assert.ok(!result.includes('jo-browser'), `leaked app name: ${result}`);
+  });
+
+  // ---- Email addresses ----
+
+  it('strips email addresses', () => {
+    const result = anonymize('User pradeep@askjo.ai sent request');
+    assert.ok(!result.includes('pradeep@'), `leaked email: ${result}`);
+    assert.ok(result.includes('<email>'));
+  });
+
+  // ---- Env var assignments ----
+
+  it('strips env var assignments', () => {
+    const result = anonymize('SPRITE_TOKEN=abc123secretvalue456 in environment');
+    assert.ok(!result.includes('abc123secret'), `leaked env value: ${result}`);
+    assert.ok(result.includes('<env-var>'));
+  });
+
+  // ---- Proxy credentials ----
+
+  it('strips proxy URLs with credentials', () => {
+    const result = anonymize('Using proxy http://user:p4ssw0rd@proxy.corp.com:8080');
+    assert.ok(!result.includes('p4ssw0rd'), `leaked proxy password: ${result}`);
+    assert.ok(!result.includes('proxy.corp.com'), `leaked proxy host: ${result}`);
+    assert.ok(result.includes('<proxy-url>'));
+  });
+
+  it('strips socks5 proxy credentials', () => {
+    const result = anonymize('socks5://admin:secret@10.0.0.1:1080');
+    assert.ok(!result.includes('admin:secret'), `leaked socks creds: ${result}`);
+  });
+
+  // ---- Connection errors with hostnames ----
+
+  it('strips hostnames in ECONNREFUSED errors', () => {
+    const result = anonymize('connect ECONNREFUSED internal.service.local:3001');
+    assert.ok(!result.includes('internal.service.local'), `leaked hostname: ${result}`);
+    assert.ok(result.includes('<host>'));
+  });
+
+  it('strips hostnames in ETIMEDOUT errors', () => {
+    const result = anonymize('connect ETIMEDOUT api.private.svc:443');
+    assert.ok(!result.includes('api.private.svc'), `leaked hostname: ${result}`);
+  });
+
+  // ---- Compound / real-world ----
+
+  it('handles a realistic stack trace with multiple leak vectors', () => {
+    const stack = `Error: Navigation timeout of 30000ms exceeded
+    at navigate (/Users/pradeep/personal/camofox-browser/server.js:1500:15)
+    at processRequest (/Users/pradeep/personal/camofox-browser/server.js:800:10)
+    url: https://super-secret-dashboard.internal.corp.com/page?auth=ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    proxy: http://user:pass@192.168.1.50:8080
+    machine: e784079b295268
+    env: BROWSER_TOKEN=sk-abcdefghijklmnopqrstuvwxyz1234567890abcd`;
+    const result = anonymize(stack);
+
+    assert.ok(!result.includes('pradeep'), `leaked username: ${result}`);
+    assert.ok(!result.includes('super-secret'), `leaked URL: ${result}`);
+    assert.ok(!result.includes('ghp_'), `leaked PAT: ${result}`);
+    assert.ok(!result.includes('user:pass'), `leaked proxy creds: ${result}`);
+    assert.ok(!result.includes('192.168.1.50'), `leaked IP: ${result}`);
+    assert.ok(!result.includes('e784079b295268'), `leaked machine ID: ${result}`);
+    assert.ok(!result.includes('sk-abcdef'), `leaked token: ${result}`);
+    assert.ok(result.includes('server.js'), 'should keep filename');
+  });
+
+  it('handles empty/null/undefined input gracefully', () => {
+    assert.equal(anonymize(''), '');
+    assert.equal(anonymize(null), '');
+    assert.equal(anonymize(undefined), '');
+  });
+
+  it('preserves clean error messages', () => {
+    const msg = 'TypeError: Cannot read properties of undefined';
+    assert.equal(anonymize(msg), msg);
+  });
+
+  it('preserves standard error names', () => {
+    const msg = 'TimeoutError: page.goto: Timeout 30000ms exceeded.';
+    assert.equal(anonymize(msg), msg);
+  });
+
+  it('handles JSON-serialized error context', () => {
+    const ctx = JSON.stringify({
+      url: 'https://internal.corp.com/api',
+      headers: { Authorization: 'Bearer eyJhbGciOiJSUzI1NiJ9.secretpayload' },
+      proxy: 'socks5://admin:hunter2@10.0.0.5:1080',
+    });
+    const result = anonymize(ctx);
+    assert.ok(!result.includes('internal.corp.com'));
+    assert.ok(!result.includes('eyJ'));
+    assert.ok(!result.includes('hunter2'));
+    assert.ok(!result.includes('10.0.0.5'));
+  });
+
+  it('strips Sentry DSN URLs', () => {
+    const result = anonymize('Sentry DSN: https://abc123def456@o123456.ingest.sentry.io/789');
+    assert.ok(!result.includes('o123456'), `leaked sentry org: ${result}`);
+  });
+
+  it('preserves operation names and durations', () => {
+    const msg = 'Operation "navigate" hung for 30s';
+    assert.equal(anonymize(msg), msg);
+  });
+
+  it('does not create <token> from short strings after prefix', () => {
+    const result = anonymize('key is sk-short');
+    assert.equal(result, 'key is sk-short');
+  });
+});
+
+// ============================================================================
+// Stack signature / dedup tests
+// ============================================================================
+
+describe('stackSignature', () => {
+
+  it('produces stable signatures for the same error', () => {
+    const err = new Error('test');
+    err.stack = `Error: test\n    at foo (/app/server.js:100:10)\n    at bar (/app/lib/utils.js:50:5)`;
+    const sig1 = stackSignature('crash', err);
+    const sig2 = stackSignature('crash', err);
+    assert.equal(sig1, sig2);
+  });
+
+  it('produces different signatures for different locations', () => {
+    const err1 = new Error('test');
+    err1.stack = `Error: test\n    at foo (server.js:100:10)`;
+    const err2 = new Error('test');
+    err2.stack = `Error: test\n    at foo (server.js:200:10)`;
+    assert.notEqual(stackSignature('crash', err1), stackSignature('crash', err2));
+  });
+
+  it('ignores column number differences (same file:line)', () => {
+    const err1 = new Error('test');
+    err1.stack = `Error: test\n    at foo (server.js:100:10)`;
+    const err2 = new Error('test');
+    err2.stack = `Error: test\n    at foo (server.js:100:55)`;
+    assert.equal(stackSignature('crash', err1), stackSignature('crash', err2));
+  });
+
+  it('skips node_modules frames', () => {
+    const err = new Error('test');
+    err.stack = `Error: test
+    at Object.something (node_modules/express/lib/router.js:50:10)
+    at myHandler (server.js:300:15)`;
+    const err2 = new Error('different message');
+    err2.stack = `Error: different message
+    at Object.other (node_modules/express/lib/router.js:99:10)
+    at myHandler (server.js:300:15)`;
+    assert.equal(stackSignature('crash', err), stackSignature('crash', err2));
+  });
+
+  it('handles errors without stack traces', () => {
+    const sig = stackSignature('crash', { message: 'ENOMEM', name: 'SystemError' });
+    assert.ok(typeof sig === 'string');
+    assert.ok(sig.length === 8, 'should be 8-char hex');
+  });
+
+  it('returns 8-char hex string', () => {
+    const sig = stackSignature('crash', new Error('any'));
+    assert.match(sig, /^[0-9a-f]{8}$/);
+  });
+});
+
+// ============================================================================
+// Rate limiter tests
+// ============================================================================
+
+describe('rate limiting', () => {
+
+  it('allows up to maxPerHour reports', () => {
+    const reporter = createReporter({
+      crashReportEnabled: true,
+      crashReportPat: 'ghp_test',
+      crashReportRepo: 'test/repo',
+      crashReportRateLimit: 3,
+    });
+    const rl = reporter._rateLimiter;
+    assert.ok(rl.tryAcquire());
+    assert.ok(rl.tryAcquire());
+    assert.ok(rl.tryAcquire());
+    assert.ok(!rl.tryAcquire(), 'should reject 4th attempt');
+    reporter.stop();
+  });
+
+  it('expires old entries after 1 hour', () => {
+    const reporter = createReporter({
+      crashReportEnabled: true,
+      crashReportPat: 'ghp_test',
+      crashReportRepo: 'test/repo',
+      crashReportRateLimit: 2,
+    });
+    const rl = reporter._rateLimiter;
+    rl.timestamps = [Date.now() - 3700_000, Date.now() - 3600_001];
+    assert.ok(rl.tryAcquire(), 'old entries should be expired');
+    assert.ok(rl.tryAcquire(), 'second should work too');
+    assert.ok(!rl.tryAcquire(), 'third should fail');
+    reporter.stop();
+  });
+});
+
+// ============================================================================
+// Reporter lifecycle tests
+// ============================================================================
+
+describe('createReporter', () => {
+
+  it('returns no-op functions when disabled', async () => {
+    const reporter = createReporter({
+      crashReportEnabled: false,
+      crashReportPat: '',
+      crashReportRepo: '',
+    });
+    await reporter.reportCrash(new Error('test'));
+    await reporter.reportHang('navigate', 30000);
+    await reporter.reportStuckLoop(60000);
+    reporter.startWatchdog();
+    reporter.stop();
+  });
+
+  it('returns no-op when PAT is missing even if enabled', () => {
+    const reporter = createReporter({
+      crashReportEnabled: true,
+      crashReportPat: '',
+      crashReportRepo: 'test/repo',
+    });
+    assert.equal(reporter._rateLimiter, undefined);
+    reporter.stop();
+  });
+
+  it('exposes anonymize for testing even when disabled', () => {
+    const reporter = createReporter({ crashReportEnabled: false });
+    assert.equal(typeof reporter._anonymize, 'function');
+    assert.ok(reporter._anonymize('/Users/foo/bar/baz.js').includes('baz.js'));
+    assert.ok(!reporter._anonymize('/Users/foo/bar/baz.js').includes('foo'));
+  });
+
+  it('stop() resolves even with no in-flight reports', async () => {
+    const reporter = createReporter({
+      crashReportEnabled: true,
+      crashReportPat: 'ghp_test',
+      crashReportRepo: 'test/repo',
+    });
+    reporter.startWatchdog();
+    const result = await reporter.stop();
+    assert.ok(Array.isArray(result));
+  });
+});
+
+// ============================================================================
+// URL anonymizer tests
+// ============================================================================
+
+describe('createUrlAnonymizer', () => {
+
+  it('preserves public infra domains verbatim', () => {
+    const { anonymizeUrl } = createUrlAnonymizer();
+    const result = anonymizeUrl('https://challenges.cloudflare.com/cdn-cgi/challenge-platform/main.js');
+    assert.ok(result.includes('challenges.cloudflare.com'), `stripped public domain: ${result}`);
+    assert.ok(!result.includes('main.js'), `leaked filename: ${result}`);
+  });
+
+  it('hashes private domains', () => {
+    const { anonymizeUrl } = createUrlAnonymizer();
+    const result = anonymizeUrl('https://internal-dashboard.corp.example.com/admin/users');
+    assert.ok(!result.includes('internal-dashboard'), `leaked hostname: ${result}`);
+    assert.ok(!result.includes('corp.example.com'), `leaked domain: ${result}`);
+    assert.ok(result.startsWith('https://site-'), 'should hash domain');
+  });
+
+  it('strips all path segments, preserves depth', () => {
+    const { anonymizeUrl } = createUrlAnonymizer();
+    const result = anonymizeUrl('https://example.com/patients/john-doe/records/2024');
+    assert.ok(!result.includes('patients'), `leaked path: ${result}`);
+    assert.ok(!result.includes('john-doe'), `leaked PII: ${result}`);
+    // Should have 4 bullet points for 4 segments
+    const bullets = (result.match(/\u2022/g) || []).length;
+    assert.equal(bullets, 4, `expected 4 path segments, got ${bullets}: ${result}`);
+  });
+
+  it('strips query param names and values, preserves count', () => {
+    const { anonymizeUrl } = createUrlAnonymizer();
+    const result = anonymizeUrl('https://example.com/page?email=user@test.com&token=abc123&view=full');
+    assert.ok(!result.includes('email'), `leaked param name: ${result}`);
+    assert.ok(!result.includes('user@'), `leaked param value: ${result}`);
+    assert.ok(result.includes('?[3]'), `should show param count: ${result}`);
+  });
+
+  it('notes fragment presence without content', () => {
+    const { anonymizeUrl } = createUrlAnonymizer();
+    const result = anonymizeUrl('https://example.com/page#secret-section');
+    assert.ok(!result.includes('secret-section'), `leaked fragment: ${result}`);
+    assert.ok(result.includes('#[frag]'), `should note fragment: ${result}`);
+  });
+
+  it('preserves non-standard ports', () => {
+    const { anonymizeUrl } = createUrlAnonymizer();
+    const result = anonymizeUrl('https://example.com:8443/api');
+    assert.ok(result.includes(':8443'), `lost port: ${result}`);
+  });
+
+  it('same domain produces same hash within one anonymizer', () => {
+    const { anonymizeUrl } = createUrlAnonymizer();
+    const r1 = anonymizeUrl('https://mysite.com/page1');
+    const r2 = anonymizeUrl('https://mysite.com/page2');
+    // Extract the site-XXXXXXXX part
+    const hash1 = r1.match(/site-[a-f0-9]+/)?.[0];
+    const hash2 = r2.match(/site-[a-f0-9]+/)?.[0];
+    assert.equal(hash1, hash2, 'same domain should produce same hash');
+  });
+
+  it('different anonymizers produce different hashes (different salts)', () => {
+    const a1 = createUrlAnonymizer();
+    const a2 = createUrlAnonymizer();
+    const r1 = a1.anonymizeUrl('https://mysite.com/');
+    const r2 = a2.anonymizeUrl('https://mysite.com/');
+    const hash1 = r1.match(/site-[a-f0-9]+/)?.[0];
+    const hash2 = r2.match(/site-[a-f0-9]+/)?.[0];
+    assert.notEqual(hash1, hash2, 'different salts should produce different hashes');
+  });
+
+  it('hashes IP addresses', () => {
+    const { anonymizeUrl } = createUrlAnonymizer();
+    const result = anonymizeUrl('http://192.168.1.100:8080/api');
+    assert.ok(!result.includes('192.168'), `leaked IP: ${result}`);
+    assert.ok(result.includes('site-'), 'should hash IP');
+  });
+
+  it('preserves localhost', () => {
+    const { anonymizeUrl } = createUrlAnonymizer();
+    assert.ok(anonymizeUrl('http://localhost:3000/test').includes('localhost'));
+    assert.ok(anonymizeUrl('http://127.0.0.1:3000/test').includes('localhost'));
+  });
+
+  it('handles data/blob/javascript URIs', () => {
+    const { anonymizeUrl } = createUrlAnonymizer();
+    assert.equal(anonymizeUrl('data:text/html,<h1>secret</h1>'), '[data-uri]');
+    assert.equal(anonymizeUrl('blob:https://example.com/abc'), '[blob-uri]');
+    assert.equal(anonymizeUrl('javascript:alert(1)'), '[javascript-uri]');
+  });
+
+  it('handles empty/null/invalid input', () => {
+    const { anonymizeUrl } = createUrlAnonymizer();
+    assert.equal(anonymizeUrl(''), '[empty]');
+    assert.equal(anonymizeUrl(null), '[empty]');
+    assert.equal(anonymizeUrl('not-a-url'), '[invalid-url]');
+  });
+
+  it('anonymizes redirect chains with correlation', () => {
+    const { anonymizeChain } = createUrlAnonymizer();
+    const chain = [
+      'https://mysite.com/login',
+      'https://accounts.google.com/o/oauth2/auth?client_id=xxx',
+      'https://mysite.com/callback?code=yyy',
+    ];
+    const result = anonymizeChain(chain);
+    assert.ok(result.includes('accounts.google.com'), 'should preserve Google');
+    assert.ok(!result.includes('mysite.com'), `leaked domain: ${result}`);
+    assert.ok(result.includes('\u2192'), 'should have arrow separators');
+    // Both mysite.com entries should have same hash
+    const hashes = result.match(/site-[a-f0-9]+/g);
+    assert.equal(hashes[0], hashes[1], 'same domain should correlate in chain');
+  });
+
+  it('never leaks multi-tenant hosting domains', () => {
+    const { anonymizeUrl } = createUrlAnonymizer();
+    // These should all be hashed, not preserved
+    for (const url of [
+      'https://myapp.herokuapp.com/',
+      'https://myapp.vercel.app/',
+      'https://myapp.netlify.app/',
+      'https://myapp.fly.dev/',
+    ]) {
+      const result = anonymizeUrl(url);
+      assert.ok(result.includes('site-'), `should hash ${url}: ${result}`);
+    }
+  });
+
+  it('strips auth credentials from URLs', () => {
+    const { anonymizeUrl } = createUrlAnonymizer();
+    const result = anonymizeUrl('https://admin:secret@example.com/dashboard');
+    assert.ok(!result.includes('admin'), `leaked username: ${result}`);
+    assert.ok(!result.includes('secret'), `leaked password: ${result}`);
+  });
+});


### PR DESCRIPTION
## What

Opt-out crash reporter that files GitHub issues when sites cause persistent problems in headless browsing. Only fires on **frustration patterns** (3+ consecutive failures on the same tab), not individual errors.

## When it fires

A tab hits 3+ consecutive `timeout`, `dead_context`, or `nav_aborted` failures without a success in between. Any successful operation resets the counter.

## What the issue contains

1. **Failure journal** — sequence of what was tried: `["timeout:navigate", "timeout:navigate", "dead_context:click"]`
2. **Anonymized URL** — per-report salted HMAC for private domains, public infra verbatim, path depth only: `https://site-a1b2c3d4/•/•/• ?[2]`
3. **Tab health snapshot** — count-only Playwright event aggregates:
   - `pageErrors` / `consoleErrors` — broken JS, infinite re-renders
   - `requestFailures` — blocked/failed subresources
   - `statusCounts` — HTTP 403/429 storms (anti-bot detection)
   - `crashes` — renderer OOM/segfault
   - `dialogCount` — alert/confirm storms (auto-dismissed)
   - `maxRedirectDepth` — redirect loops
   - `frameCount` — iframe proliferation
4. **Anonymized stack trace** — filenames + line numbers preserved, all PII stripped
5. **Event loop watchdog** — fires immediately if Node event loop stalls >5s

## Privacy

- URLs: per-report salted HMAC hash (no cross-report correlation). Public infra (Cloudflare, Google, GitHub) preserved. Path segments → `•`, query params → count only.
- Text: strips file paths, IPs, tokens, secrets, env vars, Fly IDs, email addresses, proxy credentials, base64 blobs, jo-* app names.
- Health data: counts only, no content or URLs stored.
- GitHub PAT: fine-grained, issues:write on single repo only. Blast radius = spam issues.

## Config

- `CAMOFOX_CRASH_REPORT_ENABLED` — opt-out (default: enabled). Set to `false` to disable.
- `CAMOFOX_CRASH_REPORT_PAT` — GitHub PAT (required, issues:write scope)
- `CAMOFOX_CRASH_REPORT_REPO` — target repo (default: `jo-inc/camofox-browser`)
- `CAMOFOX_CRASH_REPORT_RATE_LIMIT` — max reports/hour (default: 10)

## What it does NOT report

- Individual failures (retryable noise)
- `stale_refs`, `click_intercepted`, `element_error` (resolve on retry)
- `browser_launch`, `network`, `proxy` (infra, not site-induced)
- `tab_lock_timeout` (server capacity)
- Screenshots or images
- URL content, path segments, query param names/values

## Files

| File | Lines | What |
|---|---|---|
| `lib/reporter.js` | 637 | Text anonymizer, URL anonymizer, tab health tracker, GitHub issue filing |
| `lib/config.js` | +5 | 4 env vars |
| `server.js` | +44 net | Frustration detection, health tracker on tabs, watchdog |
| `tests/unit/reporter.test.js` | 561 | 69 tests: anonymization, URL privacy, dedup, rate limiting |

## Non-blocking

All GitHub API calls are fire-and-forget with 5s AbortController timeout. Reporter failures are swallowed. Zero impact on request latency.