### PR TITLE
fix: ship compiled plugin.js so install works on openclaw 2026.5.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build plugin (TypeScript → JS)
+        run: npm run build
+
       - name: Run unit + plugin tests (Jest)
         run: |
           npm install --no-save jest-junit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,9 @@ jobs:
 
       - run: npm ci --ignore-scripts
 
+      - name: Build plugin (TypeScript → JS)
+        run: npm run build
+
       - name: Publish with provenance
         run: npm publish --provenance --access public
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ coverage/
 # Build
 dist/
 build/
+/plugin.js
+/plugin.js.map
 
 # IDE
 .idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,10 @@
         "swagger-jsdoc": "^6.2.8"
       },
       "devDependencies": {
+        "@types/node": "^22.0.0",
         "jest": "^29.7.0",
-        "pngjs": "^7.0.0"
+        "pngjs": "^7.0.0",
+        "typescript": "^5.7.0"
       },
       "engines": {
         "node": ">=18"
@@ -1197,13 +1199,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
-      "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -6072,6 +6074,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/ua-is-frozen": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
@@ -6124,9 +6140,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "plugins/",
     "camofox.config.json",
     "plugin.ts",
+    "plugin.js",
+    "tsconfig.json",
     "openclaw.plugin.json",
     "scripts/",
     "run.sh",
@@ -52,11 +54,14 @@
     "extensions": [
       "plugin.ts"
     ],
+    "runtimeExtensions": [
+      "plugin.js"
+    ],
     "compat": {
       "pluginApi": ">=2026.3.24-beta.2"
     },
     "build": {
-      "openclawVersion": "2026.4.26"
+      "openclawVersion": "2026.5.3"
     },
     "tools": [
       {
@@ -102,6 +107,7 @@
     ]
   },
   "scripts": {
+    "build": "tsc -p .",
     "start": "node server.js",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest --runInBand --forceExit",
     "test:e2e": "NODE_OPTIONS='--experimental-vm-modules' jest --runInBand --forceExit tests/e2e",
@@ -125,7 +131,9 @@
     "swagger-jsdoc": "^6.2.8"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "jest": "^29.7.0",
-    "pngjs": "^7.0.0"
+    "pngjs": "^7.0.0",
+    "typescript": "^5.7.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noImplicitAny": false,
+    "types": ["node"]
+  },
+  "files": ["plugin.ts"]
+}


### PR DESCRIPTION
## Summary

The 2026.5.3 plugin loader requires a compiled JS sibling for any TypeScript entry declared in `openclaw.extensions`. The published `@askjo/camofox-browser@1.8.x` tarball ships only `plugin.ts`, so install fails:

```
package install requires compiled runtime output for TypeScript entry plugin.ts:
expected ./dist/plugin.js, ./dist/plugin.mjs, ./dist/plugin.cjs,
        plugin.js, plugin.mjs, plugin.cjs
Also not a valid hook pack: Error: package.json missing openclaw.hooks
```

**Repro:** `openclaw plugins install @askjo/camofox-browser` on host `>=2026.5.3-1`.

## What this PR changes

- **`tsconfig.json`** (new) — minimal ESM/NodeNext config, target ES2022, `files: ["plugin.ts"]`. Compiles to `plugin.js` at the package root, preserving the existing `./lib/*.js` import paths used by `plugin.ts`.
- **`package.json`**:
  - `scripts.build`: `tsc -p .`
  - `devDependencies`: `typescript ^5.7.0`, `@types/node ^22.0.0`
  - `files`: add `plugin.js`, `tsconfig.json`
  - `openclaw.runtimeExtensions`: `["plugin.js"]` (so the loader knows where the compiled entry is)
  - `openclaw.build.openclawVersion`: `2026.4.26` → `2026.5.3`
- **`.github/workflows/publish.yml`** — `npm run build` step before `npm publish`. (`npm ci --ignore-scripts` skips `prepublishOnly`, so an explicit step is needed.)
- **`.github/workflows/ci.yml`** — `npm run build` in the unit job so future PRs catch build regressions.
- **`.gitignore`** — ignore the built `plugin.js` / `plugin.js.map`.

The compiled output stays at the package root (rather than `dist/`) so `plugin.js`'s `./lib/*.js` imports keep resolving without rewriting them.

## Out of scope

`plugin.ts` has a handful of pre-existing TypeScript errors (commander chained-API typings, an `unknown`-spread on line 615). They emit non-fatally with the current config and don't block the build/publish. Worth tracking and fixing in a follow-up, but I didn't want to bundle them with the install fix.

## Test plan

- [x] `npm install && npm run build` produces `plugin.js` (ESM, imports preserved) at the repo root.
- [x] `npm pack` includes `plugin.js` in the tarball.
- [x] `openclaw plugins install ./askjo-camofox-browser-1.8.15.tgz --force` succeeds end-to-end on openclaw `2026.5.3-1`.
- [ ] Reviewer to confirm CI workflows pass (build + tests).
- [ ] After merge: tag a patch release so the npm package picks up the build step.
