### PR TITLE
fix: session lifecycle robustness — nav timeout, drain-before-close, proxy retry

### DIFF
--- a/lib/request-utils.js
+++ b/lib/request-utils.js
@@ -51,6 +51,9 @@ export function classifyError(err) {
   if (msg.includes('not visible') || msg.includes('not an <input>')) return 'element_error';
   if (msg.includes('Blocked URL scheme') || msg.includes('Invalid URL')) return 'invalid_url';
   if (msg.includes('net::') || msg.includes('ERR_NAME') || msg.includes('ERR_CONNECTION')) return 'network';
+  if (msg.includes('Navigation aborted: tab deleted')) return 'tab_destroyed';
+  if (msg.includes('NS_ERROR_ABORT')) return 'nav_aborted';
+  if (msg.includes('Page crashed')) return 'page_crashed';
   if (msg.includes('Navigation failed') || msg.includes('ERR_ABORTED')) return 'nav_aborted';
   return 'unknown';
 }

--- a/server.js
+++ b/server.js
@@ -1025,6 +1025,12 @@ async function closeSession(userId, session, {
 
   const key = normalizeUserId(userId);
 
+  // Drain locks BEFORE closing context — queued operations get clean "Tab destroyed"
+  // (410) instead of messy "Target page closed" (500) errors.
+  if (clearLocks) {
+    clearSessionLocks(session);
+  }
+
   if (clearDownloads) {
     await clearSessionDownloads(session).catch(() => {});
   }
@@ -1042,10 +1048,6 @@ async function closeSession(userId, session, {
   await session.context.close().catch(() => {});
   sessions.delete(key);
   await pluginEvents.emitAsync('session:destroyed', { userId: key, reason });
-
-  if (clearLocks) {
-    clearSessionLocks(session);
-  }
 
   refreshActiveTabsGauge();
 }
@@ -1198,8 +1200,21 @@ function handleRouteError(err, req, res, extraFields = {}) {
     browserRestartsTotal.labels('proxy_error').inc();
     destroySession(userId);
   }
+  // Navigation-related timeouts can poison the proxy session (e.g., Cloudflare holding
+  // the connection open for 30s). The browser context shares a single proxy session, so
+  // one poisoned page kills all subsequent navigations in that context. Destroy the
+  // entire session so the next request gets a fresh BrowserContext + proxy.
+  const NAVIGATION_TIMEOUT_ACTIONS = new Set(['click', 'navigate', 'open_url']);
+  if (isTimeoutError(err) && userId && NAVIGATION_TIMEOUT_ACTIONS.has(action)) {
+    log('warn', 'navigation timeout — destroying session for fresh proxy', {
+      action, userId, error: err.message,
+    });
+    browserRestartsTotal.labels('navigation_timeout').inc();
+    destroySession(userId);
+  }
   // Track consecutive timeouts per tab and auto-destroy stuck tabs
-  if (userId && isTimeoutError(err)) {
+  // (for non-navigation timeouts like type, scroll that don't poison the proxy)
+  if (userId && isTimeoutError(err) && !NAVIGATION_TIMEOUT_ACTIONS.has(action)) {
     const tabId = req.body?.tabId || req.query?.tabId || req.params?.tabId;
     const session = sessions.get(normalizeUserId(userId));
     if (session && tabId) {
@@ -1224,6 +1239,12 @@ function handleRouteError(err, req, res, extraFields = {}) {
   // Tab was destroyed while this request was queued in the lock
   if (isTabDestroyedError(err)) {
     return res.status(410).json({ error: 'Tab was destroyed. Open a new tab.', ...extraFields });
+  }
+  // Dead context = session torn down (by proxy error, timeout, or reaper) while this op
+  // was in flight. The ROOT CAUSE was already reported — this is a cascade error.
+  // Return 503 (retriable) so the client retries with a fresh session.
+  if (isDeadContextError(err)) {
+    return res.status(503).json({ error: 'Browser session expired. Retry to get a fresh session.', code: 'session_expired', ...extraFields });
   }
   // --- Frustration detection: report when a tab hits a streak of failures ---
   // Individual failures are noise. 3+ consecutive = the site is persistently broken.
@@ -2059,7 +2080,7 @@ app.post('/tabs', async (req, res) => {
           { statusCode: 409 },
         );
       }
-      const session = await getSession(userId, { trace: !!trace });
+      let session = await getSession(userId, { trace: !!trace });
       
       let totalTabs = 0;
       for (const group of session.tabGroups.values()) totalTabs += group.size;
@@ -2076,7 +2097,7 @@ app.post('/tabs', async (req, res) => {
       
       const page = await session.context.newPage();
       const tabId = fly.makeTabId();
-      const tabState = createTabState(page);
+      let tabState = createTabState(page);
       attachDownloadListener(tabState, tabId, log, pluginEvents, userId);
       group.set(tabId, tabState);
       refreshActiveTabsGauge();
@@ -2085,7 +2106,32 @@ app.post('/tabs', async (req, res) => {
         const urlErr = validateUrl(url);
         if (urlErr) throw Object.assign(new Error(urlErr), { statusCode: 400 });
         tabState.lastRequestedUrl = url;
-        await withPageLoadDuration('open_url', () => page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 }));
+        try {
+          await withPageLoadDuration('open_url', () => page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 }));
+        } catch (navErr) {
+          if ((isProxyError(navErr) || isTimeoutError(navErr)) && proxyPool?.canRotateSessions) {
+            log('warn', 'tab create navigate failed, retrying with fresh proxy', {
+              reqId: req.reqId, tabId, error: navErr.message,
+            });
+            browserRestartsTotal.labels('proxy_retry').inc();
+            const key = normalizeUserId(userId);
+            const oldSession = sessions.get(key);
+            if (oldSession) {
+              await closeSession(key, oldSession, { reason: 'proxy_retry_rotate', clearDownloads: true, clearLocks: true });
+            }
+            session = await getSession(userId, { trace: !!trace });
+            const retryGroup = getTabGroup(session, resolvedSessionKey);
+            const retryPage = await session.context.newPage();
+            tabState = createTabState(retryPage);
+            tabState.lastRequestedUrl = url;
+            attachDownloadListener(tabState, tabId, log, pluginEvents, userId);
+            retryGroup.set(tabId, tabState);
+            refreshActiveTabsGauge();
+            await withPageLoadDuration('open_url', () => retryPage.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 }));
+          } else {
+            throw navErr;
+          }
+        }
         tabState.visitedUrls.add(url);
       }
       
@@ -2260,7 +2306,24 @@ app.post('/tabs/:tabId/navigate', async (req, res) => {
           await prewarmGoogleHome();
         }
 
-        await navigateCurrentPage();
+        // Navigate with transparent retry on proxy/timeout errors.
+        // If the proxy is blocked or the page times out, destroy the session,
+        // get a fresh proxy, and retry once before failing to the caller.
+        try {
+          await navigateCurrentPage();
+        } catch (navErr) {
+          if ((isProxyError(navErr) || isTimeoutError(navErr)) && proxyPool?.canRotateSessions) {
+            log('warn', 'navigate failed, retrying with fresh proxy session', {
+              reqId: req.reqId, tabId, error: navErr.message,
+            });
+            browserRestartsTotal.labels('proxy_retry').inc();
+            await recreateTabOnFreshContext();
+            if (isGoogleSearch) await prewarmGoogleHome();
+            await navigateCurrentPage();
+          } else {
+            throw navErr;
+          }
+        }
 
         if (isGoogleSearch && proxyPool?.canRotateSessions && await isGoogleSearchBlocked(tabState.page)) {
           log('warn', 'google search blocked, rotating browser proxy session', {
@@ -3210,7 +3273,7 @@ app.post('/tabs/:tabId/back', async (req, res) => {
     
     const result = await withTabLock(tabId, async () => {
       try {
-        await tabState.page.goBack({ timeout: 10000 });
+        await tabState.page.goBack({ timeout: 20000 });
       } catch (navErr) {
         // NS_BINDING_CANCELLED_OLD_LOAD: Firefox cancels the old load when going back.
         // The navigation itself succeeded -- just the prior page's load was interrupted.
@@ -4623,7 +4686,7 @@ app.post('/tabs/open', async (req, res) => {
     const urlErr = validateUrl(url);
     if (urlErr) return res.status(400).json({ error: urlErr });
     
-    const session = await getSession(userId);
+    let session = await getSession(userId);
     
     // Recycle oldest tab when limits are reached instead of rejecting
     let totalTabs = 0;
@@ -4635,16 +4698,40 @@ app.post('/tabs/open', async (req, res) => {
       }
     }
     
-    const group = getTabGroup(session, listItemId);
+    let group = getTabGroup(session, listItemId);
     
-    const page = await session.context.newPage();
+    let page = await session.context.newPage();
     const tabId = fly.makeTabId();
-    const tabState = createTabState(page);
+    let tabState = createTabState(page);
     attachDownloadListener(tabState, tabId, log, pluginEvents, userId);
     group.set(tabId, tabState);
     refreshActiveTabsGauge();
     
-    await withPageLoadDuration('open_url', () => page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 }));
+    try {
+      await withPageLoadDuration('open_url', () => page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 }));
+    } catch (navErr) {
+      if ((isProxyError(navErr) || isTimeoutError(navErr)) && proxyPool?.canRotateSessions) {
+        log('warn', 'tab open failed, retrying with fresh proxy', {
+          reqId: req.reqId, tabId, error: navErr.message,
+        });
+        browserRestartsTotal.labels('proxy_retry').inc();
+        const key = normalizeUserId(userId);
+        const oldSession = sessions.get(key);
+        if (oldSession) {
+          await closeSession(key, oldSession, { reason: 'proxy_retry_rotate', clearDownloads: true, clearLocks: true });
+        }
+        session = await getSession(userId);
+        group = getTabGroup(session, listItemId);
+        page = await session.context.newPage();
+        tabState = createTabState(page);
+        attachDownloadListener(tabState, tabId, log, pluginEvents, userId);
+        group.set(tabId, tabState);
+        refreshActiveTabsGauge();
+        await withPageLoadDuration('open_url', () => page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 }));
+      } else {
+        throw navErr;
+      }
+    }
     tabState.visitedUrls.add(url);
     
     log('info', 'openclaw tab opened', { reqId: req.reqId, tabId, url: page.url() });

--- a/tests/unit/navigationTimeout.test.js
+++ b/tests/unit/navigationTimeout.test.js
@@ -1,0 +1,180 @@
+/**
+ * Tests for navigation timeout session destruction.
+ *
+ * When a click/navigate/open_url times out, the proxy session may be poisoned
+ * (e.g., Cloudflare holding the connection). The server should destroy the
+ * entire user session so the next request gets a fresh BrowserContext + proxy.
+ *
+ * Non-navigation timeouts (type, scroll) should only track per-tab consecutive
+ * timeouts without destroying the session.
+ */
+
+import { actionFromReq, classifyError } from '../../lib/request-utils.js';
+
+// --- Replicate the error handling logic from server.js ---
+
+const NAVIGATION_TIMEOUT_ACTIONS = new Set(['click', 'navigate', 'open_url']);
+const MAX_CONSECUTIVE_TIMEOUTS = 3;
+
+function isTimeoutError(err) {
+  if (!err) return false;
+  const msg = err.message || '';
+  return msg.includes('timed out after') || (msg.includes('Timeout') && msg.includes('exceeded'));
+}
+
+function isProxyError(err) {
+  if (!err) return false;
+  const msg = err.message || '';
+  return msg.includes('NS_ERROR_PROXY') || msg.includes('proxy connection') || msg.includes('Proxy connection');
+}
+
+/**
+ * Simulate handleRouteError's session/tab destruction logic.
+ * Returns { sessionDestroyed, tabDestroyed, reason }.
+ */
+function simulateErrorHandling(err, action, userId, tabState) {
+  const result = { sessionDestroyed: false, tabDestroyed: false, reason: null };
+
+  // Proxy errors destroy session
+  if (isProxyError(err) && userId) {
+    result.sessionDestroyed = true;
+    result.reason = 'proxy_error';
+    return result;
+  }
+
+  // Navigation timeouts destroy session (proxy may be poisoned)
+  if (isTimeoutError(err) && userId && NAVIGATION_TIMEOUT_ACTIONS.has(action)) {
+    result.sessionDestroyed = true;
+    result.reason = 'navigation_timeout';
+    return result;
+  }
+
+  // Non-navigation timeouts track per-tab consecutive count
+  if (isTimeoutError(err) && userId && !NAVIGATION_TIMEOUT_ACTIONS.has(action) && tabState) {
+    tabState.consecutiveTimeouts = (tabState.consecutiveTimeouts || 0) + 1;
+    if (tabState.consecutiveTimeouts >= MAX_CONSECUTIVE_TIMEOUTS) {
+      result.tabDestroyed = true;
+      result.reason = 'consecutive_timeouts';
+    }
+    return result;
+  }
+
+  return result;
+}
+
+// --- Tests ---
+
+describe('navigation timeout session destruction', () => {
+  const timeoutError = new Error('action timed out after 30000ms');
+  const playwrightTimeout = new Error('page.goto: Timeout 30000ms exceeded.\nCall log:\n  - navigating to "https://www.google.com/", waiting until "domcontentloaded"');
+  const proxyError = new Error('NS_ERROR_PROXY_CONNECTION_REFUSED');
+
+  test('click timeout destroys session', () => {
+    const result = simulateErrorHandling(timeoutError, 'click', 'user-1', {});
+    expect(result.sessionDestroyed).toBe(true);
+    expect(result.reason).toBe('navigation_timeout');
+  });
+
+  test('navigate timeout destroys session', () => {
+    const result = simulateErrorHandling(playwrightTimeout, 'navigate', 'user-1', {});
+    expect(result.sessionDestroyed).toBe(true);
+    expect(result.reason).toBe('navigation_timeout');
+  });
+
+  test('open_url timeout destroys session', () => {
+    const result = simulateErrorHandling(timeoutError, 'open_url', 'user-1', {});
+    expect(result.sessionDestroyed).toBe(true);
+    expect(result.reason).toBe('navigation_timeout');
+  });
+
+  test('type timeout does NOT destroy session, tracks per-tab', () => {
+    const tabState = { consecutiveTimeouts: 0 };
+    const result = simulateErrorHandling(timeoutError, 'type', 'user-1', tabState);
+    expect(result.sessionDestroyed).toBe(false);
+    expect(result.tabDestroyed).toBe(false);
+    expect(tabState.consecutiveTimeouts).toBe(1);
+  });
+
+  test('scroll timeout does NOT destroy session', () => {
+    const tabState = { consecutiveTimeouts: 0 };
+    const result = simulateErrorHandling(timeoutError, 'scroll', 'user-1', tabState);
+    expect(result.sessionDestroyed).toBe(false);
+    expect(tabState.consecutiveTimeouts).toBe(1);
+  });
+
+  test('3 consecutive type timeouts destroys tab (not session)', () => {
+    const tabState = { consecutiveTimeouts: 0 };
+    simulateErrorHandling(timeoutError, 'type', 'user-1', tabState);
+    simulateErrorHandling(timeoutError, 'type', 'user-1', tabState);
+    const result = simulateErrorHandling(timeoutError, 'type', 'user-1', tabState);
+    expect(result.tabDestroyed).toBe(true);
+    expect(result.sessionDestroyed).toBe(false);
+    expect(result.reason).toBe('consecutive_timeouts');
+  });
+
+  test('proxy error still destroys session', () => {
+    const result = simulateErrorHandling(proxyError, 'navigate', 'user-1', {});
+    expect(result.sessionDestroyed).toBe(true);
+    expect(result.reason).toBe('proxy_error');
+  });
+
+  test('no userId = no destruction', () => {
+    const result = simulateErrorHandling(timeoutError, 'click', null, {});
+    expect(result.sessionDestroyed).toBe(false);
+    expect(result.tabDestroyed).toBe(false);
+  });
+
+  test('non-timeout error on click does NOT destroy session', () => {
+    const otherError = new Error('Element not found');
+    const result = simulateErrorHandling(otherError, 'click', 'user-1', {});
+    expect(result.sessionDestroyed).toBe(false);
+  });
+});
+
+describe('actionFromReq classifies routes correctly', () => {
+  function makeReq(method, routePath) {
+    return { method, route: { path: routePath }, path: routePath };
+  }
+
+  test('click route → "click"', () => {
+    expect(actionFromReq(makeReq('POST', '/tabs/:tabId/click'))).toBe('click');
+  });
+
+  test('navigate route → "navigate"', () => {
+    expect(actionFromReq(makeReq('POST', '/tabs/:tabId/navigate'))).toBe('navigate');
+  });
+
+  test('open_url route → "open_url"', () => {
+    expect(actionFromReq(makeReq('POST', '/tabs/open'))).toBe('open_url');
+  });
+
+  test('type route → "type"', () => {
+    expect(actionFromReq(makeReq('POST', '/tabs/:tabId/type'))).toBe('type');
+  });
+
+  test('scroll route → "scroll"', () => {
+    expect(actionFromReq(makeReq('POST', '/tabs/:tabId/scroll'))).toBe('scroll');
+  });
+
+  test('create_tab route → "create_tab"', () => {
+    expect(actionFromReq(makeReq('POST', '/tabs'))).toBe('create_tab');
+  });
+});
+
+describe('classifyError categorizes timeout vs proxy', () => {
+  test('action timeout → "timeout"', () => {
+    expect(classifyError(new Error('action timed out after 30000ms'))).toBe('timeout');
+  });
+
+  test('playwright timeout → "timeout"', () => {
+    expect(classifyError(new Error('page.goto: Timeout 30000ms exceeded.'))).toBe('timeout');
+  });
+
+  test('proxy refused → "proxy"', () => {
+    expect(classifyError(new Error('NS_ERROR_PROXY_CONNECTION_REFUSED'))).toBe('proxy');
+  });
+
+  test('dead context → "dead_context"', () => {
+    expect(classifyError(new Error('Target page, context or browser has been closed'))).toBe('dead_context');
+  });
+});


### PR DESCRIPTION
## Summary

Five production-hardened fixes for session lifecycle reliability, ported from downstream deployment experience.

### Fix 1: Drain tab locks BEFORE closing browser context
Queued operations now get clean `Tab destroyed` (410) instead of cascading `Target page closed` (500) errors. Previously, closing the context first caused all queued `withTabLock` operations to throw unhandled dead-context errors.

### Fix 2: Navigation timeout → session destruction
Navigation-related timeouts (click, navigate, open_url) now destroy the entire user session. The browser context shares a single proxy session, so one poisoned page (e.g., Cloudflare holding connection for 30s) kills all subsequent navigations. Non-navigation timeouts (type, scroll) still use per-tab consecutive timeout tracking.

### Fix 3: Dead-context → 503 (retriable)
Dead-context errors now return `503 session_expired` instead of falling through to generic 500. The root cause (proxy error, timeout, reaper) is already reported — this prevents cascade noise and tells clients to retry for a fresh session.

### Fix 4: Transparent proxy retry on navigation
When `page.goto` fails with `NS_ERROR_PROXY` or timeout, destroys the session, gets a fresh proxy, and retries once before failing to caller. Applied to:
- `POST /tabs` (create with URL)
- `POST /tabs/:tabId/navigate`
- `POST /tabs/open`

### Fix 5: goBack timeout 10s → 20s
Back navigation uses browser cache and shouldn't need aggressive timeouts. 10s was too short for complex SPA re-renders.

### Also
- Additional error classifications in `classifyError` (`NS_ERROR_ABORT`, `Navigation aborted: tab deleted`, `Page crashed`)
- 180-line unit test file for navigation timeout behavior

---

All changes battle-tested on [askjo.ai](https://askjo.ai).