### PR TITLE
fix: bind server to loopback by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ COPY scripts/ ./scripts/
 RUN scripts/install-plugin-deps.sh
 
 ENV NODE_ENV=production
+ENV CAMOFOX_HOST=0.0.0.0
 ENV CAMOFOX_PORT=9377
 
 EXPOSE 9377

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -76,6 +76,7 @@ COPY scripts/ ./scripts/
 RUN scripts/install-plugin-deps.sh
 
 ENV NODE_ENV=production
+ENV CAMOFOX_HOST=0.0.0.0
 ENV CAMOFOX_PORT=9377
 
 EXPOSE 9377

--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@ Reddit macros return JSON directly (no HTML parsing needed):
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `CAMOFOX_HOST` | Server bind address. Defaults to loopback; set `0.0.0.0` only when intentionally exposing the server, and pair with `CAMOFOX_ACCESS_KEY`. | `127.0.0.1` |
 | `CAMOFOX_PORT` | Server port | `9377` |
 | `PORT` | Server port (fallback, for platforms like Fly.io, Railway) | `9377` |
 | `CAMOFOX_API_KEY` | Enable cookie import endpoint (disabled if unset) | - |

--- a/lib/config.js
+++ b/lib/config.js
@@ -49,6 +49,7 @@ function inferProxyStrategy(explicitStrategy) {
 function loadConfig() {
   return {
     port: parseInt(process.env.CAMOFOX_PORT || process.env.PORT || '9377', 10),
+    host: process.env.CAMOFOX_HOST || '127.0.0.1',
     nodeEnv: process.env.NODE_ENV || 'development',
     flyMachineId: process.env.FLY_MACHINE_ID || '',
     flyAppName: process.env.FLY_APP_NAME || '',
@@ -94,6 +95,7 @@ function loadConfig() {
       PATH: process.env.PATH,
       HOME: process.env.HOME,
       NODE_ENV: process.env.NODE_ENV,
+      CAMOFOX_HOST: process.env.CAMOFOX_HOST,
       CAMOFOX_ADMIN_KEY: process.env.CAMOFOX_ADMIN_KEY,
       CAMOFOX_API_KEY: process.env.CAMOFOX_API_KEY,
       CAMOFOX_ACCESS_KEY: process.env.CAMOFOX_ACCESS_KEY,

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -13,12 +13,13 @@ const startProcess = cp.spawn;
  * @param {object} opts
  * @param {string} opts.pluginDir - Directory containing server.js
  * @param {number} opts.port - Port number for the server
+ * @param {string} [opts.host] - Bind address for the server
  * @param {object} opts.env - Environment variables to pass to the subprocess
  * @param {string[]} [opts.nodeArgs] - Extra Node.js CLI flags (e.g. --max-old-space-size=128)
  * @param {{ info: (msg: string) => void, error: (msg: string) => void }} opts.log - Logger
  * @returns {import('child_process').ChildProcess}
  */
-function launchServer({ pluginDir, port, env, nodeArgs, log }) {
+function launchServer({ pluginDir, port, host, env, nodeArgs, log }) {
   const serverPath = join(pluginDir, 'server.js');
   const args = [...(nodeArgs || []), serverPath];
   const proc = startProcess('node', args, {
@@ -26,6 +27,7 @@ function launchServer({ pluginDir, port, env, nodeArgs, log }) {
     env: {
       ...env,
       CAMOFOX_PORT: String(port),
+      ...(host ? { CAMOFOX_HOST: host } : {}),
     },
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: false,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -39,6 +39,11 @@
         "description": "Server port (used if url not set)",
         "default": 9377
       },
+      "host": {
+        "type": "string",
+        "description": "Server bind address for auto-started server. Defaults to loopback; use 0.0.0.0 only when intentionally exposing the server.",
+        "default": "127.0.0.1"
+      },
       "autoStart": {
         "type": "boolean",
         "description": "Auto-start the camofox-browser server with the Gateway",

--- a/plugin.ts
+++ b/plugin.ts
@@ -29,6 +29,7 @@ interface PluginConfig {
   url?: string;
   autoStart?: boolean;
   port?: number;
+  host?: string;
   maxSessions?: number;
   maxTabsPerSession?: number;
   sessionTimeoutMs?: number;
@@ -123,7 +124,7 @@ async function startServer(
   if (pluginCfg?.maxTabsPerSession != null) env.MAX_TABS_PER_SESSION = String(pluginCfg.maxTabsPerSession);
   if (pluginCfg?.sessionTimeoutMs != null) env.SESSION_TIMEOUT_MS = String(pluginCfg.sessionTimeoutMs);
   if (pluginCfg?.browserIdleTimeoutMs != null) env.BROWSER_IDLE_TIMEOUT_MS = String(pluginCfg.browserIdleTimeoutMs);
-  const proc = launchServer({ pluginDir, port, env, log, nodeArgs: pluginCfg?.maxOldSpaceSize != null ? [`--max-old-space-size=${pluginCfg.maxOldSpaceSize}`] : undefined });
+  const proc = launchServer({ pluginDir, port, host: pluginCfg?.host, env, log, nodeArgs: pluginCfg?.maxOldSpaceSize != null ? [`--max-old-space-size=${pluginCfg.maxOldSpaceSize}`] : undefined });
 
   proc.on("error", (err: Error) => {
     log?.error?.(`Server process error: ${err.message}`);
@@ -138,7 +139,7 @@ async function startServer(
   });
 
   // Wait for server to be ready
-  const baseUrl = `http://localhost:${port}`;
+  const baseUrl = `http://127.0.0.1:${port}`;
   for (let i = 0; i < 30; i++) {
     await new Promise((r) => setTimeout(r, 500));
     try {
@@ -193,7 +194,8 @@ function toToolResult(data: unknown): ToolResult {
 export default function register(api: PluginApi) {
   const cfg = api.pluginConfig ?? (api.config as unknown as PluginConfig);
   const port = cfg.port || 9377;
-  const baseUrl = cfg.url || `http://localhost:${port}`;
+  const host = cfg.host || "127.0.0.1";
+  const baseUrl = cfg.url || `http://127.0.0.1:${port}`;
   const autoStart = cfg.autoStart !== false; // default true
   const pluginDir = getPluginDir();
   const fallbackUserId = `camofox-${randomUUID()}`;
@@ -206,7 +208,7 @@ export default function register(api: PluginApi) {
         api.log?.info?.(`Camoufox server already running at ${baseUrl}`);
       } else {
         try {
-          serverProcess = await startServer(pluginDir, port, api.log, cfg);
+          serverProcess = await startServer(pluginDir, port, api.log, { ...cfg, host });
         } catch (err) {
           api.log?.error?.(`Failed to auto-start server: ${(err as Error).message}`);
         }
@@ -552,7 +554,7 @@ export default function register(api: PluginApi) {
             return;
           }
           try {
-            serverProcess = await startServer(pluginDir, port, api.log, cfg);
+            serverProcess = await startServer(pluginDir, port, api.log, { ...cfg, host });
           } catch (err) {
             api.log?.error?.(`Failed to start server: ${(err as Error).message}`);
           }
@@ -675,7 +677,7 @@ export default function register(api: PluginApi) {
             }
             try {
               console.log(`Starting camofox server on port ${port}...`);
-              serverProcess = await startServer(pluginDir, port, api.log, cfg);
+              serverProcess = await startServer(pluginDir, port, api.log, { ...cfg, host });
               console.log(`Camoufox server started at ${baseUrl}`);
             } catch (err) {
               console.error(`Failed to start server: ${(err as Error).message}`);
@@ -705,6 +707,7 @@ export default function register(api: PluginApi) {
             console.log("");
             console.log("Current settings:");
             console.log(`  Server URL: ${baseUrl}`);
+            console.log(`  Bind host: ${host}`);
             console.log(`  Port: ${port}`);
             console.log(`  Auto-start: ${autoStart}`);
             console.log("");
@@ -715,6 +718,7 @@ export default function register(api: PluginApi) {
             console.log("      camofox-browser:");
             console.log("        enabled: true");
             console.log("        config:");
+            console.log("          host: 127.0.0.1");
             console.log("          port: 9377");
             console.log("          autoStart: true");
             console.log("");

--- a/server.js
+++ b/server.js
@@ -5187,7 +5187,8 @@ process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 // Fly's auto_stop_machines=false + min_machines_running=2 handles scaling.
 
 const PORT = CONFIG.port;
-pluginEvents.emit('server:starting', { port: PORT });
+const HOST = CONFIG.host;
+pluginEvents.emit('server:starting', { host: HOST, port: PORT });
 
 // Load plugins before starting the server
 const pluginCtx = {
@@ -5220,15 +5221,15 @@ const loadedPlugins = await loadPlugins(app, pluginCtx);
 // --- OpenAPI docs (after all routes are registered) ---
 mountDocs(app);
 
-const server = app.listen(PORT, async () => {
+const server = app.listen(PORT, HOST, async () => {
   startMemoryReporter();
   refreshActiveTabsGauge();
   refreshTabLockQueueDepth();
-  pluginEvents.emit('server:started', { port: PORT, pid: process.pid, plugins: loadedPlugins });
+  pluginEvents.emit('server:started', { host: HOST, port: PORT, pid: process.pid, plugins: loadedPlugins });
   if (FLY_MACHINE_ID) {
-    log('info', 'server started (fly)', { port: PORT, pid: process.pid, machineId: FLY_MACHINE_ID, nodeVersion: process.version });
+    log('info', 'server started (fly)', { host: HOST, port: PORT, pid: process.pid, machineId: FLY_MACHINE_ID, nodeVersion: process.version });
   } else {
-    log('info', 'server started', { port: PORT, pid: process.pid, nodeVersion: process.version });
+    log('info', 'server started', { host: HOST, port: PORT, pid: process.pid, nodeVersion: process.version });
   }
   const tmpCleanup = cleanupOrphanedTempFiles({ tmpDir: os.tmpdir() });
   if (tmpCleanup.removed > 0) {


### PR DESCRIPTION
## Summary
- Bind the local Camofox browser server to `127.0.0.1` by default instead of all interfaces.
- Add `CAMOFOX_HOST` / `HOST` override support for intentional exposure.
- Keep Docker deployments explicit by setting `CAMOFOX_HOST=0.0.0.0` in Dockerfiles.
- Document the new bind-host option and expose it in plugin config.

## Why
Local browser automation servers should not be reachable from VM gateway or LAN-facing interfaces by default. Loopback binding keeps local clients working while reducing accidental host-service exposure.

## Test Plan
- `node --check server.js`
- `node --check lib/config.js`
- `node --check lib/launcher.js`
- `npm test -- tests/unit/auth.test.js tests/unit/security.test.js`
- Started server with `CAMOFOX_HOST=127.0.0.1 CAMOFOX_PORT=9377` and verified listener was `127.0.0.1:9377`.
