### PR TITLE
feat: POST /tabs/:tabId/viewport — physically resize page via Playwright

### DIFF
--- a/server.js
+++ b/server.js
@@ -3026,19 +3026,108 @@ app.post('/tabs/:tabId/scroll', async (req, res) => {
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, req.params.tabId);
     if (!found) return res.status(404).json({ error: 'Tab not found' });
-    
+
     const { tabState } = found;
     tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
-    
+
     const isVertical = direction === 'up' || direction === 'down';
     const delta = (direction === 'up' || direction === 'left') ? -amount : amount;
     await tabState.page.mouse.wheel(isVertical ? 0 : delta, isVertical ? delta : 0);
     await tabState.page.waitForTimeout(300);
-    
+
     pluginEvents.emit('tab:scroll', { userId, tabId: req.params.tabId, direction, amount });
     res.json({ ok: true });
   } catch (err) {
     log('error', 'scroll failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
+// Set viewport
+/**
+ * @openapi
+ * /tabs/{tabId}/viewport:
+ *   post:
+ *     tags: [Interaction]
+ *     summary: Set the page viewport size
+ *     description: >
+ *       Physically resizes the page via Playwright's `page.setViewportSize`,
+ *       triggering a real layout reflow. SPAs that listen for resize events
+ *       (responsive media queries, useMediaQuery hooks, ResizeObserver
+ *       subscribers) re-render correctly. Useful for responsive testing —
+ *       `evaluate(window.resizeTo(...))` is a no-op on non-popup windows in
+ *       most browsers.
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId, width, height]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *               width:
+ *                 type: integer
+ *                 minimum: 100
+ *                 maximum: 4000
+ *                 description: Viewport width in CSS pixels.
+ *               height:
+ *                 type: integer
+ *                 minimum: 100
+ *                 maximum: 4000
+ *                 description: Viewport height in CSS pixels.
+ *     responses:
+ *       200:
+ *         description: Viewport set.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                 width:
+ *                   type: integer
+ *                 height:
+ *                   type: integer
+ *       400:
+ *         description: Width or height missing or out of range.
+ *       404:
+ *         description: Tab not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+app.post('/tabs/:tabId/viewport', async (req, res) => {
+  try {
+    const { userId, width, height } = req.body;
+    if (typeof width !== 'number' || typeof height !== 'number' || width < 100 || height < 100 || width > 4000 || height > 4000) {
+      return res.status(400).json({ error: 'width and height required (100..4000 px)' });
+    }
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, req.params.tabId);
+    if (!found) return res.status(404).json({ error: 'Tab not found' });
+
+    const { tabState } = found;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
+
+    await tabState.page.setViewportSize({ width: Math.round(width), height: Math.round(height) });
+    // Settle for SPAs that re-render on viewport change (media queries,
+    // ResizeObserver subscribers, useMediaQuery hooks).
+    await tabState.page.waitForTimeout(150);
+
+    pluginEvents.emit('tab:viewport', { userId, tabId: req.params.tabId, width, height });
+    res.json({ ok: true, width: Math.round(width), height: Math.round(height) });
+  } catch (err) {
+    log('error', 'viewport failed', { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
   }
 });


### PR DESCRIPTION
## Summary

Adds a new endpoint that wraps Playwright's `page.setViewportSize({width, height})` so clients can trigger a real layout reflow.

The current workaround for tools that need responsive testing — clients calling `evaluate(window.resizeTo(...))` — is a no-op on non-popup windows in most modern browsers. This route is the correct primitive for headless test runners and visual-regression tools that capture each page at multiple viewports (e.g. mobile / tablet / desktop).

## Behavior

- Method: `POST /tabs/:tabId/viewport`
- Body: `{userId, width, height}` — width/height are CSS pixels in [100, 4000]
- Returns `{ok: true, width, height}` on success, 400 when out of range, 404 on unknown tab
- 150ms settle after resize so SPAs that re-render on viewport change (media queries, ResizeObserver subscribers, useMediaQuery hooks) have a chance to settle before the response

Mirrors the existing `/scroll` route shape: same error handling, same plugin event emit (`tab:viewport`), same OpenAPI documentation pattern (`@openapi` JSDoc above the handler).

## Use case

BugHunter's v0.17 multi-viewport responsive vision pass needs to capture each authenticated route at 375 / 768 / 1280 px to surface mobile-only bugs (table no horizontal-scroll, modals fullscreen on phone, sidebar-collapse failing). The matching `set_viewport` MCP tool was just added to camofox-mcp and routes to this endpoint.

## Notes

- Camoufox's stealth layer may continue to report fingerprint-resistant values for `window.innerWidth` / `screen.width` regardless of viewport — this is an orthogonal concern. The viewport set IS applied at the rendering layer (screenshots reflect the new size); JS-side overrides are a separate fingerprinting feature, not a viewport-set bug.
- Single test commit; no test suite included — happy to add a smoke test at `tests/integration/viewport.test.js` if useful, just point me at the test convention.

## Test plan

- [x] Manual smoke: `POST /tabs/<id>/viewport` with width=375, height=244 returns `{ok:true, width:375, height:244}` on a live tab
- [x] Manual smoke: `POST /tabs/<bad>/viewport` returns 404
- [x] Manual smoke: `POST /tabs/<id>/viewport` with width=50 returns 400