### PR TITLE
feat: add POST /tabs/:tabId/evaluate endpoint for JavaScript execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,19 @@ POST /tabs/:tabId/scroll
 {"userId": "agent1", "direction": "down", "amount": 500}
 ```
 
+### Evaluate JavaScript
+```bash
+POST /tabs/:tabId/evaluate
+{"userId": "agent1", "expression": "document.title"}
+```
+Returns: `{"ok": true, "result": "Page Title"}`
+
+Execute arbitrary JavaScript in the page context. Useful for:
+- Extracting data not visible in the accessibility tree (e.g., `data-*` attributes, hidden inputs)
+- Injecting values into form fields that don't have accessibility refs
+- Reading/writing cookies, localStorage, sessionStorage
+- Triggering JavaScript callbacks (e.g., reCAPTCHA response handlers)
+
 ### Navigation
 ```bash
 POST /tabs/:tabId/back     {"userId": "agent1"}

--- a/server.js
+++ b/server.js
@@ -3043,6 +3043,33 @@ app.post('/tabs/:tabId/scroll', async (req, res) => {
   }
 });
 
+// Evaluate JavaScript in page context
+app.post('/tabs/:tabId/evaluate', async (req, res) => {
+  const tabId = req.params.tabId;
+  
+  try {
+    const { userId, expression } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    if (!expression) return res.status(400).json({ error: 'expression required' });
+    
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, tabId);
+    if (!found) return res.status(404).json({ error: 'Tab not found' });
+    
+    const { tabState } = found;
+    tabState.toolCalls++;
+    
+    const result = await withTabLock(tabId, async () => {
+      return await tabState.page.evaluate(expression);
+    });
+    
+    res.json({ ok: true, result });
+  } catch (err) {
+    log('error', 'evaluate failed', { reqId: req.reqId, error: err.message });
+    res.status(500).json({ error: safeError(err) });
+  }
+});
+
 // Back
 /**
  * @openapi


### PR DESCRIPTION
## Summary

Adds a `POST /tabs/:tabId/evaluate` endpoint that executes arbitrary JavaScript in the page context using Playwright's `page.evaluate()`.

## Motivation

AI browser agents often need to interact with page elements that aren't exposed in the accessibility tree — hidden inputs, `data-*` attributes, CAPTCHA response fields, localStorage values, etc. Currently there's no way to read or write these from the API.

This is the minimum viable endpoint needed for:
- **CAPTCHA solving**: Extract `data-sitekey` attributes, inject solved tokens into `g-recaptcha-response` textareas
- **Data extraction**: Read hidden form values, meta tags, structured data not in the a11y tree
- **State manipulation**: Write to localStorage/sessionStorage, trigger JS callbacks

## Implementation

- Single new route handler following the same pattern as `/click`, `/type`, `/scroll`
- Uses `withTabLock()` for concurrency safety
- Increments `tabState.toolCalls` for stats tracking
- Returns `{ ok: true, result: <serializable-value> }` on success

## Usage

```bash
POST /tabs/:tabId/evaluate
{"userId": "agent1", "expression": "document.title"}
# Returns: {"ok": true, "result": "Example Domain"}

POST /tabs/:tabId/evaluate  
{"userId": "agent1", "expression": "document.querySelector('[data-sitekey]')?.getAttribute('data-sitekey')"}
# Returns: {"ok": true, "result": "6Le-xxxxx"}
```

## Testing

Manually verified against live pages (example.com, openweathermap.org). Expression execution, error handling, and tab locking all work correctly.