### PR TITLE
feat: POST /tabs/:tabId/viewport for responsive testing

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1029,6 +1029,91 @@
         }
       }
     },
+    "/tabs/{tabId}/viewport": {
+      "post": {
+        "tags": [
+          "Interaction"
+        ],
+        "summary": "Set the page viewport size",
+        "description": "Physically resizes the page via Playwright's `page.setViewportSize`, triggering a real layout reflow. Use for responsive testing — `window.resizeTo()` is a no-op on non-popup windows.\n",
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId",
+                  "width",
+                  "height"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "width": {
+                    "type": "integer",
+                    "minimum": 100,
+                    "maximum": 4000
+                  },
+                  "height": {
+                    "type": "integer",
+                    "minimum": 100,
+                    "maximum": 4000
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Viewport set.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "width": {
+                      "type": "integer"
+                    },
+                    "height": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Width or height missing or out of range."
+          },
+          "404": {
+            "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/tabs/{tabId}/back": {
       "post": {
         "tags": [

--- a/server.js
+++ b/server.js
@@ -3072,6 +3072,88 @@ app.post('/tabs/:tabId/scroll', async (req, res) => {
   }
 });
 
+// Viewport
+/**
+ * @openapi
+ * /tabs/{tabId}/viewport:
+ *   post:
+ *     tags: [Interaction]
+ *     summary: Set the page viewport size
+ *     description: >
+ *       Physically resizes the page via Playwright's `page.setViewportSize`,
+ *       triggering a real layout reflow. Use for responsive testing —
+ *       `window.resizeTo()` is a no-op on non-popup windows.
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId, width, height]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *               width:
+ *                 type: integer
+ *                 minimum: 100
+ *                 maximum: 4000
+ *               height:
+ *                 type: integer
+ *                 minimum: 100
+ *                 maximum: 4000
+ *     responses:
+ *       200:
+ *         description: Viewport set.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                 width:
+ *                   type: integer
+ *                 height:
+ *                   type: integer
+ *       400:
+ *         description: Width or height missing or out of range.
+ *       404:
+ *         description: Tab not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+app.post('/tabs/:tabId/viewport', async (req, res) => {
+  try {
+    const { userId, width, height } = req.body;
+    if (!Number.isFinite(width) || !Number.isFinite(height) || width < 100 || height < 100 || width > 4000 || height > 4000) {
+      return res.status(400).json({ error: 'width and height required (100..4000 px)' });
+    }
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, req.params.tabId);
+    if (!found) return res.status(404).json({ error: 'Tab not found' });
+
+    const { tabState } = found;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
+
+    await tabState.page.setViewportSize({ width: Math.round(width), height: Math.round(height) });
+    await tabState.page.waitForTimeout(150);
+
+    pluginEvents.emit('tab:viewport', { userId, tabId: req.params.tabId, width, height });
+    res.json({ ok: true, width: Math.round(width), height: Math.round(height) });
+  } catch (err) {
+    log('error', 'viewport failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
 // Back
 /**
  * @openapi

--- a/tests/e2e/viewport.test.js
+++ b/tests/e2e/viewport.test.js
@@ -1,0 +1,76 @@
+import { createClient } from '../helpers/client.js';
+import { getSharedEnv } from './sharedEnv.js';
+
+describe('Viewport', () => {
+  let serverUrl;
+  let testSiteUrl;
+
+  beforeAll(() => {
+    const env = getSharedEnv();
+    serverUrl = env.serverUrl;
+    testSiteUrl = env.testSiteUrl;
+  });
+
+  test('set viewport to mobile size', async () => {
+    const client = createClient(serverUrl);
+
+    try {
+      const { tabId } = await client.createTab(`${testSiteUrl}/`);
+
+      const result = await client.viewport(tabId, { width: 375, height: 667 });
+      expect(result.ok).toBe(true);
+      expect(result.width).toBe(375);
+      expect(result.height).toBe(667);
+    } finally {
+      await client.cleanup();
+    }
+  });
+
+  test('set viewport to desktop size', async () => {
+    const client = createClient(serverUrl);
+
+    try {
+      const { tabId } = await client.createTab(`${testSiteUrl}/`);
+
+      const result = await client.viewport(tabId, { width: 1920, height: 1080 });
+      expect(result.ok).toBe(true);
+      expect(result.width).toBe(1920);
+      expect(result.height).toBe(1080);
+    } finally {
+      await client.cleanup();
+    }
+  });
+
+  test('rejects invalid dimensions', async () => {
+    const client = createClient(serverUrl);
+
+    try {
+      const { tabId } = await client.createTab(`${testSiteUrl}/`);
+
+      // Width too small — client throws on non-200
+      await expect(client.viewport(tabId, { width: 50, height: 720 }))
+        .rejects.toThrow('width and height required');
+    } finally {
+      await client.cleanup();
+    }
+  });
+
+  test('viewport change triggers layout reflow', async () => {
+    const client = createClient(serverUrl);
+
+    try {
+      const { tabId } = await client.createTab(`${testSiteUrl}/`);
+
+      // Set to wide desktop
+      await client.viewport(tabId, { width: 1920, height: 1080 });
+
+      // Set to narrow mobile — if the page has responsive CSS,
+      // snapshot content may differ (we just verify the call succeeds)
+      const result = await client.viewport(tabId, { width: 320, height: 568 });
+      expect(result.ok).toBe(true);
+      expect(result.width).toBe(320);
+    } finally {
+      await client.cleanup();
+    }
+  });
+});

--- a/tests/helpers/client.js
+++ b/tests/helpers/client.js
@@ -127,7 +127,11 @@ class BrowserClient {
   async scroll(tabId, options) {
     return this.request('POST', `/tabs/${tabId}/scroll`, { userId: this.userId, ...options });
   }
-  
+
+  async viewport(tabId, { width, height }) {
+    return this.request('POST', `/tabs/${tabId}/viewport`, { userId: this.userId, width, height });
+  }
+
   async back(tabId) {
     return this.request('POST', `/tabs/${tabId}/back`, { userId: this.userId });
   }

--- a/tests/unit/viewport.test.js
+++ b/tests/unit/viewport.test.js
@@ -1,0 +1,88 @@
+/**
+ * Tests for POST /tabs/:tabId/viewport endpoint validation and behavior.
+ */
+import { describe, test, expect } from '@jest/globals';
+
+// ============================================================================
+// Validation logic (mirrors the guard in server.js)
+// ============================================================================
+
+function validateViewport(width, height) {
+  if (!Number.isFinite(width) || !Number.isFinite(height) ||
+      width < 100 || height < 100 || width > 4000 || height > 4000) {
+    return { error: 'width and height required (100..4000 px)' };
+  }
+  return null;
+}
+
+describe('viewport validation', () => {
+  test('rejects missing width', () => {
+    expect(validateViewport(undefined, 720)).not.toBeNull();
+  });
+
+  test('rejects missing height', () => {
+    expect(validateViewport(1280, undefined)).not.toBeNull();
+  });
+
+  test('rejects string width', () => {
+    expect(validateViewport('1280', 720)).not.toBeNull();
+  });
+
+  test('rejects string height', () => {
+    expect(validateViewport(1280, '720')).not.toBeNull();
+  });
+
+  test('rejects width below 100', () => {
+    expect(validateViewport(99, 720)).not.toBeNull();
+  });
+
+  test('rejects height below 100', () => {
+    expect(validateViewport(1280, 99)).not.toBeNull();
+  });
+
+  test('rejects width above 4000', () => {
+    expect(validateViewport(4001, 720)).not.toBeNull();
+  });
+
+  test('rejects height above 4000', () => {
+    expect(validateViewport(1280, 4001)).not.toBeNull();
+  });
+
+  test('accepts minimum values (100x100)', () => {
+    expect(validateViewport(100, 100)).toBeNull();
+  });
+
+  test('accepts maximum values (4000x4000)', () => {
+    expect(validateViewport(4000, 4000)).toBeNull();
+  });
+
+  test('accepts standard desktop viewport (1280x720)', () => {
+    expect(validateViewport(1280, 720)).toBeNull();
+  });
+
+  test('accepts mobile viewport (375x667)', () => {
+    expect(validateViewport(375, 667)).toBeNull();
+  });
+
+  test('accepts tablet viewport (768x1024)', () => {
+    expect(validateViewport(768, 1024)).toBeNull();
+  });
+
+  test('rejects NaN', () => {
+    expect(validateViewport(NaN, 720)).not.toBeNull();
+  });
+
+  test('rejects Infinity', () => {
+    expect(validateViewport(Infinity, 720)).not.toBeNull();
+    expect(validateViewport(1280, -Infinity)).not.toBeNull();
+  });
+
+  test('rejects null', () => {
+    expect(validateViewport(null, null)).not.toBeNull();
+  });
+
+  test('accepts floats (will be rounded by endpoint)', () => {
+    // The endpoint uses Math.round(), so 1280.5 → 1281
+    expect(validateViewport(1280.5, 720.9)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds `POST /tabs/:tabId/viewport` wrapping Playwright's `page.setViewportSize()` for real CSS layout reflows. `window.resizeTo()` is a no-op on non-popup windows — this is the correct primitive for responsive testing and visual regression tools.

## Endpoint

```
POST /tabs/:tabId/viewport
{ "userId": "...", "width": 375, "height": 667 }
→ { "ok": true, "width": 375, "height": 667 }
```

- **Validation**: width/height must be finite numbers in 100..4000 px
- **Settle delay**: 150ms after resize for SPAs (media queries, ResizeObserver, useMediaQuery hooks)
- **Plugin event**: emits `tab:viewport`
- **Improved validation** over #1587: uses `Number.isFinite()` to reject NaN/Infinity (which bypass typeof + range checks)

## Tests

- 17 unit tests: all validation edge cases (missing, strings, out-of-range, NaN, Infinity, null, floats, valid breakpoints)
- 4 e2e tests: mobile resize, desktop resize, invalid dimensions rejected, sequential resizes

## Attribution

Based on the approach from #1587 by @cunninghambe, with improved input validation and full test coverage.

Co-authored-by: cunninghambe <cunninghambe@users.noreply.github.com>