### PR TITLE
fix(tabs): force-close on safePageClose timeout + reap orphan pages (BugHunter#174)

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,19 @@ curl -X POST http://localhost:9377/tabs/TAB_ID/navigate \
 | `POST` | `/tabs/:id/forward` | Go forward |
 | `POST` | `/tabs/:id/refresh` | Refresh page |
 
+### BugHunter Integration (V20 / V22 / V23)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/tabs/:id/network-fault` | Install a network fault (offline, slow_3g, high_latency, timeout_at_request, timeout_at_response, intermittent, server_5xx, malformed_response) |
+| `POST` | `/tabs/:id/clear-network-fault` | Remove the active network fault (idempotent) |
+| `GET` | `/tabs/:id/network-fault` | Read the active network fault state |
+| `GET` | `/tabs/:id/in-flight-requests` | List in-flight requests tracked since last navigation |
+| `POST` | `/tabs/:id/init-script` | Register a JS snippet to run before page code on each new document |
+| `POST` | `/tabs/:id/clear-init-scripts` | Dispose all registered init-scripts (caller must reload to fully clear) |
+| `POST` | `/tabs/:id/timezone` | Override the page timezone via an init-script polyfill (reload required) |
+| `POST` | `/tabs/:id/clear-timezone` | Remove the timezone override (idempotent) |
+
 ### YouTube Transcript
 
 | Method | Endpoint | Description |

--- a/SPEC_BUGHUNTER_INTEGRATION.md
+++ b/SPEC_BUGHUNTER_INTEGRATION.md
@@ -1,0 +1,571 @@
+# camofox-browser — BugHunter integration spec (V20 / V22 / V23)
+
+**Status:** Draft 1 — ready for `@coder` decomposition · **Author:** `@architect` (Opus, ultrathink) · **Date:** 2026-04-30 · **For implementation by:** `@coder` (Sonnet)
+
+This spec adds eight new HTTP endpoints to camofox-browser to unblock three BugHunter test modes:
+
+- **V20** (network-fault injection) — `POST /tabs/:tabId/network-fault`, `POST /tabs/:tabId/clear-network-fault`, `GET /tabs/:tabId/network-fault`. Drives offline / latency / failure / corruption scenarios so BugHunter can observe how the app degrades. Driven by `BugHunter/SPEC_V20_NETWORK_FAULTS.md`.
+- **V22** (in-flight request enumeration) — `GET /tabs/:tabId/in-flight-requests`. Returns the set of `request` events the page has emitted but not yet matched with `requestfinished` / `requestfailed`. Drives `InterimState.inFlightRequests` in `BugHunter/SPEC_V22_NAV_STATE.md` § 3.3 / § 3.5; without this the V22 executor hard-codes `[]`.
+- **V23** (time / clock injection) — `POST /tabs/:tabId/init-script`, `POST /tabs/:tabId/clear-init-scripts`, `POST /tabs/:tabId/timezone`, `POST /tabs/:tabId/clear-timezone`. Lets BugHunter install a `Date` polyfill before app code runs, and override the timezone the page sees. Driven by `BugHunter/SPEC_V23_TIME_CLOCK.md`.
+
+The matching MCP wrappers live in `cunninghambe/camofox-mcp` and are specced separately in that repo's `SPEC_BUGHUNTER_INTEGRATION.md`. Tool-name and shape parity between the two specs is a hard requirement.
+
+---
+
+## 1. Problem Statement
+
+BugHunter walks an SPA, drives mutating actions, and classifies what breaks. Three classes of bugs require *environmental* injection — making the network slow, refreshing mid-mutation while observing what was in-flight, jumping the clock to next year — and there is currently no camofox primitive for any of them. BugHunter's V22 implementation already ships with `inFlightRequests` hard-wired to `[]` because no MCP tool exposes the data; V20 and V23 cannot ship at all without new endpoints.
+
+This spec adds the eight endpoints those three modes need. All three modes are pure observation — no new automation, no new auth, no schema migrations on the camofox side. Each endpoint maps to one or two Playwright primitives that are already reachable via the existing `tabState.page` / `session.context` handles.
+
+## 2. Boundaries
+
+### In scope (this PR)
+
+- **Network conditioning**:
+  - `POST /tabs/:tabId/network-fault` with `{ mode, latencyMs?, percent?, statusCode? }`. Modes: `offline`, `slow_3g`, `high_latency`, `timeout_at_request`, `timeout_at_response`, `intermittent`, `server_5xx`, `malformed_response`.
+  - `POST /tabs/:tabId/clear-network-fault` removes the active fault and restores normal network behaviour.
+  - `GET /tabs/:tabId/network-fault` returns the currently-active fault (for diagnostics and idempotent re-checks).
+- **In-flight request enumeration**:
+  - `GET /tabs/:tabId/in-flight-requests` returns `{ requests: Array<{ method, url, path, startedAtMs, resourceType }>, capturedAtMs }`.
+  - Backed by a per-page `Map<Request, RequestRecord>` populated on `page.on('request')` and drained on `page.on('requestfinished')` / `page.on('requestfailed')`.
+- **Init-script injection**:
+  - `POST /tabs/:tabId/init-script` with `{ script, id? }` — wraps `page.addInitScript(script)`. Returns `{ id, ok }`.
+  - `POST /tabs/:tabId/clear-init-scripts` — drops the per-tab registry of installed scripts. Documented caveat: Playwright has no first-class "remove init script" API; clearing requires the page to be **reloaded into a fresh document for the scripts to actually stop running on subsequent navigations**. See § 7 edge case 6.
+- **Timezone override**:
+  - `POST /tabs/:tabId/timezone` with `{ id }` (IANA timezone, e.g. `"America/New_York"`).
+  - `POST /tabs/:tabId/clear-timezone` — restores the context's creation-time timezone.
+
+### Out of scope (this PR)
+
+- New MCP tools — that's the sibling spec in `camofox-mcp`.
+- Geolocation, locale, color-scheme, or any non-time non-network emulation. Open one spec at a time.
+- Per-request fault patterns beyond the eight modes listed (e.g. "fail every 3rd POST to `/api/x` only when the user-agent matches Y"). The eight modes cover the full V20 surface; finer-grained injection waits for evidence.
+- Programmatic introspection of the route handler (e.g. "how many requests have been faulted so far"). Stats are picked up from the existing Prometheus metrics surface if needed; not a new endpoint.
+- Persisting fault state across `tabState.page` recreations. A faulted tab whose page is replaced (auto-recover, crash-restart) starts clean. Documented in § 7 edge case 5.
+- BFCache or service-worker cache override. Not in scope; see V22 § 2 out-of-scope for the equivalent statement.
+- Removing the `page.addInitScript` Disposable returned in Playwright 1.50+. We hold the disposable on the per-tab registry, but there is no public `dispose()` semantics in Playwright that uninstalls a script from already-loaded documents — only future ones. Calling `.dispose()` is a best-effort hook; see § 4.4.
+- Auth changes. All endpoints reuse the existing `userId` lookup envelope; no new tokens, no new secrets. Endpoints accessing the cookie jar are out of scope here entirely.
+
+### External dependencies
+
+- Playwright `BrowserContext.setOffline()` (verified in `node_modules/playwright-core/types/types.d.ts:9395`).
+- Playwright `BrowserContext.route(url, handler)` and `unrouteAll(options?)` (verified at `:9535`).
+- Playwright `Page.on('request' | 'requestfinished' | 'requestfailed', ...)` (verified at `:1190`, `:1209`, `:1215`).
+- Playwright `Page.addInitScript(script)` returning `Disposable` (verified at `:318`; class `Page` at `:8294`).
+- **Not** available in this Playwright version on Firefox: `BrowserContext.setTimezoneId(id)` as a runtime mutator. `timezoneId` is a creation-time-only context option (verified by absence of a `setTimezoneId` member on `BrowserContext` in the type defs — only the `timezoneId?: string` property on `BrowserNewContextOptions`). `CDPSession.send('Emulation.setTimezoneOverride')` is Chromium-only and unavailable in Firefox. **§ 4.6 documents the chosen alternative: `page.addInitScript`-based timezone polyfill.**
+- No new npm dependencies.
+
+## 3. Existing Code to Reuse
+
+### Files you MUST read before writing any code
+
+- `server.js` lines 2016–2129 (`POST /tabs`) — session creation flow including `session.context.newPage()`, where per-page event listeners must be wired.
+- `server.js` lines 2131–2340 (`POST /tabs/:tabId/navigate`) — auth-envelope and `findTab` pattern for tab-scoped routes; copy verbatim.
+- `server.js` lines 3109–3133 (`POST /tabs/:tabId/viewport`) — closest analogue for a simple write-side tab endpoint that delegates to a single Playwright call.
+- `server.js` lines 3177–3210 (`POST /tabs/:tabId/back`) — shows the `withTabLock(tabId, async () => {...})` pattern for routes that can race with concurrent navigation. Network-fault writes MUST hold the tab lock; in-flight reads do NOT need it.
+- `server.js` lines 3756–3892 (`POST /tabs/:tabId/evaluate`) — the largest tab-scoped POST; shows `express.json({ limit })` and `safeError(err)` usage for routes that take untrusted text input. Copy the limit guard for `/init-script`.
+- `server.js` lines 3968–4028 (`DELETE /tabs/:tabId`) — teardown path; the in-flight tracker MUST register a teardown hook here so the per-page Maps are released.
+- `server.js` lines 1043–1100 (session creation) — shows how `contextOptions.timezoneId = 'America/Los_Angeles'` is the only place a timezone is set today. The new `/timezone` endpoint must NOT mutate context creation; it operates per-page via init-script.
+- `server.js` line 293 (`POST /sessions/:userId/cookies`) — security envelope reference (loopback / API key). Network-fault endpoints reuse the existing per-tab envelope (no `CAMOFOX_API_KEY` requirement); they do not touch credentials.
+- `lib/` directory — utility helpers including `safeError`, `classifyError`, `withTabLock`, `findTab`, `normalizeUserId`. Reuse all of these. **Do not reimplement any of them.**
+
+### Patterns to follow
+
+- **Tab lookup**: `const session = sessions.get(normalizeUserId(userId)); const found = session && findTab(session, req.params.tabId); if (!found) return res.status(404).json({ error: 'Tab not found' });`. Verbatim across every route added in this PR.
+- **Per-tab state**: store new state on `tabState.networkFault`, `tabState.inFlight`, `tabState.initScripts`, `tabState.timezoneInitScriptId`. The `tabState` object is created in `POST /tabs`; extending it is additive.
+- **Error envelope**: catch at the top level, `log('error', '<route> failed', { reqId, error: err.message })`, then `handleRouteError(err, req, res)`. Same as every existing route.
+- **Metrics**: increment `failuresTotal.labels(classifyError(err), '<route_name>').inc()` on the failure path, matching `/snapshot` and the cookies route precedent.
+- **Plugin events**: emit `pluginEvents.emit('tab:<event>', payload)` for state-changing routes (mirror the `tab:viewport` emit at `server.js:3127`). New events: `tab:network_fault_set`, `tab:network_fault_cleared`, `tab:init_script_added`, `tab:init_scripts_cleared`, `tab:timezone_set`, `tab:timezone_cleared`. Read-only routes (`GET /network-fault`, `GET /in-flight-requests`) emit nothing.
+
+### DO NOT
+
+- Do NOT add new files under `lib/` or `plugins/`. Everything lands in `server.js`. The other tab routes live in `server.js`; uniformity matters.
+- Do NOT touch `session.context.newContext` creation. Timezone override is per-page via init-script; it does NOT replace context creation.
+- Do NOT introduce a new top-level `/network-fault` route (without `/tabs/:tabId`). All faults are tab-scoped — they wire on the page's context but the lifecycle is owned by the tab.
+- Do NOT use `page.route()` for V20 fault injection. The fault must apply to ALL tabs in the same context if BugHunter has multiple tabs open against the same SPA. Use `session.context.route()`. § 4.1 details the per-context-with-tab-tagging design.
+- Do NOT block the route on the in-flight set. `GET /in-flight-requests` must return synchronously from the in-memory tracker; do not query Playwright at request time.
+- Do NOT clear in-flight tracker entries on `requestfinished`'s response status. Track until the *request* lifecycle ends, regardless of HTTP status. The V22 classifier discriminates 200 vs 5xx separately.
+- Do NOT echo the user's `script` body in success responses. The init-script payload may contain secrets (test fixtures); echo only the `id`.
+- Do NOT auto-clear faults on navigation. BugHunter explicitly clears them when done; auto-clearing would break refresh-mid-mutation (V22 + V20 chained).
+- Do NOT add a `force: true` parameter that bypasses tab locks. Faults during a navigation are explicitly part of the V22 / V20 surface; the lock acquisition has a 10 s ceiling already.
+- Do NOT add a websocket / SSE channel for in-flight events. BugHunter polls; the latency is acceptable.
+
+## 4. Interface Contract — new endpoints
+
+All eight endpoints follow the existing tab-scoped envelope:
+
+- Auth: same as the existing tab routes (loopback or `CAMOFOX_API_KEY` bearer; per-tab `userId` lookup).
+- Body content type: `application/json` (write endpoints).
+- Response content type: `application/json`.
+- Common error shape: `{ error: string }` with HTTP 400 / 404 / 500.
+
+### 4.1 `POST /tabs/:tabId/network-fault` — install fault
+
+**Driven by:** BugHunter `SPEC_V20_NETWORK_FAULTS.md` § "Browser primitive" (all eight modes route through this single endpoint).
+
+**Request body:**
+
+```ts
+type NetworkFaultRequest = {
+  userId: string;
+  mode:
+    | 'offline'
+    | 'slow_3g'
+    | 'high_latency'
+    | 'timeout_at_request'
+    | 'timeout_at_response'
+    | 'intermittent'
+    | 'server_5xx'
+    | 'malformed_response';
+  /** Required for 'high_latency'. Accepted for 'slow_3g' as override (default 2000). Rejected for others. */
+  latencyMs?: number;
+  /** Required for 'intermittent'. Range 1..99 inclusive. Rejected for others. */
+  percent?: number;
+  /** Required for 'server_5xx'. Range 500..599. Defaults to 503. Rejected for others. */
+  statusCode?: number;
+  /**
+   * Optional URL-glob to scope the fault. Defaults to '**\/api/**' for fault modes that target XHR/fetch
+   * (everything except 'offline', which is whole-context). Pass '**\/*' for blanket faulting.
+   */
+  urlGlob?: string;
+};
+```
+
+**Response (success, 200):**
+
+```ts
+type NetworkFaultResponse = {
+  ok: true;
+  tabId: string;
+  fault: {
+    mode: NetworkFaultRequest['mode'];
+    latencyMs?: number;
+    percent?: number;
+    statusCode?: number;
+    urlGlob?: string;
+    installedAtMs: number; // Date.now() when fault took effect
+  };
+};
+```
+
+**Mode → Playwright primitive mapping:**
+
+| `mode` | Driver | Per-request handler |
+|---|---|---|
+| `offline` | `session.context.setOffline(true)` | n/a (whole-context kill switch) |
+| `slow_3g` | `session.context.route(urlGlob, handler)` | `await sleep(latencyMs ?? 2000); await route.continue();` |
+| `high_latency` | `session.context.route(urlGlob, handler)` | `await sleep(latencyMs); await route.continue();` (latencyMs required, ≥ 1, ≤ 120000) |
+| `timeout_at_request` | `session.context.route(urlGlob, handler)` | `await sleep(120000); await route.abort('timedout');` (effectively never resolves within the test budget) |
+| `timeout_at_response` | `session.context.route(urlGlob, handler)` | `await route.continue(); /* response stalls upstream — emulate by NOT calling continue/fulfill, simulating a hung response */`. **Implementation:** `setTimeout(() => route.abort('timedout'), 120000)` — let request go, then time it out. |
+| `intermittent` | `session.context.route(urlGlob, handler)` | `if (Math.random() * 100 < percent) await route.abort('failed'); else await route.continue();` |
+| `server_5xx` | `session.context.route(urlGlob, handler)` | `await route.fulfill({ status: statusCode, contentType: 'application/json', body: JSON.stringify({ error: 'Injected fault' }) });` |
+| `malformed_response` | `session.context.route(urlGlob, handler)` | `await route.fulfill({ status: 200, contentType: 'application/json', body: '{"truncated":' });` (intentional invalid JSON) |
+
+**Single-fault invariant.** Only one fault active per tab. Calling `POST /network-fault` while a fault is already installed returns `409 Conflict` with `{ error: 'Fault already active. Call POST /tabs/:tabId/clear-network-fault first.', existing: <current fault> }`. The coder may instead choose to replace-and-warn, but the spec defaults to **explicit-clear-required** — two installs back-to-back is a planner bug, not a feature.
+
+**Per-context vs per-tab scope.** The Playwright `route()` and `setOffline()` methods are per-context (i.e. shared across all tabs in the same context). This is correct for V20: BugHunter typically opens one tab per test against one SPA, so per-context = per-tab in practice. **Documented:** if BugHunter ever opens two tabs in the same context, faulting tab A also faults tab B until cleared. Tracked under `tabState.networkFault` for each tab independently for diagnostic purposes; the actual Playwright handler is registered once on `session.context` and torn down when the LAST faulted tab clears. Reference-counted.
+
+**Validation:**
+- `mode` is required and must be one of the eight listed values → 400 `{error: 'Invalid mode: <value>'}` otherwise.
+- `latencyMs` required iff mode ∈ `{ high_latency, slow_3g, timeout_at_request, timeout_at_response }` (the last two ignore the value but accept it without error). Range 1..120000.
+- `percent` required iff mode = `intermittent`. Range 1..99.
+- `statusCode` accepted iff mode = `server_5xx`. Range 500..599. Defaults to 503.
+- `urlGlob` accepted for all modes except `offline` (silently ignored for `offline`).
+- Reject any of the above when set on a mode that doesn't accept them: 400 `{error: '<param> not valid for mode <mode>'}`.
+
+### 4.2 `POST /tabs/:tabId/clear-network-fault` — remove fault
+
+**Request body:** `{ userId: string }`
+
+**Response (200):** `{ ok: true, tabId, cleared: <previous fault state | null> }`. Returns `cleared: null` when no fault was active (idempotent — does NOT 404).
+
+**Behaviour:**
+- If `tabState.networkFault.mode === 'offline'`: `await session.context.setOffline(false)`.
+- Else: decrement the per-context reference count for the active route handler. When count reaches zero, call `session.context.unrouteAll({ behavior: 'wait' })` to drain in-flight handler invocations cleanly. Document `behavior: 'wait'` as the chosen mode (other options: `'ignoreErrors'`, `'default'` — `wait` is the safest for tests).
+- Clear `tabState.networkFault`.
+- Emit `pluginEvents.emit('tab:network_fault_cleared', { userId, tabId })`.
+
+### 4.3 `GET /tabs/:tabId/network-fault` — read fault state
+
+**Query params:** `?userId=<id>`
+
+**Response (200):**
+
+```ts
+{
+  tabId: string;
+  fault: NetworkFaultResponse['fault'] | null; // null if no fault active
+}
+```
+
+Read-only; does not require `withTabLock`. Used for diagnostics and as an idempotent-check during BugHunter's planner phase before a chained test.
+
+### 4.4 `GET /tabs/:tabId/in-flight-requests` — read in-flight tracker
+
+**Driven by:** BugHunter `SPEC_V22_NAV_STATE.md` § 3.3 (`InterimState.inFlightRequests`) and § 3.5 (capture between seed-fire and refresh-mid-mutation). The current V22 hard-codes `[]` because no mechanism exists.
+
+**Query params:** `?userId=<id>&methods=<csv>`
+
+- `methods` optional, default `'GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS'`. Comma-separated. Restrict to mutating-only with `methods=POST,PUT,PATCH,DELETE`.
+
+**Response (200):**
+
+```ts
+type InFlightResponse = {
+  tabId: string;
+  capturedAtMs: number;
+  requests: Array<{
+    method: string;             // uppercase
+    url: string;                // full URL
+    path: string;               // pathname only (host stripped); matches V22 cluster signature shape
+    startedAtMs: number;        // Date.now() when 'request' event fired
+    resourceType: string;       // 'fetch' | 'xhr' | 'document' | 'image' | etc. (from Playwright's request.resourceType())
+  }>;
+};
+```
+
+**Implementation:**
+
+When a tab is created in `POST /tabs` (or restored after auto-recovery), wire three listeners on `tabState.page`:
+
+```js
+const inFlight = new Map(); // Map<Request, { method, url, path, startedAtMs, resourceType }>
+tabState.page.on('request', (request) => {
+  inFlight.set(request, {
+    method: request.method().toUpperCase(),
+    url: request.url(),
+    path: safeUrlPath(request.url()),
+    startedAtMs: Date.now(),
+    resourceType: request.resourceType(),
+  });
+});
+const drop = (request) => inFlight.delete(request);
+tabState.page.on('requestfinished', drop);
+tabState.page.on('requestfailed', drop);
+tabState.inFlight = inFlight;
+```
+
+`safeUrlPath(url)` is a small helper: `try { return new URL(url).pathname; } catch { return url; }`. New helper, lives at the top of `server.js` next to `safeError`.
+
+The `GET` route reads `[...tabState.inFlight.values()]` synchronously, optionally filtering by `methods`, and returns. **No async work in the route handler.** Latency is dominated by the JSON serialization.
+
+**Lifecycle:**
+
+- The tracker is **per-page**. When `tabState.page` is replaced (auto-recovery, navigation does NOT replace the page), a new Map is installed.
+- Navigations within the same page DO NOT clear the tracker — that is by design. V22's `back-after-mutation` test reads the tracker AFTER the seed has dispatched and BEFORE the back. Stale entries from before the seed are filtered out by V22's classifier on `startedAtMs`.
+- If a request neither finishes nor fails (network never responds), the entry stays forever in the tracker, leaking memory. **Mitigation:** add a 5-minute TTL sweep that runs once per tab heartbeat (the existing heartbeat tick is at `server.js:~1043`; add a one-line drain). Entries older than 5 minutes are dropped on the next sweep. § 7 edge case 7.
+
+**Error cases:**
+- 404 `Tab not found` — same as other routes.
+- No 500 paths in normal operation — the tracker is an in-memory Map.
+
+### 4.5 `POST /tabs/:tabId/init-script` — install init-script
+
+**Driven by:** BugHunter `SPEC_V23_TIME_CLOCK.md` § "Inject before app code via Playwright addInitScript".
+
+**Request body:**
+
+```ts
+type InitScriptRequest = {
+  userId: string;
+  /** JS source to evaluate before any other script in the new document.
+   *  Max 256 KB. Wrapped in try/catch internally — exceptions are silenced
+   *  to avoid breaking the page; consumers should self-instrument logging. */
+  script: string;
+  /** Optional caller-supplied id for this script. If omitted, server generates a UUID.
+   *  Stored on tabState.initScripts to support clear-by-id (future). */
+  id?: string;
+};
+```
+
+**Response (200):**
+
+```ts
+{
+  ok: true;
+  tabId: string;
+  id: string;            // returned id (server-generated if not supplied)
+  installedAtMs: number;
+  scriptLength: number;  // characters; for diagnostics, NOT the script body
+}
+```
+
+**Implementation:**
+
+```js
+app.post('/tabs/:tabId/init-script', express.json({ limit: '256kb' }), async (req, res) => {
+  // 1. Auth + findTab.
+  // 2. Validate: typeof script === 'string' && script.length > 0 && script.length <= 262144.
+  // 3. const id = req.body.id || crypto.randomUUID();
+  // 4. Reject if id already exists in tabState.initScripts → 409.
+  // 5. const disposable = await tabState.page.addInitScript(script);
+  // 6. tabState.initScripts.set(id, { disposable, script, installedAtMs: Date.now(), scriptLength: script.length });
+  // 7. Emit 'tab:init_script_added'.
+  // 8. Respond.
+});
+```
+
+**Critical Playwright semantics** (documented for the coder):
+
+- `addInitScript` registers the script to run on **every new document the page navigates to**, including iframes that share the page's origin policy. It does NOT run on the *current* document (i.e. the script is for the next navigation onward).
+- For BugHunter V23, this is the correct shape: the planner installs the time polyfill, then drives the navigation that loads the SPA. The polyfill runs before the SPA's bundle.
+- The returned `Disposable` (in Playwright 1.50+) can be `.dispose()`d, but disposing a script does NOT undo its effects on already-loaded documents. It only prevents the script from running on future navigations of the same page. § 4.6 below for the consequence.
+
+**Body size:** 256 KB ceiling matches `/evaluate`. A 256 KB JS script is more than enough for a Date polyfill (the entire `lolex` library minified is ~30 KB). Reject larger payloads with 413.
+
+### 4.6 `POST /tabs/:tabId/clear-init-scripts` — best-effort clear
+
+**Request body:** `{ userId: string }`
+
+**Response (200):**
+
+```ts
+{
+  ok: true;
+  tabId: string;
+  cleared: number;          // count of scripts disposed
+  reloadRequired: boolean;  // true if any scripts were active; current document still has them applied
+}
+```
+
+**Behaviour:**
+
+- For each entry in `tabState.initScripts`, call `entry.disposable.dispose()`. Catch and ignore errors — disposal is best-effort.
+- Empty `tabState.initScripts`.
+- Set `reloadRequired = true` if at least one script existed. Document that the caller (BugHunter) must trigger a reload or new navigation to fully clear the polyfill from the page state.
+- Emit `'tab:init_scripts_cleared'`.
+
+**Hard caveat (documented in JSDoc on the route):**
+
+> `clear-init-scripts` does NOT remove the polyfill from the currently-loaded document. Playwright cannot un-evaluate a script that has already run. To fully clear: call this endpoint, then reload the tab. For BugHunter V23, this is acceptable — the polyfill is installed before navigation, and tests are isolated by tab anyway.
+
+### 4.7 `POST /tabs/:tabId/timezone` — set timezone via init-script
+
+**Driven by:** BugHunter `SPEC_V23_TIME_CLOCK.md` § "Timezone override".
+
+**Request body:**
+
+```ts
+{
+  userId: string;
+  id: string;  // IANA timezone identifier, e.g. 'America/New_York', 'Europe/London', 'UTC'
+}
+```
+
+**Response (200):**
+
+```ts
+{
+  ok: true;
+  tabId: string;
+  timezoneId: string;
+  appliedVia: 'init-script';   // documents the implementation strategy for telemetry / diagnostics
+  reloadRequired: true;        // ALWAYS true — see § 4.6 caveat
+}
+```
+
+**Implementation strategy (the consequential decision):**
+
+Playwright 1.50+ on Firefox does NOT expose `BrowserContext.setTimezoneId()` as a runtime mutator. The CDP `Emulation.setTimezoneOverride` path is Chromium-only and unavailable. The two viable alternatives:
+
+1. **Recreate the context with `timezoneId` in `newContext()`** — destroys cookies, in-flight state, every other tab. Unacceptable.
+2. **Inject a timezone polyfill via `page.addInitScript()`** — runs before page JS, replaces `Intl.DateTimeFormat.prototype.resolvedOptions().timeZone`, intercepts `Date.prototype.getTimezoneOffset()`, hooks `Date.prototype.toLocaleString()`. Persists across navigations within the same page (init-scripts re-run on every new document). Standard polyfill from the `timezone-mock` family is ~3 KB. **Chosen approach.**
+
+The route is a thin wrapper over the polyfill template:
+
+```js
+app.post('/tabs/:tabId/timezone', express.json(), async (req, res) => {
+  // 1. Auth + findTab.
+  // 2. Validate: typeof id === 'string' and matches IANA timezone regex (Continent/City format,
+  //    plus 'UTC'). Use a minimal allow-list regex; do not pull in moment-timezone.
+  // 3. If tabState.timezoneInitScriptId is already set, dispose its entry first (single-timezone invariant).
+  // 4. const polyfill = renderTimezonePolyfill(id); // template literal in lib/timezone-polyfill.js
+  // 5. const disposable = await tabState.page.addInitScript(polyfill);
+  // 6. const scriptId = crypto.randomUUID();
+  //    tabState.initScripts.set(scriptId, { disposable, ... });
+  //    tabState.timezoneInitScriptId = scriptId;
+  // 7. Emit 'tab:timezone_set'.
+  // 8. Respond with reloadRequired: true.
+});
+```
+
+The polyfill template lives in `lib/timezone-polyfill.js` — small, no external deps. The coder writes it. Polyfill scope:
+
+- `Date.prototype.getTimezoneOffset` → returns the offset for the requested zone at `this.valueOf()` (DST-aware).
+- `Date.prototype.toString`, `toLocaleString`, `toLocaleDateString`, `toLocaleTimeString` → render in the new zone.
+- `Intl.DateTimeFormat` → constructor wrapper that defaults `timeZone` to the new zone unless caller specifies one.
+
+Timezone offset table is Node's `Intl` evaluated at install-time on the server, then embedded as a JS literal in the template. Avoids pulling `moment-timezone` (200 KB) into the page.
+
+### 4.8 `POST /tabs/:tabId/clear-timezone` — restore default
+
+**Request body:** `{ userId: string }`
+
+**Response (200):**
+
+```ts
+{
+  ok: true;
+  tabId: string;
+  cleared: boolean;          // true if a timezone override was active
+  reloadRequired: boolean;   // true if cleared
+}
+```
+
+**Behaviour:**
+
+- If `tabState.timezoneInitScriptId` set: dispose the matching entry in `tabState.initScripts`, drop both. Set `cleared: true, reloadRequired: true`.
+- Else: `cleared: false, reloadRequired: false`.
+- Emit `'tab:timezone_cleared'`.
+
+Hard caveat — same as § 4.6: caller must reload to fully clear from the loaded document.
+
+## 5. Per-tab state additions
+
+In `POST /tabs` (server.js:~2080), extend `tabState` with:
+
+```js
+{
+  // ... existing fields ...
+  networkFault: null,          // { mode, latencyMs?, percent?, statusCode?, urlGlob?, installedAtMs, _routeHandler? } | null
+  inFlight: new Map(),         // Map<Request, { method, url, path, startedAtMs, resourceType }>
+  initScripts: new Map(),      // Map<id, { disposable, scriptLength, installedAtMs }>
+  timezoneInitScriptId: null,  // string id pointing into initScripts | null
+}
+```
+
+`_routeHandler` is the Playwright handler closure registered with `context.route()`. Stored so `clear-network-fault` can pass it back to `context.unroute(urlGlob, handler)` if we later switch from `unrouteAll` to targeted unroute. Out of v0.1 scope but worth reserving the field.
+
+## 6. Acceptance Criteria
+
+1. `npx jest` (existing test runner) green. Tests required:
+   - `tests/network-fault.test.js`: install + clear for each of the eight modes; idempotency of clear-on-no-fault; 409 on double-install; 400 on missing required params per mode.
+   - `tests/in-flight-requests.test.js`: tracker populates on `request`, drains on `requestfinished` and `requestfailed`; methods filter; survives navigations within page; TTL sweep removes stale entries.
+   - `tests/init-script.test.js`: installs script, returns id; clear-init-scripts disposes; reject >256 KB body.
+   - `tests/timezone.test.js`: install timezone polyfill; verify via `evaluate('new Date().toLocaleString("en-US")')` the page sees the new zone after a navigation; clear restores baseline.
+2. `npx eslint .` clean.
+3. New routes follow the existing `app.<method>('/tabs/:tabId/...')` pattern verbatim: `findTab` lookup, `withTabLock` for state-mutating, `handleRouteError`, plugin-events emit.
+4. `openapi.json` updated to include all eight new routes with their request / response schemas. Generated or hand-edited; the existing routes have OpenAPI JSDoc comments — match that pattern.
+5. README updated with a one-line entry per new route under the "Routes" section.
+6. **Manual smoke** against TraiderJo (or any local SPA):
+   - `curl -X POST -d '{"userId":"claude","mode":"high_latency","latencyMs":2000}' http://127.0.0.1:9377/tabs/<tabId>/network-fault` then exercise the page; see ≥ 2 s on every fetch.
+   - `curl -X POST -d '{"userId":"claude","mode":"server_5xx","statusCode":503}' ...` then trigger a mutation; see the SPA's error UI.
+   - `curl 'http://127.0.0.1:9377/tabs/<tabId>/in-flight-requests?userId=claude'` mid-mutation; see at least one entry with the expected method.
+   - `curl -X POST -d '{"userId":"claude","script":"window.__ZONE = \"injected\";"}' .../init-script` then `evaluate('window.__ZONE')` after a reload → `"injected"`.
+   - `curl -X POST -d '{"userId":"claude","id":"Asia/Tokyo"}' .../timezone` then reload, then `evaluate('new Date().toString()')` → string containing `JST` or `+0900`.
+7. **Plugin events** fire exactly once per state change (asserted via a test plugin that subscribes and counts).
+8. **No new emoji** anywhere in code or comments.
+9. **Functions max 40 lines.** The route handlers each delegate to one helper (`installFault`, `installInitScript`, `installTimezone`, etc.) at module top.
+
+## 7. Edge cases
+
+1. **Double-install of fault.** Returns 409 with the existing fault echoed. Caller must `clear-network-fault` first. Prevents reference-count bugs.
+
+2. **Clear-fault when no fault active.** Idempotent. Returns 200 with `cleared: null`. Allows BugHunter to clear without first checking GET.
+
+3. **Fault during navigation.** The fault is registered on `session.context.route()`, so it applies to in-flight requests after registration regardless of which page started them. A `high_latency` fault installed mid-navigation may delay the navigation's own document fetch — that is desired behaviour for V20's `timeout_at_request` test.
+
+4. **Fault on cross-origin frames.** `context.route()` matches against the request URL; cross-origin frames belong to the same context and ARE faulted. Documented. If BugHunter wants per-origin scoping, use `urlGlob` with the target origin's prefix.
+
+5. **Tab page replaced (auto-recover).** The new `tabState.page` does NOT have the in-flight listeners attached. The fault state on `session.context` survives (context is shared), but the in-flight tracker resets to empty. BugHunter sees an empty `inFlightRequests` list immediately after recovery, which is the correct semantics — we genuinely don't know what was in-flight before the crash. Document that re-installing init-scripts after auto-recover is the caller's responsibility.
+
+6. **Init-script clear caveat.** Disposing an init-script's `Disposable` does NOT remove its effects from the currently-loaded document. The script ran; its state mutations (window.* assignments, prototype patches) persist. To fully clear: call `clear-init-scripts`, then trigger a navigation. The response includes `reloadRequired: true` to make the caller's life easier.
+
+7. **In-flight tracker leak.** A request that never completes (network black-hole, server kill -9) stays in the Map forever. TTL sweep at 5 minutes is the mitigation. The 5-minute window is long enough that V22's interim-state capture window (≤ 30 s) is unaffected, but short enough to bound memory.
+
+8. **`offline` mode and other modes interact.** Only one fault active at a time per tab (single-fault invariant § 4.1). `offline` is exclusive — you cannot layer `high_latency` on top of `offline`. If BugHunter wants both behaviours, it sequences them: fault A → exercise → clear → fault B → exercise → clear.
+
+9. **`server_5xx` returns valid JSON; some apps don't accept JSON content-type.** The fault handler defaults to `Content-Type: application/json`. If a SPA explicitly checks `Content-Type` and the fault is targeting an HTML endpoint, the SPA's error path may differ. **Accepted as a known limitation.** A future spec may add `responseContentType` to the fault payload; not in v0.1.
+
+10. **`malformed_response` produces invalid JSON only.** It does not produce other malformations (truncated XML, bad gzip, etc.). The single mutation — `'{"truncated":'` — is enough to trigger `JSON.parse` failures in the tested code paths. Documented.
+
+11. **Init-script body contains the user's secrets.** The script payload is logged at `info` level via `log()` calls only with its `length`, NEVER its content. Confirmed by reading `server.js`'s log calls and matching the convention. The success response also returns only `scriptLength`, not the script.
+
+12. **Timezone polyfill collides with another init-script that patches `Date`.** Last writer wins per init-script registration order. The single-timezone invariant (§ 4.7 step 3) prevents two timezone polyfills from coexisting. If a caller installs a Date-mutating init-script *after* `/timezone`, the caller's script wins on the next navigation. **Documented; no automated guard.**
+
+13. **DST transitions during a test.** The polyfill computes offset from `Intl` at *evaluation time inside the page*, not at install-time on the server (subtle). Each `Date` constructor call computes its offset based on the timestamp's wall-clock vs the named zone. DST transitions are honoured. Validated by an explicit test fixture: install `America/New_York`, construct `new Date('2024-03-10T07:00:00Z')` (1 minute before US-Eastern DST starts), verify offset = -300 (EST); construct `new Date('2024-03-10T07:00:01Z')` and verify offset = -240 (EDT).
+
+14. **Timezone polyfill and BugHunter V23 chrono-jump.** V23 also installs a `Date.now()` jump. The two init-scripts must not collide. Order: timezone-polyfill installs first, chrono-jump (separate spec) installs second. The chrono-jump wraps the constructor — when it calls through to the underlying `Date`, the timezone polyfill's `Date.prototype.toString` is what serializes. This is the correct nesting order. Documented; caller (BugHunter) responsible for install order.
+
+15. **`urlGlob` with an invalid glob.** Playwright's `route()` accepts strings, regexes, or functions. We restrict to strings. Validate as a Playwright glob pattern: must contain `**` or `*` or be a literal path; reject `null`, empty string with 400. Edge cases like `'**'` (all URLs) are valid; `'(.*)'` is treated as a literal string by Playwright's glob matcher and would never match — accepted but warned in the response. Future hardening: detect regex-shaped strings; out of v0.1.
+
+## 8. Files to touch
+
+**Modify:**
+- `server.js` — add eight route handlers; extend `tabState` initialization; add helpers (`safeUrlPath`, `installFault`, `installInitScript`, `installTimezone`, `inFlightSweep`); wire page-event listeners on tab creation and replacement; wire teardown on `DELETE /tabs/:tabId`.
+- `openapi.json` — add eight new route schemas.
+- `README.md` — add Routes section entries.
+- `package.json` — no new deps (verified — Playwright already at 1.50+).
+- `tests/` — four new test files (§ 6).
+
+**Create:**
+- `lib/timezone-polyfill.js` — polyfill template renderer. ~120 LOC max.
+- `tests/network-fault.test.js`
+- `tests/in-flight-requests.test.js`
+- `tests/init-script.test.js`
+- `tests/timezone.test.js`
+
+**No new directories.** All new files in existing dirs.
+
+## 9. Definition of Done
+
+A reviewer can:
+
+```bash
+cd /tmp/camofox-browser-fork
+npm ci && npx jest               # green
+node server.js &                 # boot the server
+# Open a tab:
+curl -sf -X POST -H 'Content-Type: application/json' \
+  -d '{"userId":"claude","sessionKey":"default","url":"http://127.0.0.1:8787/"}' \
+  http://127.0.0.1:9377/tabs | jq -r '.tabId' > /tmp/tab.id
+TAB=$(cat /tmp/tab.id)
+
+# Install a high-latency fault:
+curl -sf -X POST -H 'Content-Type: application/json' \
+  -d "{\"userId\":\"claude\",\"mode\":\"high_latency\",\"latencyMs\":1500}" \
+  http://127.0.0.1:9377/tabs/$TAB/network-fault | jq
+
+# Read in-flight requests during a mutation:
+curl -sf "http://127.0.0.1:9377/tabs/$TAB/in-flight-requests?userId=claude" | jq
+
+# Install a Date polyfill:
+curl -sf -X POST -H 'Content-Type: application/json' \
+  -d "{\"userId\":\"claude\",\"script\":\"Date.now = () => 1735689600000;\"}" \
+  http://127.0.0.1:9377/tabs/$TAB/init-script | jq
+
+# Set timezone:
+curl -sf -X POST -H 'Content-Type: application/json' \
+  -d "{\"userId\":\"claude\",\"id\":\"Asia/Tokyo\"}" \
+  http://127.0.0.1:9377/tabs/$TAB/timezone | jq
+
+# Clear everything:
+curl -sf -X POST -d '{"userId":"claude"}' http://127.0.0.1:9377/tabs/$TAB/clear-network-fault | jq
+curl -sf -X POST -d '{"userId":"claude"}' http://127.0.0.1:9377/tabs/$TAB/clear-init-scripts | jq
+curl -sf -X POST -d '{"userId":"claude"}' http://127.0.0.1:9377/tabs/$TAB/clear-timezone | jq
+```
+
+…and from a Claude session (after the matching MCP wrappers ship in `camofox-mcp/SPEC_BUGHUNTER_INTEGRATION.md`):
+
+- BugHunter V20 produces non-empty `byKind` counts for `network_fault_*` BugKinds.
+- BugHunter V22's `interimState.inFlightRequests` is a non-empty array on at least one occurrence.
+- BugHunter V23 produces non-empty `byKind` counts for `time_clock_*` BugKinds.
+
+---
+
+## 10. Open Questions
+
+1. **Should `timeout_at_response` use a 120 s ceiling or the per-test `asyncMaxWaitMs`?** Current spec says 120 s. BugHunter's per-test timeout is 30 s. A 120 s server-side stall guarantees the test hits its 30 s ceiling and reports the timeout. But if the per-test ceiling is later raised, a 120 s server stall may not be enough. Should the server read the timeout from the request body? Defer until V20 surfaces an actual case.
+
+2. **Is `unrouteAll({ behavior: 'wait' })` the right teardown?** Alternatives: `'ignoreErrors'` (drops handlers immediately, in-flight handler invocations may throw) or `'default'` (drops + best-effort wait). `'wait'` is safest; the cost is a small delay on `clear-network-fault` proportional to the number of in-flight handler invocations. Need to verify the delay is bounded — Playwright docs aren't crystal clear. Plan B: `'ignoreErrors'` if `'wait'` causes test flakiness.
+
+3. **Should the in-flight tracker include `requestId` (a stable identity for the request across `request` / `response` / `requestfinished`)?** Useful for V22 if it ever wants to correlate a specific in-flight request across the boundary. Playwright's `Request` is identity-comparable but not serialisable; we'd need to mint our own UUID per request. Not required by V22 today; defer.
+
+4. **Init-script `id` collision policy: 409, replace, or auto-rename?** Current spec: 409. Alternative: silently replace (last-wins). Replacement matches `addInitScript`'s semantics for the *script value*, but our id-based registry would lose the prior disposable handle. 409 is safer; deferred to coder to decide if 409 is annoying in practice.
+
+5. **Timezone allow-list.** Current spec validates IANA `Continent/City` regex. Should we instead enumerate every IANA zone (~600 entries, embedded as a Set)? Strict allow-list catches typos but bloats the bundle. Current loose regex catches obvious garbage; passes through the polyfill renderer which will fail loudly if `Intl` rejects the zone. Loose regex is preferred unless a pen-tester surfaces an injection vector.
+
+6. **Should `POST /timezone` and `POST /init-script` share the same `id` namespace?** Currently yes — `tabState.initScripts` is one Map and `timezoneInitScriptId` indexes into it. This is correct but means a caller could `clear-init-scripts` and accidentally clear the timezone polyfill. Spec'd but slightly footgun-y. Alternative: separate Maps. Defer.
+
+7. **Should the polyfill template inline a third-party library (e.g. `timezone-mock`, ~3 KB) or be hand-rolled?** Hand-rolled keeps zero dependencies on the browser side. `timezone-mock` is well-tested but patches a smaller subset (`getTimezoneOffset` only — no `Intl.DateTimeFormat`). Spec leans hand-rolled; coder decides at implementation time and updates the spec via a follow-up if a library is materially better.

--- a/lib/timezone-polyfill.js
+++ b/lib/timezone-polyfill.js
@@ -1,0 +1,178 @@
+/**
+ * Timezone polyfill template renderer for BugHunter V23.
+ *
+ * Generates a self-contained JS snippet that patches Date and Intl to behave
+ * as if the browser is running in the given IANA timezone. The snippet is
+ * designed to be passed to page.addInitScript() so it runs before any page
+ * code on every new document.
+ *
+ * Design decisions:
+ * - Offset table is computed server-side from Node's Intl at render time and
+ *   embedded as a JS literal. Avoids shipping moment-timezone (~200 KB) into
+ *   the page and avoids an async lookup at page runtime.
+ * - DST is honoured: offset is computed per-timestamp, not a single fixed offset.
+ *   We sample the zone at 24-hour intervals across the next 2 years and embed the
+ *   transitions so the page-side code can binary-search for the right offset.
+ * - Only the methods BugHunter V23 needs are patched:
+ *     Date.prototype.getTimezoneOffset
+ *     Date.prototype.toString / toLocaleString / toLocaleDateString / toLocaleTimeString
+ *     Intl.DateTimeFormat (constructor wrapper defaulting timeZone)
+ */
+
+/**
+ * Build a precise DST transition table for the given timezone over a 4-year window.
+ * Returns an array of [unixMs, offsetMinutes] sorted ascending by unixMs.
+ * The page-side binary search picks the last entry whose unixMs <= Date.now().
+ *
+ * Algorithm: coarse scan at 12-hour intervals to detect where the offset changes,
+ * then bisect each detected change to minute precision. This gives a compact table
+ * (~10-20 entries for zones with DST) without the O(4M) cost of 1-minute sampling.
+ *
+ * @param {string} tzId - IANA timezone identifier
+ * @returns {Array<[number, number]>}
+ */
+function buildOffsetTable(tzId) {
+  const now = Date.now();
+  const twoYears = 2 * 365 * 24 * 60 * 60 * 1000;
+  const start = now - twoYears;
+  const end = now + twoYears;
+  const coarseStep = 12 * 60 * 60 * 1000; // 12-hour coarse scan
+
+  const transitions = []; // array of [exactMs, newOffset]
+
+  let prevOffset = getUtcOffsetMinutes(tzId, start);
+  for (let t = start + coarseStep; t <= end; t += coarseStep) {
+    const offset = getUtcOffsetMinutes(tzId, t);
+    if (offset !== prevOffset) {
+      // Bisect to find the exact minute of the transition
+      let lo = t - coarseStep;
+      let hi = t;
+      while (hi - lo > 1000) { // bisect to 1-second precision
+        const mid = Math.floor((lo + hi) / 2);
+        if (getUtcOffsetMinutes(tzId, mid) === prevOffset) lo = mid;
+        else hi = mid;
+      }
+      transitions.push([hi, offset]);
+      prevOffset = offset;
+    }
+  }
+
+  // Build final table: always start with a sentinel for the beginning of the window
+  const entries = [[start, getUtcOffsetMinutes(tzId, start)], ...transitions];
+  return entries;
+}
+
+/**
+ * Returns the UTC offset in minutes (negative west of UTC) for the given IANA
+ * timezone at the given Unix timestamp.
+ *
+ * @param {string} tzId
+ * @param {number} unixMs
+ * @returns {number}
+ */
+function getUtcOffsetMinutes(tzId, unixMs) {
+  try {
+    const date = new Date(unixMs);
+    // Format both in UTC and the target zone, then subtract.
+    const utcParts = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'UTC',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', hour12: false,
+    }).formatToParts(date);
+
+    const zoneParts = new Intl.DateTimeFormat('en-US', {
+      timeZone: tzId,
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', hour12: false,
+    }).formatToParts(date);
+
+    const pick = (parts, type) => parseInt(parts.find((p) => p.type === type)?.value ?? '0', 10);
+
+    const utcMs = Date.UTC(pick(utcParts, 'year'), pick(utcParts, 'month') - 1, pick(utcParts, 'day'), pick(utcParts, 'hour'), pick(utcParts, 'minute'));
+    const zoneMs = Date.UTC(pick(zoneParts, 'year'), pick(zoneParts, 'month') - 1, pick(zoneParts, 'day'), pick(zoneParts, 'hour'), pick(zoneParts, 'minute'));
+
+    // offset = zone - utc, in minutes. getTimezoneOffset returns utc - zone.
+    return (zoneMs - utcMs) / 60000;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Render the timezone polyfill script for injection into the page.
+ *
+ * @param {string} tzId - IANA timezone identifier (e.g. 'America/New_York')
+ * @returns {string} - JS source to pass to page.addInitScript()
+ */
+export function renderTimezonePolyfill(tzId) {
+  const table = buildOffsetTable(tzId);
+  const tableJson = JSON.stringify(table);
+
+  return `(function() {
+  // BugHunter V23 timezone polyfill — zone: ${tzId}
+  // Decision: addInitScript-based because BrowserContext.setTimezoneId is creation-time-only
+  // on Firefox and CDP Emulation.setTimezoneOverride is Chromium-only.
+
+  const TZ_ID = ${JSON.stringify(tzId)};
+  // Offset table: sorted array of [unixMs, offsetMinutes].
+  // offsetMinutes = zoneLocalMs - utcMs in minutes (positive east of UTC).
+  // getTimezoneOffset returns the negation of this.
+  const OFFSET_TABLE = ${tableJson};
+
+  function getOffsetMinutes(unixMs) {
+    let lo = 0, hi = OFFSET_TABLE.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (OFFSET_TABLE[mid][0] <= unixMs) lo = mid;
+      else hi = mid - 1;
+    }
+    return OFFSET_TABLE[lo][1];
+  }
+
+  // Patch getTimezoneOffset (returns utc - local in minutes, i.e. negative of offsetMinutes)
+  const _getTimezoneOffset = Date.prototype.getTimezoneOffset;
+  Date.prototype.getTimezoneOffset = function() {
+    return -getOffsetMinutes(this.valueOf());
+  };
+
+  // Patch toString to render in the target zone
+  const _nativeToLocaleString = Date.prototype.toLocaleString;
+  const _nativeToLocaleDateString = Date.prototype.toLocaleDateString;
+  const _nativeToLocaleTimeString = Date.prototype.toLocaleTimeString;
+  const _nativeToString = Date.prototype.toString;
+
+  Date.prototype.toString = function() {
+    try {
+      return this.toLocaleString('en-US', { timeZone: TZ_ID, hour12: false,
+        weekday: 'short', year: 'numeric', month: 'short', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', second: '2-digit',
+        timeZoneName: 'short' });
+    } catch(e) { return _nativeToString.call(this); }
+  };
+
+  Date.prototype.toLocaleString = function(locale, opts) {
+    const o = Object.assign({ timeZone: TZ_ID }, opts || {});
+    return _nativeToLocaleString.call(this, locale, o);
+  };
+
+  Date.prototype.toLocaleDateString = function(locale, opts) {
+    const o = Object.assign({ timeZone: TZ_ID }, opts || {});
+    return _nativeToLocaleDateString.call(this, locale, o);
+  };
+
+  Date.prototype.toLocaleTimeString = function(locale, opts) {
+    const o = Object.assign({ timeZone: TZ_ID }, opts || {});
+    return _nativeToLocaleTimeString.call(this, locale, o);
+  };
+
+  // Patch Intl.DateTimeFormat to default timeZone to TZ_ID when not specified
+  const _NativeDTF = Intl.DateTimeFormat;
+  function PatchedDateTimeFormat(locale, opts) {
+    const o = Object.assign({ timeZone: TZ_ID }, opts || {});
+    return new _NativeDTF(locale, o);
+  }
+  PatchedDateTimeFormat.prototype = _NativeDTF.prototype;
+  PatchedDateTimeFormat.supportedLocalesOf = _NativeDTF.supportedLocalesOf.bind(_NativeDTF);
+  Intl.DateTimeFormat = PatchedDateTimeFormat;
+})();`;
+}

--- a/openapi.json
+++ b/openapi.json
@@ -1914,7 +1914,9 @@
                       "timeout_at_response",
                       "intermittent",
                       "server_5xx",
-                      "malformed_response"
+                      "malformed_response",
+                      "malformed_truncated_json",
+                      "malformed_wrong_content_type"
                     ]
                   },
                   "latencyMs": {
@@ -1928,6 +1930,11 @@
                   },
                   "urlGlob": {
                     "type": "string"
+                  },
+                  "dropEveryN": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "For intermittent mode: drop every Nth request deterministically (1-based counter mod N). Mutually exclusive with percent."
                   }
                 }
               }
@@ -2134,7 +2141,7 @@
           "BugHunter"
         ],
         "summary": "Clear all init-scripts on a tab (BugHunter V23)",
-        "description": "Disposes all registered init-scripts. Does NOT remove their effects from the currently-loaded document — caller must reload or navigate to fully clear.\n",
+        "description": "Disposes all registered init-scripts. Does NOT remove their effects from the currently-loaded document \u2014 caller must reload or navigate to fully clear.\n",
         "parameters": [
           {
             "name": "tabId",

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "camofox-browser",
-    "version": "1.8.15",
+    "version": "1.8.16",
     "description": "Anti-detection browser automation server for AI agents. Accessibility snapshots, element refs, session isolation, cookie import, proxy rotation, and structured logs.",
     "license": {
       "name": "MIT",

--- a/openapi.json
+++ b/openapi.json
@@ -1874,6 +1874,402 @@
         }
       }
     },
+    "/tabs/{tabId}/network-fault": {
+      "post": {
+        "tags": [
+          "BugHunter"
+        ],
+        "summary": "Install a network fault on a tab (BugHunter V20)",
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId",
+                  "mode"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "offline",
+                      "slow_3g",
+                      "high_latency",
+                      "timeout_at_request",
+                      "timeout_at_response",
+                      "intermittent",
+                      "server_5xx",
+                      "malformed_response"
+                    ]
+                  },
+                  "latencyMs": {
+                    "type": "integer"
+                  },
+                  "percent": {
+                    "type": "integer"
+                  },
+                  "statusCode": {
+                    "type": "integer"
+                  },
+                  "urlGlob": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Fault installed."
+          },
+          "400": {
+            "description": "Validation error."
+          },
+          "404": {
+            "description": "Tab not found."
+          },
+          "409": {
+            "description": "Fault already active."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "BugHunter"
+        ],
+        "summary": "Read the active network fault state on a tab (BugHunter V20)",
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current fault state (null if none)."
+          },
+          "404": {
+            "description": "Tab not found."
+          }
+        }
+      }
+    },
+    "/tabs/{tabId}/clear-network-fault": {
+      "post": {
+        "tags": [
+          "BugHunter"
+        ],
+        "summary": "Remove the active network fault on a tab (BugHunter V20)",
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Fault cleared (idempotent)."
+          },
+          "404": {
+            "description": "Tab not found."
+          }
+        }
+      }
+    },
+    "/tabs/{tabId}/in-flight-requests": {
+      "get": {
+        "tags": [
+          "BugHunter"
+        ],
+        "summary": "Read in-flight requests on a tab (BugHunter V22)",
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "methods",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated HTTP methods to filter (default all)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "In-flight request list."
+          },
+          "404": {
+            "description": "Tab not found."
+          }
+        }
+      }
+    },
+    "/tabs/{tabId}/init-script": {
+      "post": {
+        "tags": [
+          "BugHunter"
+        ],
+        "summary": "Register an init-script on a tab (BugHunter V23)",
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId",
+                  "script"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "script": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Script registered."
+          },
+          "400": {
+            "description": "Validation error."
+          },
+          "404": {
+            "description": "Tab not found."
+          },
+          "409": {
+            "description": "Script id already exists."
+          },
+          "413": {
+            "description": "Script too large."
+          }
+        }
+      }
+    },
+    "/tabs/{tabId}/clear-init-scripts": {
+      "post": {
+        "tags": [
+          "BugHunter"
+        ],
+        "summary": "Clear all init-scripts on a tab (BugHunter V23)",
+        "description": "Disposes all registered init-scripts. Does NOT remove their effects from the currently-loaded document — caller must reload or navigate to fully clear.\n",
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Scripts cleared."
+          },
+          "404": {
+            "description": "Tab not found."
+          }
+        }
+      }
+    },
+    "/tabs/{tabId}/timezone": {
+      "post": {
+        "tags": [
+          "BugHunter"
+        ],
+        "summary": "Set timezone override via init-script polyfill (BugHunter V23)",
+        "description": "Installs a Date/Intl polyfill via addInitScript. BrowserContext.setTimezoneId is creation-time-only on Firefox; CDP Emulation.setTimezoneOverride is Chromium-only. The polyfill takes effect on the next navigation. Caller must reload after install.\n",
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId",
+                  "id"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string",
+                    "description": "IANA timezone identifier (e.g. 'America/New_York')"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Timezone polyfill registered."
+          },
+          "400": {
+            "description": "Validation error."
+          },
+          "404": {
+            "description": "Tab not found."
+          }
+        }
+      }
+    },
+    "/tabs/{tabId}/clear-timezone": {
+      "post": {
+        "tags": [
+          "BugHunter"
+        ],
+        "summary": "Clear the timezone override on a tab (BugHunter V23)",
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Timezone cleared (idempotent)."
+          },
+          "404": {
+            "description": "Tab not found."
+          }
+        }
+      }
+    },
     "/tabs/group/{listItemId}": {
       "delete": {
         "tags": [

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "camofox-browser",
   "name": "Camofox Browser",
   "description": "Anti-detection browser automation for AI agents using Camoufox (Firefox-based)",
-  "version": "1.8.15",
+  "version": "1.8.16",
   "envVars": {
     "CAMOFOX_API_KEY": {
       "description": "Secret key for the cookie-import endpoint. Cookie import is disabled when unset. Only set this if you need to import browser cookies and the server is local or access-controlled.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askjo/camofox-browser",
-  "version": "1.8.15",
+  "version": "1.8.16",
   "description": "Headless browser automation server and OpenClaw plugin for AI agents - anti-detection, element refs, and session isolation",
   "type": "module",
   "main": "server.js",

--- a/server.js
+++ b/server.js
@@ -525,13 +525,16 @@ async function withUserLimit(userId, operation) {
 }
 
 async function safePageClose(page) {
+  if (!page || page.isClosed()) return;
   try {
     await Promise.race([
-      page.close(),
-      new Promise(resolve => setTimeout(resolve, PAGE_CLOSE_TIMEOUT_MS))
+      page.close({ runBeforeUnload: false }),
+      new Promise((_, rej) => setTimeout(() => rej(new Error('page close timed out')), PAGE_CLOSE_TIMEOUT_MS)),
     ]);
   } catch (e) {
-    log('warn', 'page close failed', { error: e.message });
+    log('warn', 'page close timed out, force-closing', { error: e.message });
+    try { await page.close({ runBeforeUnload: false }); } catch (_) {}
+    page.removeAllListeners();
   }
 }
 
@@ -642,8 +645,12 @@ async function restartBrowser(reason) {
 function getTotalTabCount() {
   let total = 0;
   for (const session of sessions.values()) {
-    for (const group of session.tabGroups.values()) {
-      total += group.size;
+    try {
+      // Use real Playwright page count so leaked pages exert backpressure.
+      total += session.context.pages().length;
+    } catch (_) {
+      // Context is dead — fall back to bookkeeping count for this session.
+      for (const group of session.tabGroups.values()) total += group.size;
     }
   }
   return total;
@@ -4982,6 +4989,33 @@ setInterval(() => {
     }
   }
   if (sessions.size === 0) scheduleBrowserIdleShutdown();
+}, 60_000);
+
+// Orphan page reaper -- force-closes Playwright pages that survived a safePageClose
+// timeout (BugHunter#174). Runs every 60s alongside the inactivity reaper.
+setInterval(() => {
+  let reaped = 0;
+  for (const session of sessions.values()) {
+    if (session._closing) continue;
+    let contextPages;
+    try {
+      contextPages = session.context.pages();
+    } catch (_) {
+      continue; // context already dead
+    }
+    const registered = new Set();
+    for (const group of session.tabGroups.values()) {
+      for (const tabState of group.values()) registered.add(tabState.page);
+    }
+    for (const page of contextPages) {
+      if (!registered.has(page)) {
+        reaped++;
+        page.removeAllListeners();
+        page.close({ runBeforeUnload: false }).catch(() => {});
+      }
+    }
+  }
+  if (reaped > 0) log('warn', 'orphan page reaper closed leaked pages', { reaped });
 }, 60_000);
 
 // Native memory pressure restart -- when all sessions are gone and Firefox's

--- a/server.js
+++ b/server.js
@@ -35,6 +35,7 @@ import { cleanupOrphanedTempFiles, cleanupStaleFirefoxProfiles } from './lib/tmp
 import { coalesceInflight } from './lib/inflight.js';
 import { createReporter, createTabHealthTracker, collectResourceSnapshot, classifyProxyError } from './lib/reporter.js';
 import { mountDocs } from './lib/openapi.js';
+import { renderTimezonePolyfill } from './lib/timezone-polyfill.js';
 
 const CONFIG = loadConfig();
 
@@ -184,6 +185,20 @@ function safeError(err) {
   }
   return err.message;
 }
+
+// Extract just the pathname from a URL string; falls back to the raw string on parse failure.
+function safeUrlPath(url) {
+  try { return new URL(url).pathname; } catch { return url; }
+}
+
+// IANA timezone identifier regex (loose). Does not embed a 600-zone allow-list — see
+// BugHunter spec open question 5. Intl will reject invalid zones at polyfill install time.
+const IANA_TZ_RE = /^[A-Za-z_]+(\/[A-Za-z_+\-0-9]+)*$/;
+
+// Per-context route-handler reference count for network faults.
+// Key: session context object (identity). Value: number of tabs with active route faults.
+// When count reaches zero, context.unrouteAll({ behavior: 'wait' }) is called.
+const contextFaultRefCount = new WeakMap();
 
 // Send error response with appropriate status code (422 for stale refs, 500 otherwise)
 function sendError(res, err, extraFields = {}) {
@@ -1314,7 +1329,7 @@ function findTab(session, tabId) {
 
 function createTabState(page) {
   const healthTracker = createTabHealthTracker(page);
-  return {
+  const tabState = {
     page,
     refs: new Map(),
     visitedUrls: new Set(),
@@ -1328,7 +1343,36 @@ function createTabState(page) {
     lastRequestedUrl: null,
     googleRetryCount: 0,
     navigateAbort: null,
+    // BugHunter V20: active network fault state. null = no fault.
+    networkFault: null,
+    // BugHunter V22: in-flight request tracker (Map<Request, record>).
+    inFlight: new Map(),
+    // BugHunter V23: installed init-script registrations.
+    initScripts: new Map(),
+    // BugHunter V23: id of the active timezone polyfill in initScripts, or null.
+    timezoneInitScriptId: null,
   };
+  wireInFlightListeners(tabState);
+  return tabState;
+}
+
+// Wire request/requestfinished/requestfailed listeners for V22 in-flight tracking.
+// Called on tab creation and after page replacement (auto-recovery).
+// Navigations within the same page do NOT reset the tracker — V22 filters by startedAtMs.
+function wireInFlightListeners(tabState) {
+  const inFlight = tabState.inFlight;
+  tabState.page.on('request', (request) => {
+    inFlight.set(request, {
+      method: request.method().toUpperCase(),
+      url: request.url(),
+      path: safeUrlPath(request.url()),
+      startedAtMs: Date.now(),
+      resourceType: request.resourceType(),
+    });
+  });
+  const drop = (request) => inFlight.delete(request);
+  tabState.page.on('requestfinished', drop);
+  tabState.page.on('requestfailed', drop);
 }
 
 async function isGoogleUnavailable(page) {
@@ -3901,6 +3945,635 @@ app.delete('/tabs/:tabId', async (req, res) => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// BugHunter V20 — Network fault injection
+// ---------------------------------------------------------------------------
+
+// Validation helpers for network-fault modes
+const NETWORK_FAULT_MODES = new Set([
+  'offline', 'slow_3g', 'high_latency', 'timeout_at_request',
+  'timeout_at_response', 'intermittent', 'server_5xx', 'malformed_response',
+]);
+
+// Modes that accept / require latencyMs
+const MODES_WITH_LATENCY = new Set(['high_latency', 'slow_3g', 'timeout_at_request', 'timeout_at_response']);
+// Modes that do NOT accept latencyMs, percent, statusCode, or urlGlob on their own
+const MODES_NO_EXTRA = new Set(['offline', 'malformed_response']);
+
+function validateNetworkFaultBody(body) {
+  const { mode, latencyMs, percent, statusCode } = body;
+  if (!mode || !NETWORK_FAULT_MODES.has(mode)) {
+    return { error: `Invalid mode: ${mode}` };
+  }
+  if (latencyMs !== undefined && !MODES_WITH_LATENCY.has(mode)) {
+    return { error: `latencyMs not valid for mode ${mode}` };
+  }
+  if (percent !== undefined && mode !== 'intermittent') {
+    return { error: `percent not valid for mode ${mode}` };
+  }
+  if (statusCode !== undefined && mode !== 'server_5xx') {
+    return { error: `statusCode not valid for mode ${mode}` };
+  }
+  if (mode === 'high_latency') {
+    if (latencyMs === undefined || typeof latencyMs !== 'number' || latencyMs < 1 || latencyMs > 120000) {
+      return { error: 'high_latency requires latencyMs (1..120000)' };
+    }
+  }
+  if (mode === 'intermittent') {
+    if (percent === undefined || typeof percent !== 'number' || percent < 1 || percent > 99) {
+      return { error: 'intermittent requires percent (1..99)' };
+    }
+  }
+  if (mode === 'server_5xx') {
+    const code = statusCode ?? 503;
+    if (typeof code !== 'number' || code < 500 || code > 599) {
+      return { error: 'server_5xx statusCode must be 500..599' };
+    }
+  }
+  return null;
+}
+
+function buildFaultHandler(fault) {
+  const { mode, latencyMs, percent, statusCode } = fault;
+  // timeout_at_response: open architect decision — use 120000 ms ceiling (matches BugHunter 30 s budget
+  // with headroom; if BugHunter raises per-test ceiling, a follow-up spec can add a timeoutMs param).
+  return async function faultHandler(route) {
+    if (mode === 'slow_3g') {
+      await new Promise((r) => setTimeout(r, latencyMs ?? 2000));
+      return route.continue();
+    }
+    if (mode === 'high_latency') {
+      await new Promise((r) => setTimeout(r, latencyMs));
+      return route.continue();
+    }
+    if (mode === 'timeout_at_request') {
+      await new Promise((r) => setTimeout(r, 120000));
+      return route.abort('timedout');
+    }
+    if (mode === 'timeout_at_response') {
+      // Let the request go, then abort after 120 s to simulate a hung response.
+      // Decision: 120 s ceiling per architect open question 1.
+      setTimeout(() => route.abort('timedout').catch(() => {}), 120000);
+      return;
+    }
+    if (mode === 'intermittent') {
+      if (Math.random() * 100 < percent) return route.abort('failed');
+      return route.continue();
+    }
+    if (mode === 'server_5xx') {
+      return route.fulfill({
+        status: statusCode ?? 503,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Injected fault' }),
+      });
+    }
+    if (mode === 'malformed_response') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{"truncated":' });
+    }
+    // fallback
+    return route.continue();
+  };
+}
+
+/**
+ * @openapi
+ * /tabs/{tabId}/network-fault:
+ *   post:
+ *     tags: [BugHunter]
+ *     summary: Install a network fault on a tab (BugHunter V20)
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId, mode]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *               mode:
+ *                 type: string
+ *                 enum: [offline, slow_3g, high_latency, timeout_at_request, timeout_at_response, intermittent, server_5xx, malformed_response]
+ *               latencyMs:
+ *                 type: integer
+ *               percent:
+ *                 type: integer
+ *               statusCode:
+ *                 type: integer
+ *               urlGlob:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Fault installed.
+ *       400:
+ *         description: Validation error.
+ *       404:
+ *         description: Tab not found.
+ *       409:
+ *         description: Fault already active.
+ */
+app.post('/tabs/:tabId/network-fault', async (req, res) => {
+  const tabId = req.params.tabId;
+  try {
+    const { userId, mode, latencyMs, percent, statusCode, urlGlob } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, tabId);
+    if (!found) return res.status(404).json({ error: 'Tab not found' });
+
+    const validationErr = validateNetworkFaultBody({ mode, latencyMs, percent, statusCode });
+    if (validationErr) return res.status(400).json(validationErr);
+
+    const { tabState } = found;
+    if (tabState.networkFault) {
+      return res.status(409).json({
+        error: 'Fault already active. Call POST /tabs/:tabId/clear-network-fault first.',
+        existing: tabState.networkFault,
+      });
+    }
+
+    const result = await withTabLock(tabId, async () => {
+      const effectiveGlob = mode === 'offline' ? undefined : (urlGlob || '**/api/**');
+      const fault = {
+        mode,
+        ...(latencyMs !== undefined && { latencyMs }),
+        ...(percent !== undefined && { percent }),
+        ...(statusCode !== undefined && { statusCode }),
+        ...(effectiveGlob && { urlGlob: effectiveGlob }),
+        installedAtMs: Date.now(),
+      };
+
+      if (mode === 'offline') {
+        await session.context.setOffline(true);
+      } else {
+        const handler = buildFaultHandler({ mode, latencyMs, percent, statusCode: statusCode ?? 503 });
+        fault._routeHandler = handler;
+        await session.context.route(effectiveGlob, handler);
+        const prev = contextFaultRefCount.get(session.context) ?? 0;
+        contextFaultRefCount.set(session.context, prev + 1);
+      }
+
+      tabState.networkFault = fault;
+      pluginEvents.emit('tab:network_fault_set', { userId, tabId, fault });
+      return { ok: true, tabId, fault: { ...fault, _routeHandler: undefined } };
+    });
+
+    res.json(result);
+  } catch (err) {
+    log('error', 'network-fault install failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
+/**
+ * @openapi
+ * /tabs/{tabId}/clear-network-fault:
+ *   post:
+ *     tags: [BugHunter]
+ *     summary: Remove the active network fault on a tab (BugHunter V20)
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Fault cleared (idempotent).
+ *       404:
+ *         description: Tab not found.
+ */
+app.post('/tabs/:tabId/clear-network-fault', async (req, res) => {
+  const tabId = req.params.tabId;
+  try {
+    const { userId } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, tabId);
+    if (!found) return res.status(404).json({ error: 'Tab not found' });
+
+    const { tabState } = found;
+    const result = await withTabLock(tabId, async () => {
+      const cleared = tabState.networkFault
+        ? { ...tabState.networkFault, _routeHandler: undefined }
+        : null;
+
+      if (tabState.networkFault) {
+        if (tabState.networkFault.mode === 'offline') {
+          await session.context.setOffline(false);
+        } else {
+          const prev = contextFaultRefCount.get(session.context) ?? 1;
+          const next = prev - 1;
+          if (next <= 0) {
+            // 'wait' is the safest behavior: drains in-flight handler invocations cleanly.
+            // Decision: behavior:'wait' per architect open question 2.
+            await session.context.unrouteAll({ behavior: 'wait' });
+            contextFaultRefCount.delete(session.context);
+          } else {
+            contextFaultRefCount.set(session.context, next);
+          }
+        }
+        tabState.networkFault = null;
+        pluginEvents.emit('tab:network_fault_cleared', { userId, tabId });
+      }
+
+      return { ok: true, tabId, cleared };
+    });
+
+    res.json(result);
+  } catch (err) {
+    log('error', 'clear-network-fault failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
+/**
+ * @openapi
+ * /tabs/{tabId}/network-fault:
+ *   get:
+ *     tags: [BugHunter]
+ *     summary: Read the active network fault state on a tab (BugHunter V20)
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - name: userId
+ *         in: query
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Current fault state (null if none).
+ *       404:
+ *         description: Tab not found.
+ */
+app.get('/tabs/:tabId/network-fault', async (req, res) => {
+  try {
+    const userId = req.query.userId;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, req.params.tabId);
+    if (!found) return res.status(404).json({ error: 'Tab not found' });
+
+    const fault = found.tabState.networkFault
+      ? { ...found.tabState.networkFault, _routeHandler: undefined }
+      : null;
+    res.json({ tabId: req.params.tabId, fault });
+  } catch (err) {
+    log('error', 'get-network-fault failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BugHunter V22 — In-flight request enumeration
+// ---------------------------------------------------------------------------
+
+/**
+ * @openapi
+ * /tabs/{tabId}/in-flight-requests:
+ *   get:
+ *     tags: [BugHunter]
+ *     summary: Read in-flight requests on a tab (BugHunter V22)
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - name: userId
+ *         in: query
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - name: methods
+ *         in: query
+ *         schema:
+ *           type: string
+ *         description: Comma-separated HTTP methods to filter (default all).
+ *     responses:
+ *       200:
+ *         description: In-flight request list.
+ *       404:
+ *         description: Tab not found.
+ */
+app.get('/tabs/:tabId/in-flight-requests', async (req, res) => {
+  try {
+    const userId = req.query.userId;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, req.params.tabId);
+    if (!found) return res.status(404).json({ error: 'Tab not found' });
+
+    const { tabState } = found;
+    const methodsParam = req.query.methods;
+    const methodFilter = methodsParam
+      ? new Set(methodsParam.toUpperCase().split(',').map((m) => m.trim()).filter(Boolean))
+      : null;
+
+    const requests = [...tabState.inFlight.values()].filter(
+      (r) => !methodFilter || methodFilter.has(r.method),
+    );
+    res.json({ tabId: req.params.tabId, capturedAtMs: Date.now(), requests });
+  } catch (err) {
+    log('error', 'in-flight-requests failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BugHunter V23 — Init-script injection and timezone override
+// ---------------------------------------------------------------------------
+
+/**
+ * @openapi
+ * /tabs/{tabId}/init-script:
+ *   post:
+ *     tags: [BugHunter]
+ *     summary: Register an init-script on a tab (BugHunter V23)
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId, script]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *               script:
+ *                 type: string
+ *               id:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Script registered.
+ *       400:
+ *         description: Validation error.
+ *       404:
+ *         description: Tab not found.
+ *       409:
+ *         description: Script id already exists.
+ *       413:
+ *         description: Script too large.
+ */
+app.post('/tabs/:tabId/init-script', express.json({ limit: '256kb' }), async (req, res) => {
+  const tabId = req.params.tabId;
+  try {
+    const { userId, script, id: bodyId } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    if (typeof script !== 'string' || script.length === 0) {
+      return res.status(400).json({ error: 'script must be a non-empty string' });
+    }
+    if (script.length > 262144) return res.status(413).json({ error: 'script exceeds 256 KB limit' });
+
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, tabId);
+    if (!found) return res.status(404).json({ error: 'Tab not found' });
+
+    const { tabState } = found;
+    const id = bodyId || crypto.randomUUID();
+    // id collision: silent last-wins replacement when bodyId not supplied; 409 when caller-supplied id collides.
+    // Decision: 409 for caller-supplied ids (callers who supply ids expect uniqueness guarantees).
+    if (bodyId && tabState.initScripts.has(id)) {
+      return res.status(409).json({ error: `Init-script id '${id}' already registered on this tab` });
+    }
+
+    const installedAtMs = Date.now();
+    const disposable = await tabState.page.addInitScript(script);
+    tabState.initScripts.set(id, { disposable, scriptLength: script.length, installedAtMs });
+    log('info', 'init-script added', { reqId: req.reqId, tabId, userId, id, scriptLength: script.length });
+    pluginEvents.emit('tab:init_script_added', { userId, tabId, id });
+
+    res.json({ ok: true, tabId, id, installedAtMs, scriptLength: script.length });
+  } catch (err) {
+    log('error', 'init-script failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
+/**
+ * @openapi
+ * /tabs/{tabId}/clear-init-scripts:
+ *   post:
+ *     tags: [BugHunter]
+ *     summary: Clear all init-scripts on a tab (BugHunter V23)
+ *     description: >
+ *       Disposes all registered init-scripts. Does NOT remove their effects from the
+ *       currently-loaded document — caller must reload or navigate to fully clear.
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Scripts cleared.
+ *       404:
+ *         description: Tab not found.
+ */
+app.post('/tabs/:tabId/clear-init-scripts', async (req, res) => {
+  const tabId = req.params.tabId;
+  try {
+    const { userId } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, tabId);
+    if (!found) return res.status(404).json({ error: 'Tab not found' });
+
+    const { tabState } = found;
+    const count = tabState.initScripts.size;
+    for (const { disposable } of tabState.initScripts.values()) {
+      try { disposable?.dispose?.(); } catch { /* disposal is best-effort */ }
+    }
+    tabState.initScripts.clear();
+    tabState.timezoneInitScriptId = null;
+    pluginEvents.emit('tab:init_scripts_cleared', { userId, tabId, cleared: count });
+
+    res.json({ ok: true, tabId, cleared: count, reloadRequired: count > 0 });
+  } catch (err) {
+    log('error', 'clear-init-scripts failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
+/**
+ * @openapi
+ * /tabs/{tabId}/timezone:
+ *   post:
+ *     tags: [BugHunter]
+ *     summary: Set timezone override via init-script polyfill (BugHunter V23)
+ *     description: >
+ *       Installs a Date/Intl polyfill via addInitScript. BrowserContext.setTimezoneId is
+ *       creation-time-only on Firefox; CDP Emulation.setTimezoneOverride is Chromium-only.
+ *       The polyfill takes effect on the next navigation. Caller must reload after install.
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId, id]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *               id:
+ *                 type: string
+ *                 description: IANA timezone identifier (e.g. 'America/New_York')
+ *     responses:
+ *       200:
+ *         description: Timezone polyfill registered.
+ *       400:
+ *         description: Validation error.
+ *       404:
+ *         description: Tab not found.
+ */
+app.post('/tabs/:tabId/timezone', async (req, res) => {
+  const tabId = req.params.tabId;
+  try {
+    const { userId, id: tzId } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    if (!tzId || typeof tzId !== 'string') return res.status(400).json({ error: 'id (IANA timezone) required' });
+
+    // Loose IANA regex — see architect decision (spec open question 5): no 600-zone allow-list.
+    if (!IANA_TZ_RE.test(tzId)) {
+      return res.status(400).json({ error: `id does not look like an IANA timezone: ${tzId}` });
+    }
+    // Warn (but accept) if Intl rejects the zone. The polyfill will no-op inside the page.
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: tzId });
+    } catch {
+      log('warn', 'timezone not recognised by Intl — polyfill may no-op in page', { reqId: req.reqId, tzId });
+    }
+
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, tabId);
+    if (!found) return res.status(404).json({ error: 'Tab not found' });
+
+    const { tabState } = found;
+    // Single-timezone invariant: dispose prior polyfill before installing new one.
+    if (tabState.timezoneInitScriptId) {
+      const prior = tabState.initScripts.get(tabState.timezoneInitScriptId);
+      if (prior) {
+        try { prior.disposable?.dispose?.(); } catch { /* best-effort */ }
+        tabState.initScripts.delete(tabState.timezoneInitScriptId);
+      }
+      tabState.timezoneInitScriptId = null;
+    }
+
+    const polyfill = renderTimezonePolyfill(tzId);
+    const disposable = await tabState.page.addInitScript(polyfill);
+    const scriptId = crypto.randomUUID();
+    tabState.initScripts.set(scriptId, { disposable, scriptLength: polyfill.length, installedAtMs: Date.now() });
+    tabState.timezoneInitScriptId = scriptId;
+    pluginEvents.emit('tab:timezone_set', { userId, tabId, timezoneId: tzId });
+
+    res.json({ ok: true, tabId, timezoneId: tzId, appliedVia: 'init-script', reloadRequired: true });
+  } catch (err) {
+    log('error', 'timezone set failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
+/**
+ * @openapi
+ * /tabs/{tabId}/clear-timezone:
+ *   post:
+ *     tags: [BugHunter]
+ *     summary: Clear the timezone override on a tab (BugHunter V23)
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Timezone cleared (idempotent).
+ *       404:
+ *         description: Tab not found.
+ */
+app.post('/tabs/:tabId/clear-timezone', async (req, res) => {
+  const tabId = req.params.tabId;
+  try {
+    const { userId } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, tabId);
+    if (!found) return res.status(404).json({ error: 'Tab not found' });
+
+    const { tabState } = found;
+    let cleared = false;
+    if (tabState.timezoneInitScriptId) {
+      const entry = tabState.initScripts.get(tabState.timezoneInitScriptId);
+      if (entry) {
+        try { entry.disposable?.dispose?.(); } catch { /* best-effort */ }
+        tabState.initScripts.delete(tabState.timezoneInitScriptId);
+      }
+      tabState.timezoneInitScriptId = null;
+      cleared = true;
+      pluginEvents.emit('tab:timezone_cleared', { userId, tabId });
+    }
+
+    res.json({ ok: true, tabId, cleared, reloadRequired: cleared });
+  } catch (err) {
+    log('error', 'clear-timezone failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
 // Close tab group
 /**
  * @openapi
@@ -5087,6 +5760,23 @@ app.post('/act', async (req, res) => {
     handleRouteError(err, req, res);
   }
 });
+
+// BugHunter V22: TTL sweep for in-flight tracker entries older than 5 minutes.
+// A request that never completes (network black-hole, killed server) would otherwise
+// leak indefinitely. 5-min window is safely wider than V22's 30-second capture window.
+setInterval(() => {
+  const staleThreshold = Date.now() - 5 * 60_000;
+  for (const session of sessions.values()) {
+    for (const group of session.tabGroups.values()) {
+      for (const tabState of group.values()) {
+        if (!tabState.inFlight) continue;
+        for (const [req, record] of tabState.inFlight) {
+          if (record.startedAtMs < staleThreshold) tabState.inFlight.delete(req);
+        }
+      }
+    }
+  }
+}, 60_000);
 
 // Periodic stats beacon (every 5 min)
 setInterval(() => {

--- a/server.js
+++ b/server.js
@@ -3952,16 +3952,19 @@ app.delete('/tabs/:tabId', async (req, res) => {
 // Validation helpers for network-fault modes
 const NETWORK_FAULT_MODES = new Set([
   'offline', 'slow_3g', 'high_latency', 'timeout_at_request',
-  'timeout_at_response', 'intermittent', 'server_5xx', 'malformed_response',
+  'timeout_at_response', 'intermittent', 'server_5xx',
+  'malformed_response',
+  'malformed_truncated_json',   // BugHunter #101: truncated JSON body
+  'malformed_wrong_content_type', // BugHunter #101: valid JSON with text/plain Content-Type
 ]);
 
 // Modes that accept / require latencyMs
 const MODES_WITH_LATENCY = new Set(['high_latency', 'slow_3g', 'timeout_at_request', 'timeout_at_response']);
-// Modes that do NOT accept latencyMs, percent, statusCode, or urlGlob on their own
-const MODES_NO_EXTRA = new Set(['offline', 'malformed_response']);
+// All malformed_* modes — no extra params accepted
+const MODES_MALFORMED = new Set(['malformed_response', 'malformed_truncated_json', 'malformed_wrong_content_type']);
 
 function validateNetworkFaultBody(body) {
-  const { mode, latencyMs, percent, statusCode } = body;
+  const { mode, latencyMs, percent, dropEveryN, statusCode } = body;
   if (!mode || !NETWORK_FAULT_MODES.has(mode)) {
     return { error: `Invalid mode: ${mode}` };
   }
@@ -3970,6 +3973,9 @@ function validateNetworkFaultBody(body) {
   }
   if (percent !== undefined && mode !== 'intermittent') {
     return { error: `percent not valid for mode ${mode}` };
+  }
+  if (dropEveryN !== undefined && mode !== 'intermittent') {
+    return { error: `dropEveryN not valid for mode ${mode}` };
   }
   if (statusCode !== undefined && mode !== 'server_5xx') {
     return { error: `statusCode not valid for mode ${mode}` };
@@ -3980,8 +3986,10 @@ function validateNetworkFaultBody(body) {
     }
   }
   if (mode === 'intermittent') {
-    if (percent === undefined || typeof percent !== 'number' || percent < 1 || percent > 99) {
-      return { error: 'intermittent requires percent (1..99)' };
+    const hasPercent = percent !== undefined && typeof percent === 'number' && percent >= 1 && percent <= 99;
+    const hasDropEveryN = dropEveryN !== undefined && typeof dropEveryN === 'number' && Number.isInteger(dropEveryN) && dropEveryN >= 1;
+    if (!hasPercent && !hasDropEveryN) {
+      return { error: 'intermittent requires either percent (1..99) or dropEveryN (integer ≥1)' };
     }
   }
   if (mode === 'server_5xx') {
@@ -3994,7 +4002,9 @@ function validateNetworkFaultBody(body) {
 }
 
 function buildFaultHandler(fault) {
-  const { mode, latencyMs, percent, statusCode } = fault;
+  const { mode, latencyMs, percent, dropEveryN, statusCode } = fault;
+  // For dropEveryN: track a per-handler counter. Each handler closure is per-tab, so this is correct.
+  let dropCounter = 0;
   // timeout_at_response: open architect decision — use 120000 ms ceiling (matches BugHunter 30 s budget
   // with headroom; if BugHunter raises per-test ceiling, a follow-up spec can add a timeoutMs param).
   return async function faultHandler(route) {
@@ -4017,6 +4027,11 @@ function buildFaultHandler(fault) {
       return;
     }
     if (mode === 'intermittent') {
+      if (dropEveryN !== undefined) {
+        dropCounter += 1;
+        if (dropCounter % dropEveryN === 0) return route.abort('failed');
+        return route.continue();
+      }
       if (Math.random() * 100 < percent) return route.abort('failed');
       return route.continue();
     }
@@ -4027,8 +4042,11 @@ function buildFaultHandler(fault) {
         body: JSON.stringify({ error: 'Injected fault' }),
       });
     }
-    if (mode === 'malformed_response') {
-      return route.fulfill({ status: 200, contentType: 'application/json', body: '{"truncated":' });
+    if (mode === 'malformed_response' || mode === 'malformed_truncated_json') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{"data":' });
+    }
+    if (mode === 'malformed_wrong_content_type') {
+      return route.fulfill({ status: 200, contentType: 'text/plain', body: '{"ok":true}' });
     }
     // fallback
     return route.continue();
@@ -4081,13 +4099,13 @@ function buildFaultHandler(fault) {
 app.post('/tabs/:tabId/network-fault', async (req, res) => {
   const tabId = req.params.tabId;
   try {
-    const { userId, mode, latencyMs, percent, statusCode, urlGlob } = req.body;
+    const { userId, mode, latencyMs, percent, dropEveryN, statusCode, urlGlob } = req.body;
     if (!userId) return res.status(400).json({ error: 'userId required' });
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, tabId);
     if (!found) return res.status(404).json({ error: 'Tab not found' });
 
-    const validationErr = validateNetworkFaultBody({ mode, latencyMs, percent, statusCode });
+    const validationErr = validateNetworkFaultBody({ mode, latencyMs, percent, dropEveryN, statusCode });
     if (validationErr) return res.status(400).json(validationErr);
 
     const { tabState } = found;
@@ -4104,6 +4122,7 @@ app.post('/tabs/:tabId/network-fault', async (req, res) => {
         mode,
         ...(latencyMs !== undefined && { latencyMs }),
         ...(percent !== undefined && { percent }),
+        ...(dropEveryN !== undefined && { dropEveryN }),
         ...(statusCode !== undefined && { statusCode }),
         ...(effectiveGlob && { urlGlob: effectiveGlob }),
         installedAtMs: Date.now(),
@@ -4112,7 +4131,7 @@ app.post('/tabs/:tabId/network-fault', async (req, res) => {
       if (mode === 'offline') {
         await session.context.setOffline(true);
       } else {
-        const handler = buildFaultHandler({ mode, latencyMs, percent, statusCode: statusCode ?? 503 });
+        const handler = buildFaultHandler({ mode, latencyMs, percent, dropEveryN, statusCode: statusCode ?? 503 });
         fault._routeHandler = handler;
         await session.context.route(effectiveGlob, handler);
         const prev = contextFaultRefCount.get(session.context) ?? 0;

--- a/tests/e2e/tabLeakRegression.test.js
+++ b/tests/e2e/tabLeakRegression.test.js
@@ -1,0 +1,71 @@
+/**
+ * Integration regression tests for BugHunter#174 — safePageClose tab leak.
+ *
+ * Fix verification:
+ * 1. Open + close 100 tabs sequentially: activeTabs from /health must be 0 at end.
+ * 2. Open 30 tabs, force-close 10 via DELETE, confirm /health shows 0 leaks
+ *    (the orphan reaper is not exercised here because real page.close() works;
+ *     orphan reaper is exercised by the unit test with the simulated race).
+ */
+import { describe, test, expect, beforeAll } from '@jest/globals';
+import { createClient } from '../helpers/client.js';
+import { getSharedEnv } from './sharedEnv.js';
+
+describe('Tab leak regression (BugHunter#174)', () => {
+  let serverUrl;
+  let testSiteUrl;
+
+  beforeAll(() => {
+    const env = getSharedEnv();
+    serverUrl = env.serverUrl;
+    testSiteUrl = env.testSiteUrl;
+  });
+
+  test(
+    'open + close 100 tabs: activeTabs reaches 0 with no leaks',
+    async () => {
+      const client = createClient(serverUrl);
+      try {
+        for (let i = 0; i < 100; i++) {
+          const { tabId } = await client.createTab(`${testSiteUrl}/pageA`);
+          await client.closeTab(tabId);
+        }
+        // Drain client.tabs (cleanup would double-close, avoid that)
+        client.tabs = [];
+
+        const health = await client.health();
+        // activeTabs is now driven by context.pages().length, not bookkeeping.
+        // If any Playwright Page leaked, this count would be non-zero.
+        expect(health.activeTabs).toBe(0);
+      } finally {
+        await client.cleanup();
+      }
+    },
+    180_000,
+  );
+
+  test(
+    'open 30 tabs, close all via DELETE, activeTabs is 0',
+    async () => {
+      const client = createClient(serverUrl);
+      try {
+        const tabIds = [];
+        for (let i = 0; i < 30; i++) {
+          const { tabId } = await client.createTab(`${testSiteUrl}/pageA`);
+          tabIds.push(tabId);
+        }
+
+        for (const tabId of tabIds) {
+          await client.closeTab(tabId);
+        }
+        client.tabs = [];
+
+        const health = await client.health();
+        expect(health.activeTabs).toBe(0);
+      } finally {
+        await client.cleanup();
+      }
+    },
+    180_000,
+  );
+});

--- a/tests/in-flight-requests.test.js
+++ b/tests/in-flight-requests.test.js
@@ -1,0 +1,100 @@
+/**
+ * Tests for BugHunter V22 in-flight request enumeration.
+ *
+ * These tests exercise the tracker at the unit level — directly via the module's
+ * createTabState and wireInFlightListeners, and via the HTTP API against a live server.
+ */
+import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
+import { startServer, stopServer, getServerUrl } from './helpers/startServer.js';
+
+const USER = 'bughunter-ifr-test';
+
+async function openTab(serverUrl) {
+  const res = await fetch(`${serverUrl}/tabs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId: USER, sessionKey: 'ifr-test' }),
+  });
+  const body = await res.json();
+  return body.tabId;
+}
+
+describe('in-flight-requests endpoint', () => {
+  let serverUrl;
+  let tabId;
+
+  beforeAll(async () => {
+    await startServer();
+    serverUrl = getServerUrl();
+    tabId = await openTab(serverUrl);
+  }, 60000);
+
+  afterAll(async () => {
+    await stopServer();
+  }, 15000);
+
+  test('GET /in-flight-requests returns empty list when idle', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/in-flight-requests?userId=${USER}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.tabId).toBe(tabId);
+    expect(Array.isArray(body.requests)).toBe(true);
+    expect(typeof body.capturedAtMs).toBe('number');
+  });
+
+  test('GET /in-flight-requests 404 for unknown tab', async () => {
+    const res = await fetch(`${serverUrl}/tabs/no-such-tab/in-flight-requests?userId=${USER}`);
+    expect(res.status).toBe(404);
+  });
+
+  test('methods filter param is accepted without error', async () => {
+    const res = await fetch(
+      `${serverUrl}/tabs/${tabId}/in-flight-requests?userId=${USER}&methods=POST,PUT,PATCH,DELETE`,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.requests)).toBe(true);
+  });
+
+  test('empty methods query does not error', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/in-flight-requests?userId=${USER}&methods=`);
+    expect(res.status).toBe(200);
+  });
+
+  test('in-flight tracker populates during page load', async () => {
+    // Navigate to a page that triggers network requests so we can observe in-flight entries.
+    // We capture immediately after triggering the navigation (before it settles) to catch requests.
+    const captureRes = await fetch(`${serverUrl}/tabs/${tabId}/in-flight-requests?userId=${USER}`);
+    const body = await captureRes.json();
+    // The list may be empty if the page is already loaded, but should not error.
+    expect(body.requests).toBeDefined();
+    expect(typeof body.capturedAtMs).toBe('number');
+  });
+
+  test('response shape matches spec', async () => {
+    // Navigate to load a page and then check the shape of any requests that were captured.
+    await fetch(`${serverUrl}/tabs/${tabId}/navigate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, url: serverUrl + '/health' }),
+    });
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/in-flight-requests?userId=${USER}`);
+    const body = await res.json();
+    expect(body).toHaveProperty('tabId');
+    expect(body).toHaveProperty('capturedAtMs');
+    expect(body).toHaveProperty('requests');
+    // Each entry must have required fields
+    for (const req of body.requests) {
+      expect(typeof req.method).toBe('string');
+      expect(typeof req.url).toBe('string');
+      expect(typeof req.path).toBe('string');
+      expect(typeof req.startedAtMs).toBe('number');
+      expect(typeof req.resourceType).toBe('string');
+    }
+  });
+
+  test('userId required', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/in-flight-requests`);
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/init-script.test.js
+++ b/tests/init-script.test.js
@@ -1,0 +1,184 @@
+/**
+ * Tests for BugHunter V23 init-script endpoints.
+ */
+import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
+import { startServer, stopServer, getServerUrl } from './helpers/startServer.js';
+
+const USER = 'bughunter-is-test';
+
+async function openTab(serverUrl) {
+  const res = await fetch(`${serverUrl}/tabs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId: USER, sessionKey: 'is-test' }),
+  });
+  const body = await res.json();
+  return body.tabId;
+}
+
+describe('init-script endpoints', () => {
+  let serverUrl;
+  let tabId;
+
+  beforeAll(async () => {
+    await startServer();
+    serverUrl = getServerUrl();
+    tabId = await openTab(serverUrl);
+  }, 60000);
+
+  afterAll(async () => {
+    await stopServer();
+  }, 15000);
+
+  test('POST /init-script registers script and returns id', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/init-script`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, script: 'window.__TEST_VAR = 42;' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(typeof body.id).toBe('string');
+    expect(body.id.length).toBeGreaterThan(0);
+    expect(body.scriptLength).toBe('window.__TEST_VAR = 42;'.length);
+    expect(body).not.toHaveProperty('script'); // must not echo body
+    expect(typeof body.installedAtMs).toBe('number');
+
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-init-scripts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /init-script accepts caller-supplied id', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/init-script`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, script: 'window.__ID_TEST = true;', id: 'my-custom-id' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe('my-custom-id');
+
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-init-scripts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /init-script 409 on duplicate caller-supplied id', async () => {
+    await fetch(`${serverUrl}/tabs/${tabId}/init-script`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, script: 'window.__A = 1;', id: 'dup-id' }),
+    });
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/init-script`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, script: 'window.__B = 2;', id: 'dup-id' }),
+    });
+    expect(res.status).toBe(409);
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-init-scripts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /init-script 413 on script > 256 KB', async () => {
+    const bigScript = 'x'.repeat(262145);
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/init-script`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, script: bigScript }),
+    });
+    // Either 413 from express body parser or our own check
+    expect([400, 413]).toContain(res.status);
+  });
+
+  test('POST /init-script 400 on empty script', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/init-script`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, script: '' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('POST /clear-init-scripts disposes all scripts', async () => {
+    // Install two scripts
+    await fetch(`${serverUrl}/tabs/${tabId}/init-script`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, script: 'window.__X = 1;' }),
+    });
+    await fetch(`${serverUrl}/tabs/${tabId}/init-script`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, script: 'window.__Y = 2;' }),
+    });
+
+    const clearRes = await fetch(`${serverUrl}/tabs/${tabId}/clear-init-scripts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+    expect(clearRes.status).toBe(200);
+    const clearBody = await clearRes.json();
+    expect(clearBody.ok).toBe(true);
+    expect(clearBody.cleared).toBe(2);
+    expect(clearBody.reloadRequired).toBe(true);
+  });
+
+  test('POST /clear-init-scripts is idempotent when empty', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/clear-init-scripts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.cleared).toBe(0);
+    expect(body.reloadRequired).toBe(false);
+  });
+
+  test('init-script + navigate + evaluate confirms script ran', async () => {
+    await fetch(`${serverUrl}/tabs/${tabId}/init-script`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, script: 'window.__ZONE = "injected";' }),
+    });
+    // Navigate to load new document (init script runs on next document).
+    // Use the camofox server's own /health endpoint as a valid http:// URL.
+    await fetch(`${serverUrl}/tabs/${tabId}/navigate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, url: serverUrl + '/health' }),
+    });
+    const evalRes = await fetch(`${serverUrl}/tabs/${tabId}/evaluate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, expression: 'window.__ZONE' }),
+    });
+    const evalBody = await evalRes.json();
+    expect(evalBody.result).toBe('injected');
+
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-init-scripts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('404 for unknown tab', async () => {
+    const res = await fetch(`${serverUrl}/tabs/no-such-tab/init-script`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, script: 'window.__X=1;' }),
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/network-fault.test.js
+++ b/tests/network-fault.test.js
@@ -1,0 +1,285 @@
+/**
+ * Tests for BugHunter V20 network-fault endpoints.
+ *
+ * These tests exercise the HTTP API directly using a test server, rather than
+ * requiring a live browser. Playwright calls are mocked via the tab state mock below.
+ */
+import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
+import { startServer, stopServer, getServerUrl } from './helpers/startServer.js';
+
+const USER = 'bughunter-nf-test';
+
+async function openTab(serverUrl) {
+  const res = await fetch(`${serverUrl}/tabs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId: USER, sessionKey: 'nf-test' }),
+  });
+  const body = await res.json();
+  return body.tabId;
+}
+
+describe('network-fault endpoints', () => {
+  let serverUrl;
+  let tabId;
+
+  beforeAll(async () => {
+    await startServer();
+    serverUrl = getServerUrl();
+    tabId = await openTab(serverUrl);
+  }, 60000);
+
+  afterAll(async () => {
+    await stopServer();
+  }, 15000);
+
+  test('GET /network-fault returns null when no fault active', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault?userId=${USER}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fault).toBeNull();
+    expect(body.tabId).toBe(tabId);
+  });
+
+  test('POST /network-fault installs offline mode', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'offline' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.fault.mode).toBe('offline');
+    expect(typeof body.fault.installedAtMs).toBe('number');
+
+    // Clear for subsequent tests
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /network-fault installs slow_3g mode', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'slow_3g' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fault.mode).toBe('slow_3g');
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /network-fault installs high_latency mode with latencyMs', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'high_latency', latencyMs: 1500 }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fault.mode).toBe('high_latency');
+    expect(body.fault.latencyMs).toBe(1500);
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /network-fault installs timeout_at_request mode', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'timeout_at_request' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fault.mode).toBe('timeout_at_request');
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /network-fault installs timeout_at_response mode', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'timeout_at_response' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fault.mode).toBe('timeout_at_response');
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /network-fault installs intermittent mode', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'intermittent', percent: 50 }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fault.mode).toBe('intermittent');
+    expect(body.fault.percent).toBe(50);
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /network-fault installs server_5xx mode', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'server_5xx', statusCode: 503 }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fault.mode).toBe('server_5xx');
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /network-fault installs malformed_response mode', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'malformed_response' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fault.mode).toBe('malformed_response');
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('GET /network-fault reflects installed fault', async () => {
+    await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'server_5xx', statusCode: 503 }),
+    });
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault?userId=${USER}`);
+    const body = await res.json();
+    expect(body.fault.mode).toBe('server_5xx');
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /network-fault 409 on double-install', async () => {
+    await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'offline' }),
+    });
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'slow_3g' }),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.existing).toBeDefined();
+    expect(body.existing.mode).toBe('offline');
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /clear-network-fault is idempotent when no fault active', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/clear-network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.cleared).toBeNull();
+  });
+
+  test('400 on invalid mode', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'banana' }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('Invalid mode');
+  });
+
+  test('400 when high_latency missing latencyMs', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'high_latency' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('400 when intermittent missing percent', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'intermittent' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('400 when percent sent for non-intermittent mode', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'offline', percent: 50 }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('percent not valid for mode offline');
+  });
+
+  test('400 when statusCode sent for non-server_5xx mode', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'offline', statusCode: 503 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('404 for unknown tab', async () => {
+    const res = await fetch(`${serverUrl}/tabs/nonexistent-tab/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'offline' }),
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/network-fault.test.js
+++ b/tests/network-fault.test.js
@@ -175,6 +175,78 @@ describe('network-fault endpoints', () => {
     });
   });
 
+  test('POST /network-fault installs malformed_truncated_json mode', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'malformed_truncated_json' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fault.mode).toBe('malformed_truncated_json');
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /network-fault installs malformed_wrong_content_type mode', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'malformed_wrong_content_type' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fault.mode).toBe('malformed_wrong_content_type');
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /network-fault installs intermittent mode with dropEveryN', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'intermittent', dropEveryN: 3 }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fault.mode).toBe('intermittent');
+    expect(body.fault.dropEveryN).toBe(3);
+    expect(body.fault.percent).toBeUndefined();
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('400 when dropEveryN sent for non-intermittent mode', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'offline', dropEveryN: 3 }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('dropEveryN not valid for mode offline');
+  });
+
+  test('400 when intermittent has neither percent nor dropEveryN', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, mode: 'intermittent' }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('intermittent requires either percent');
+  });
+
   test('GET /network-fault reflects installed fault', async () => {
     await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
       method: 'POST',
@@ -245,14 +317,8 @@ describe('network-fault endpoints', () => {
     expect(res.status).toBe(400);
   });
 
-  test('400 when intermittent missing percent', async () => {
-    const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ userId: USER, mode: 'intermittent' }),
-    });
-    expect(res.status).toBe(400);
-  });
+  // Note: 'intermittent missing both percent and dropEveryN' is now covered by the
+  // 'intermittent has neither percent nor dropEveryN' test added in the #101 block above.
 
   test('400 when percent sent for non-intermittent mode', async () => {
     const res = await fetch(`${serverUrl}/tabs/${tabId}/network-fault`, {

--- a/tests/timezone.test.js
+++ b/tests/timezone.test.js
@@ -1,0 +1,197 @@
+/**
+ * Tests for BugHunter V23 timezone endpoints.
+ */
+import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
+import { startServer, stopServer, getServerUrl } from './helpers/startServer.js';
+
+const USER = 'bughunter-tz-test';
+
+async function openTab(serverUrl) {
+  const res = await fetch(`${serverUrl}/tabs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId: USER, sessionKey: 'tz-test' }),
+  });
+  const body = await res.json();
+  return body.tabId;
+}
+
+describe('timezone endpoints', () => {
+  let serverUrl;
+  let tabId;
+
+  beforeAll(async () => {
+    await startServer();
+    serverUrl = getServerUrl();
+    tabId = await openTab(serverUrl);
+  }, 60000);
+
+  afterAll(async () => {
+    await stopServer();
+  }, 15000);
+
+  test('POST /timezone installs polyfill and returns reloadRequired: true', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, id: 'America/New_York' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.timezoneId).toBe('America/New_York');
+    expect(body.appliedVia).toBe('init-script');
+    expect(body.reloadRequired).toBe(true);
+
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /timezone + reload makes page see new timezone', async () => {
+    await fetch(`${serverUrl}/tabs/${tabId}/timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, id: 'Asia/Tokyo' }),
+    });
+    // Navigate to apply init-script. Use the server's /health as a valid http:// URL.
+    await fetch(`${serverUrl}/tabs/${tabId}/navigate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, url: serverUrl + '/health' }),
+    });
+    // Verify getTimezoneOffset returns -540 (JST = UTC+9, getTimezoneOffset returns utc - local)
+    const evalRes = await fetch(`${serverUrl}/tabs/${tabId}/evaluate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, expression: 'new Date(0).getTimezoneOffset()' }),
+    });
+    const evalBody = await evalRes.json();
+    // JST is UTC+9, so getTimezoneOffset should be -540
+    expect(evalBody.result).toBe(-540);
+
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('DST: America/New_York offset is 300 (EST) before spring forward, 240 (EDT) after', async () => {
+    await fetch(`${serverUrl}/tabs/${tabId}/timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, id: 'America/New_York' }),
+    });
+    await fetch(`${serverUrl}/tabs/${tabId}/navigate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, url: serverUrl + '/health' }),
+    });
+
+    // 2027-03-14T06:59:59Z = 1 second before DST begins in Eastern Time (2am local → 3am).
+    // Using 2027 (not 2024) because the polyfill offset table covers ±2 years from now (2026).
+    const beforeRes = await fetch(`${serverUrl}/tabs/${tabId}/evaluate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, expression: 'new Date("2027-03-14T06:59:59Z").getTimezoneOffset()' }),
+    });
+    const beforeBody = await beforeRes.json();
+    expect(beforeBody.result).toBe(300); // EST: UTC-5 → getTimezoneOffset = 300
+
+    // 2027-03-14T07:00:01Z = 1 second after DST begins
+    const afterRes = await fetch(`${serverUrl}/tabs/${tabId}/evaluate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, expression: 'new Date("2027-03-14T07:00:01Z").getTimezoneOffset()' }),
+    });
+    const afterBody = await afterRes.json();
+    expect(afterBody.result).toBe(240); // EDT: UTC-4 → getTimezoneOffset = 240
+
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('POST /clear-timezone clears active polyfill', async () => {
+    await fetch(`${serverUrl}/tabs/${tabId}/timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, id: 'Europe/London' }),
+    });
+    const clearRes = await fetch(`${serverUrl}/tabs/${tabId}/clear-timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+    expect(clearRes.status).toBe(200);
+    const clearBody = await clearRes.json();
+    expect(clearBody.cleared).toBe(true);
+    expect(clearBody.reloadRequired).toBe(true);
+  });
+
+  test('POST /clear-timezone is idempotent when no timezone set', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/clear-timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.cleared).toBe(false);
+    expect(body.reloadRequired).toBe(false);
+  });
+
+  test('double-set timezone replaces prior polyfill (single-zone invariant)', async () => {
+    await fetch(`${serverUrl}/tabs/${tabId}/timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, id: 'America/Los_Angeles' }),
+    });
+    const secondRes = await fetch(`${serverUrl}/tabs/${tabId}/timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, id: 'Asia/Tokyo' }),
+    });
+    expect(secondRes.status).toBe(200);
+    const body = await secondRes.json();
+    expect(body.timezoneId).toBe('Asia/Tokyo');
+
+    await fetch(`${serverUrl}/tabs/${tabId}/clear-timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+  });
+
+  test('400 on invalid IANA format', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, id: '' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('400 on missing id', async () => {
+    const res = await fetch(`${serverUrl}/tabs/${tabId}/timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('404 for unknown tab', async () => {
+    const res = await fetch(`${serverUrl}/tabs/no-such-tab/timezone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: USER, id: 'UTC' }),
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/orphanReaper.test.js
+++ b/tests/unit/orphanReaper.test.js
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for the orphan page reaper (BugHunter#174).
+ *
+ * The reaper walks each session's context.pages() and force-closes any Page
+ * NOT present in that session's tabGroups (orphans from prior safePageClose
+ * timeouts). Registered pages are untouched.
+ */
+import { describe, test, expect, jest } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverSource = readFileSync(resolve(__dirname, '../../server.js'), 'utf8');
+
+// Extract reaper logic by simulating its internals.
+function buildOrphanReaper({ log = () => {} } = {}) {
+  return function runOrphanReaper(sessions) {
+    let reaped = 0;
+    for (const session of sessions.values()) {
+      if (session._closing) continue;
+      let contextPages;
+      try {
+        contextPages = session.context.pages();
+      } catch (_) {
+        continue;
+      }
+      const registered = new Set();
+      for (const group of session.tabGroups.values()) {
+        for (const tabState of group.values()) registered.add(tabState.page);
+      }
+      for (const page of contextPages) {
+        if (!registered.has(page)) {
+          reaped++;
+          page.removeAllListeners();
+          page.close({ runBeforeUnload: false }).catch(() => {});
+        }
+      }
+    }
+    if (reaped > 0) log('warn', 'orphan page reaper closed leaked pages', { reaped });
+    return reaped;
+  };
+}
+
+function makePage() {
+  return {
+    removeAllListeners: jest.fn(),
+    close: jest.fn(async () => {}),
+  };
+}
+
+describe('orphan page reaper — source shape', () => {
+  test('reaper interval is present in server source', () => {
+    expect(serverSource).toContain('orphan page reaper closed leaked pages');
+  });
+
+  test('reaper skips sessions marked _closing', () => {
+    expect(serverSource).toContain('if (session._closing) continue');
+  });
+});
+
+describe('orphan page reaper — behaviour', () => {
+  test('skips pages that are in tabGroups (registered)', () => {
+    const page = makePage();
+    const tabState = { page };
+    const group = new Map([['tab-1', tabState]]);
+    const session = {
+      _closing: false,
+      context: { pages: () => [page] },
+      tabGroups: new Map([['grp-1', group]]),
+    };
+    const sessions = new Map([['user-1', session]]);
+    const reaper = buildOrphanReaper();
+    const reaped = reaper(sessions);
+    expect(reaped).toBe(0);
+    expect(page.close).not.toHaveBeenCalled();
+  });
+
+  test('closes orphan pages not in tabGroups', () => {
+    const orphan = makePage();
+    const registered = makePage();
+    const tabState = { page: registered };
+    const group = new Map([['tab-1', tabState]]);
+    const session = {
+      _closing: false,
+      context: { pages: () => [registered, orphan] },
+      tabGroups: new Map([['grp-1', group]]),
+    };
+    const sessions = new Map([['user-1', session]]);
+
+    const logs = [];
+    const reaper = buildOrphanReaper({ log: (...a) => logs.push(a) });
+    const reaped = reaper(sessions);
+
+    expect(reaped).toBe(1);
+    expect(orphan.removeAllListeners).toHaveBeenCalledTimes(1);
+    expect(orphan.close).toHaveBeenCalledWith({ runBeforeUnload: false });
+    expect(registered.close).not.toHaveBeenCalled();
+    expect(logs[0][1]).toContain('orphan page reaper');
+  });
+
+  test('skips sessions marked _closing', () => {
+    const orphan = makePage();
+    const session = {
+      _closing: true,
+      context: { pages: () => [orphan] },
+      tabGroups: new Map(),
+    };
+    const sessions = new Map([['user-1', session]]);
+    const reaper = buildOrphanReaper();
+    expect(reaper(sessions)).toBe(0);
+    expect(orphan.close).not.toHaveBeenCalled();
+  });
+
+  test('skips sessions whose context.pages() throws', () => {
+    const session = {
+      _closing: false,
+      context: { pages: () => { throw new Error('context dead'); } },
+      tabGroups: new Map(),
+    };
+    const sessions = new Map([['user-1', session]]);
+    const reaper = buildOrphanReaper();
+    expect(() => reaper(sessions)).not.toThrow();
+    expect(reaper(sessions)).toBe(0);
+  });
+
+  test('counts orphans across multiple sessions', () => {
+    const orphanA = makePage();
+    const orphanB = makePage();
+    const sessionA = {
+      _closing: false,
+      context: { pages: () => [orphanA] },
+      tabGroups: new Map(),
+    };
+    const sessionB = {
+      _closing: false,
+      context: { pages: () => [orphanB] },
+      tabGroups: new Map(),
+    };
+    const sessions = new Map([['user-1', sessionA], ['user-2', sessionB]]);
+    const logs = [];
+    const reaper = buildOrphanReaper({ log: (...a) => logs.push(a) });
+    expect(reaper(sessions)).toBe(2);
+    expect(logs[0][2].reaped).toBe(2);
+  });
+
+  test('no log emitted when nothing to reap', () => {
+    const sessions = new Map();
+    const logs = [];
+    const reaper = buildOrphanReaper({ log: (...a) => logs.push(a) });
+    expect(reaper(sessions)).toBe(0);
+    expect(logs).toHaveLength(0);
+  });
+});

--- a/tests/unit/safePageClose.test.js
+++ b/tests/unit/safePageClose.test.js
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for safePageClose (BugHunter#174).
+ *
+ * Covers:
+ * 1. Happy path: page closes within timeout — no force-close triggered
+ * 2. Timeout path: hung page.close() causes force-close + removeAllListeners
+ * 3. Already-closed page is a no-op (isClosed guard)
+ * 4. null page is a no-op
+ */
+import { describe, test, expect, jest } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverSource = readFileSync(resolve(__dirname, '../../server.js'), 'utf8');
+
+// Re-implement safePageClose inline from the source so we can inject mocks
+// without importing the full server (which starts a browser).
+function buildSafePageClose({ log = () => {}, PAGE_CLOSE_TIMEOUT_MS = 100 } = {}) {
+  return async function safePageClose(page) {
+    if (!page || page.isClosed()) return;
+    try {
+      await Promise.race([
+        page.close({ runBeforeUnload: false }),
+        new Promise((_, rej) => setTimeout(() => rej(new Error('page close timed out')), PAGE_CLOSE_TIMEOUT_MS)),
+      ]);
+    } catch (e) {
+      log('warn', 'page close timed out, force-closing', { error: e.message });
+      try { await page.close({ runBeforeUnload: false }); } catch (_) {}
+      page.removeAllListeners();
+    }
+  };
+}
+
+describe('safePageClose — source shape', () => {
+  test('uses runBeforeUnload: false in primary close call', () => {
+    expect(serverSource).toContain("page.close({ runBeforeUnload: false })");
+  });
+
+  test('rejects on timeout (not resolves)', () => {
+    expect(serverSource).toContain("page close timed out");
+    // The timeout branch must use reject, not resolve
+    const fnStart = serverSource.indexOf('async function safePageClose');
+    const fnEnd = serverSource.indexOf('\n}', fnStart) + 2;
+    const fn = serverSource.slice(fnStart, fnEnd);
+    expect(fn).toContain('rej(');
+    expect(fn).not.toMatch(/new Promise\(\s*resolve\s*=>/);
+  });
+
+  test('calls removeAllListeners in catch block', () => {
+    const fnStart = serverSource.indexOf('async function safePageClose');
+    const fnEnd = serverSource.indexOf('\n}', fnStart) + 2;
+    const fn = serverSource.slice(fnStart, fnEnd);
+    expect(fn).toContain('page.removeAllListeners()');
+  });
+
+  test('guards against null/closed page', () => {
+    const fnStart = serverSource.indexOf('async function safePageClose');
+    const fnEnd = serverSource.indexOf('\n}', fnStart) + 2;
+    const fn = serverSource.slice(fnStart, fnEnd);
+    expect(fn).toContain('page.isClosed()');
+  });
+});
+
+describe('safePageClose — behaviour', () => {
+  test('happy path: closes successfully within timeout', async () => {
+    const calls = [];
+    const page = {
+      isClosed: () => false,
+      close: jest.fn(async () => { calls.push('close'); }),
+      removeAllListeners: jest.fn(),
+    };
+
+    const logs = [];
+    const safePageClose = buildSafePageClose({ log: (...a) => logs.push(a), PAGE_CLOSE_TIMEOUT_MS: 200 });
+    await safePageClose(page);
+
+    expect(page.close).toHaveBeenCalledTimes(1);
+    expect(page.removeAllListeners).not.toHaveBeenCalled();
+    expect(logs).toHaveLength(0);
+  });
+
+  test('timeout path: force-closes and removes listeners when primary close hangs', async () => {
+    let callCount = 0;
+    const page = {
+      isClosed: () => false,
+      // First call (primary): never resolves to simulate hang.
+      // Second call (force-close): resolves immediately.
+      close: jest.fn(() => {
+        callCount++;
+        if (callCount === 1) return new Promise(() => {});
+        return Promise.resolve();
+      }),
+      removeAllListeners: jest.fn(),
+    };
+
+    const logs = [];
+    const safePageClose = buildSafePageClose({ log: (...a) => logs.push(a), PAGE_CLOSE_TIMEOUT_MS: 50 });
+    await safePageClose(page);
+
+    // close() called twice: once in race, once in force-close catch
+    expect(page.close).toHaveBeenCalledTimes(2);
+    expect(page.removeAllListeners).toHaveBeenCalledTimes(1);
+    expect(logs[0][0]).toBe('warn');
+    expect(logs[0][1]).toContain('timed out');
+  }, 10_000);
+
+  test('already-closed page is skipped entirely', async () => {
+    const page = {
+      isClosed: () => true,
+      close: jest.fn(),
+      removeAllListeners: jest.fn(),
+    };
+
+    const safePageClose = buildSafePageClose({ PAGE_CLOSE_TIMEOUT_MS: 50 });
+    await safePageClose(page);
+
+    expect(page.close).not.toHaveBeenCalled();
+    expect(page.removeAllListeners).not.toHaveBeenCalled();
+  });
+
+  test('null page is a no-op', async () => {
+    const safePageClose = buildSafePageClose({ PAGE_CLOSE_TIMEOUT_MS: 50 });
+    await expect(safePageClose(null)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the Playwright `Page` reference leak identified in the [CAMOFOX_TAB_AUDIT_2026-05-03](../blob/master/BugHunter/CAMOFOX_TAB_AUDIT_2026-05-03.md) audit. After ~30 concurrent tests at concurrency=4, `POST /tabs` was returning `500: tab create timed out after 30000ms` because leaked pages were starving Firefox of DOM threads.

- **Fix 1 — safePageClose**: Timeout branch now rejects (not resolves). Catch block attempts a force-close with `runBeforeUnload: false` and calls `page.removeAllListeners()` to drop GC roots that prevented garbage collection.
- **Fix 2 — getTotalTabCount**: Switched from summing `tabGroups.size` to calling `session.context.pages().length` per session. Leaked pages now exert real backpressure on `MAX_TABS_GLOBAL`, surfacing the leak before Firefox starves.
- **Fix 3 — orphan page reaper**: New 60s `setInterval` that walks each session's `context.pages()` and force-closes any page not present in `tabGroups`. Catches pages that survived a safePageClose timeout. Logs reap count at warn level.

No change to the externally-visible behaviour of `DELETE /tabs/:tabId` on the happy path.

## Test plan

- [x] 16 new unit tests added: `tests/unit/safePageClose.test.js` (8 tests) and `tests/unit/orphanReaper.test.js` (8 tests)
- [x] 2 new e2e regression tests in `tests/e2e/tabLeakRegression.test.js` — open+close 100 tabs and assert `activeTabs === 0`, open+close 30 tabs and assert `activeTabs === 0`
- [x] All 580 pre-existing passing unit tests still pass (2 pre-existing failures in `cookies.test.js` and `openapi.test.js` are unrelated to this change)
- [x] Version bumped 1.8.15 → 1.8.16

This unblocks BugHunter's large smoke runs at concurrency=4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)