### PR TITLE
Support external Camoufox executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ Default port is `9377`. See [Environment Variables](#environment-variables) for 
 
 > **Note:** the postinstall script unsets `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` for itself before fetching the Camoufox binary. Without that override, an exported `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` (common when Playwright is configured to use system Chrome) would silently skip the binary download and crash the server at runtime.
 >
-> **Air-gapped or custom binary management:** disable the auto-fetch with `npm install --ignore-scripts` (skips lifecycle scripts for *every* dependency — bluntest option) or, more surgically, `npm install --omit=optional` plus a manual `npx camoufox-js fetch` step against your mirror. Note that `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install` no longer skips the Camoufox download (the postinstall sanitizes the env locally); use `--ignore-scripts` for that.
+> **External Camoufox executable:** set `CAMOUFOX_EXECUTABLE=/path/to/camoufox-bin` before `npm install` and when starting the server to skip the bundled download and launch that executable. Compatibility aliases are `CAMOUFOX_EXECUTABLE_PATH` and `CAMOFOX_EXECUTABLE_PATH`. This is useful for NixOS paths such as `/nix/store/.../camoufox-bin`; the executable must come from a Camoufox bundle that includes `properties.json`, `version.json`, and `fontconfig/`.
+>
+> **Air-gapped or custom binary management:** prefer `CAMOUFOX_EXECUTABLE` when you already have a Camoufox bundle. Otherwise disable the auto-fetch with `npm install --ignore-scripts` (skips lifecycle scripts for *every* dependency -- bluntest option) or, more surgically, `npm install --omit=optional` plus a manual `npx camoufox-js fetch` step against your mirror. Note that `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install` no longer skips the Camoufox download (the postinstall sanitizes the env locally); use `--ignore-scripts` or `CAMOUFOX_EXECUTABLE` for that.
 
 ### Docker
 
@@ -569,6 +571,9 @@ Reddit macros return JSON directly (no HTML parsing needed):
 | `CAMOFOX_API_KEY` | Enable cookie import endpoint (disabled if unset) | - |
 | `CAMOFOX_ADMIN_KEY` | Required for `POST /stop` | - |
 | `CAMOFOX_ACCESS_KEY` | If set, all routes (except `/health`, cookie import, and `/stop`) require `Authorization: Bearer <key>`. Lets you safely expose the server beyond loopback. | - |
+| `CAMOUFOX_EXECUTABLE` | External Camoufox executable to use instead of downloading/launching the bundled cache. Must point to a Camoufox bundle with sibling resources. | - |
+| `CAMOUFOX_EXECUTABLE_PATH` | Compatibility alias for `CAMOUFOX_EXECUTABLE` | - |
+| `CAMOFOX_EXECUTABLE_PATH` | Compatibility alias for `CAMOUFOX_EXECUTABLE` | - |
 | `CAMOFOX_COOKIES_DIR` | Directory for cookie files | `~/.camofox/cookies` |
 | `CAMOFOX_PROFILE_DIR` | Directory for persisted session profiles | `~/.camofox/profiles` |
 | `CAMOFOX_TRACES_DIR` | Directory for session trace zips | `~/.camofox/traces` |

--- a/lib/camoufox-executable.js
+++ b/lib/camoufox-executable.js
@@ -1,0 +1,189 @@
+import crypto from 'crypto';
+import {
+  accessSync,
+  constants,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
+import { dirname, join, resolve } from 'path';
+import { platform, tmpdir } from 'os';
+
+function assertExecutable(path) {
+  const stat = statSync(path);
+  if (!stat.isFile() && !stat.isSymbolicLink()) {
+    throw new Error(`Camoufox executable is not a file: ${path}`);
+  }
+  if (platform() !== 'win32') accessSync(path, constants.X_OK);
+}
+
+function nixStoreRoot(path) {
+  const match = path.match(/^\/nix\/store\/[^/]+/);
+  return match?.[0] || null;
+}
+
+function collectDirs(root, maxDepth = 4) {
+  const dirs = [];
+  const queue = [{ dir: root, depth: 0 }];
+  const seen = new Set();
+
+  while (queue.length > 0) {
+    const { dir, depth } = queue.shift();
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+    dirs.push(dir);
+    if (depth >= maxDepth) continue;
+
+    let entries = [];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+      queue.push({ dir: join(dir, entry.name), depth: depth + 1 });
+    }
+  }
+
+  return dirs;
+}
+
+function findResourceDir(executablePath) {
+  const resolvedPath = realpathSync(executablePath);
+  const directDirs = [
+    dirname(executablePath),
+    dirname(resolvedPath),
+  ];
+
+  const storeRoot = nixStoreRoot(resolvedPath) || nixStoreRoot(executablePath);
+  const likelyDirs = storeRoot
+    ? [
+        storeRoot,
+        join(storeRoot, 'lib', 'camoufox'),
+        join(storeRoot, 'libexec', 'camoufox'),
+        join(storeRoot, 'share', 'camoufox'),
+        join(storeRoot, 'opt', 'camoufox'),
+      ]
+    : [];
+
+  const allCandidates = [...directDirs, ...likelyDirs];
+  for (const dir of allCandidates) {
+    if (existsSync(join(dir, 'properties.json'))) return dir;
+  }
+
+  if (storeRoot) {
+    for (const dir of collectDirs(storeRoot)) {
+      if (existsSync(join(dir, 'properties.json'))) return dir;
+    }
+  }
+
+  return null;
+}
+
+function ensureSymlink(target, linkPath, type = 'file') {
+  rmSync(linkPath, { force: true, recursive: true });
+  symlinkSync(target, linkPath, platform() === 'win32' && type === 'dir' ? 'junction' : type);
+}
+
+function shimRootFor(executablePath, resourceDir) {
+  const key = crypto
+    .createHash('sha256')
+    .update(`${realpathSync(executablePath)}\n${realpathSync(resourceDir)}`)
+    .digest('hex')
+    .slice(0, 16);
+  return join(tmpdir(), 'camofox-browser-external-camoufox', key);
+}
+
+function ensureLaunchShim(executablePath, resourceDir) {
+  const shimRoot = shimRootFor(executablePath, resourceDir);
+  mkdirSync(shimRoot, { recursive: true });
+
+  const shimExecutable = join(shimRoot, platform() === 'win32' ? 'camoufox.exe' : 'camoufox-bin');
+  ensureSymlink(realpathSync(executablePath), shimExecutable);
+
+  for (const name of ['properties.json', 'version.json']) {
+    const target = join(resourceDir, name);
+    if (existsSync(target)) ensureSymlink(realpathSync(target), join(shimRoot, name));
+  }
+
+  const fontconfig = join(resourceDir, 'fontconfig');
+  if (existsSync(fontconfig)) ensureSymlink(realpathSync(fontconfig), join(shimRoot, 'fontconfig'), 'dir');
+
+  return shimExecutable;
+}
+
+function camoufoxLaunchFileName() {
+  if (platform() === 'win32') return 'camoufox.exe';
+  if (platform() === 'darwin') return join('Camoufox.app', 'Contents', 'MacOS', 'camoufox');
+  return 'camoufox-bin';
+}
+
+function ensureCamoufoxJsCache(resourceDir, cacheDir, executablePath) {
+  const cacheVersion = join(cacheDir, 'version.json');
+  const cacheFontconfig = join(cacheDir, 'fontconfig');
+  const cacheProperties = join(cacheDir, 'properties.json');
+  const cacheExecutable = join(cacheDir, camoufoxLaunchFileName());
+
+  if (
+    existsSync(cacheVersion) &&
+    existsSync(cacheFontconfig) &&
+    existsSync(cacheProperties) &&
+    existsSync(cacheExecutable)
+  ) {
+    return;
+  }
+
+  const versionFile = join(resourceDir, 'version.json');
+  const propertiesFile = join(resourceDir, 'properties.json');
+  const fontconfig = join(resourceDir, 'fontconfig');
+  if (!existsSync(versionFile) || !existsSync(propertiesFile) || !existsSync(fontconfig)) {
+    throw new Error(
+      `External Camoufox bundle at ${resourceDir} must include properties.json, version.json, and fontconfig/ for camoufox-js compatibility`
+    );
+  }
+
+  mkdirSync(cacheDir, { recursive: true });
+  if (!existsSync(cacheVersion)) {
+    writeFileSync(cacheVersion, readFileSync(versionFile));
+  }
+  if (!existsSync(cacheProperties)) {
+    ensureSymlink(realpathSync(propertiesFile), cacheProperties);
+  }
+  if (!existsSync(cacheFontconfig)) {
+    ensureSymlink(realpathSync(fontconfig), cacheFontconfig, 'dir');
+  }
+  if (!existsSync(cacheExecutable)) {
+    mkdirSync(dirname(cacheExecutable), { recursive: true });
+    ensureSymlink(realpathSync(executablePath), cacheExecutable);
+  }
+}
+
+export function prepareExternalCamoufoxExecutable(executablePath, { cacheDir } = {}) {
+  if (!executablePath) return null;
+  if (!cacheDir) throw new Error('cacheDir is required for external Camoufox executable preparation');
+
+  const resolvedExecutable = resolve(executablePath);
+  assertExecutable(resolvedExecutable);
+
+  const resourceDir = findResourceDir(resolvedExecutable);
+  if (!resourceDir) {
+    throw new Error(
+      `Could not find Camoufox resources for ${resolvedExecutable}. ` +
+      'Point the executable override at a Camoufox bundle that includes properties.json.'
+    );
+  }
+
+  ensureCamoufoxJsCache(resourceDir, cacheDir, resolvedExecutable);
+
+  return {
+    executablePath: ensureLaunchShim(resolvedExecutable, resourceDir),
+    resourceDir,
+  };
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -46,7 +46,27 @@ function inferProxyStrategy(explicitStrategy) {
   return 'round_robin';
 }
 
+function camoufoxCacheDir(env = process.env) {
+  const home = os.homedir();
+  if (process.platform === 'darwin') return join(home, 'Library', 'Caches', 'camoufox');
+  if (process.platform === 'win32') {
+    const base = env.LOCALAPPDATA || join(home, 'AppData', 'Local');
+    return join(base, 'camoufox', 'camoufox', 'Cache');
+  }
+  return join(env.XDG_CACHE_HOME || join(home, '.cache'), 'camoufox');
+}
+
+function camoufoxExecutablePath(env = process.env) {
+  return (
+    env.CAMOUFOX_EXECUTABLE ||
+    env.CAMOUFOX_EXECUTABLE_PATH ||
+    env.CAMOFOX_EXECUTABLE_PATH ||
+    ''
+  ).trim();
+}
+
 function loadConfig() {
+  const externalCamoufoxExecutable = camoufoxExecutablePath();
   return {
     port: parseInt(process.env.CAMOFOX_PORT || process.env.PORT || '9377', 10),
     nodeEnv: process.env.NODE_ENV || 'development',
@@ -72,6 +92,8 @@ function loadConfig() {
     buildrefsTimeoutMs: parseInt(process.env.BUILDREFS_TIMEOUT_MS) || 12000,
     browserIdleTimeoutMs: parseInt(process.env.BROWSER_IDLE_TIMEOUT_MS) || 300000,
     nativeMemRestartThresholdMb: parseInt(process.env.NATIVE_MEM_RESTART_THRESHOLD_MB) || 200,
+    camoufoxExecutablePath: externalCamoufoxExecutable,
+    camoufoxCacheDir: camoufoxCacheDir(),
     prometheusEnabled: process.env.PROMETHEUS_ENABLED === '1' || process.env.PROMETHEUS_ENABLED === 'true',
     proxy: {
       strategy: inferProxyStrategy(process.env.PROXY_STRATEGY || ''),
@@ -101,6 +123,9 @@ function loadConfig() {
       CAMOFOX_TRACES_DIR: process.env.CAMOFOX_TRACES_DIR,
       CAMOFOX_TRACES_MAX_BYTES: process.env.CAMOFOX_TRACES_MAX_BYTES,
       CAMOFOX_TRACES_TTL_HOURS: process.env.CAMOFOX_TRACES_TTL_HOURS,
+      CAMOUFOX_EXECUTABLE: process.env.CAMOUFOX_EXECUTABLE,
+      CAMOUFOX_EXECUTABLE_PATH: process.env.CAMOUFOX_EXECUTABLE_PATH,
+      CAMOFOX_EXECUTABLE_PATH: process.env.CAMOFOX_EXECUTABLE_PATH,
       PROXY_STRATEGY: process.env.PROXY_STRATEGY,
       PROXY_PROVIDER: process.env.PROXY_PROVIDER,
       PROXY_HOST: process.env.PROXY_HOST,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -25,6 +25,11 @@
       "required": false,
       "sensitive": false,
       "default": "https://camofox-telemetry.askjo.workers.dev/report"
+    },
+    "CAMOUFOX_EXECUTABLE": {
+      "description": "External Camoufox executable to use instead of downloading the bundled browser. Compatibility aliases: CAMOUFOX_EXECUTABLE_PATH, CAMOFOX_EXECUTABLE_PATH.",
+      "required": false,
+      "sensitive": false
     }
   },
   "configSchema": {
@@ -178,10 +183,10 @@
   ],
   "runtimeDependencies": {
     "camoufox": {
-      "description": "Camoufox anti-detection browser (Firefox fork). Downloaded at install time by camoufox-js from the official Camoufox GitHub releases.",
+      "description": "Camoufox anti-detection browser (Firefox fork). Downloaded at install time by camoufox-js unless CAMOUFOX_EXECUTABLE points to an external bundle.",
       "source": "https://github.com/nicedayzhu/camoufox/releases",
       "installer": "camoufox-js (npm)",
-      "installedBy": "postinstall script: npx camoufox-js fetch",
+      "installedBy": "postinstall script: npx camoufox-js fetch, skipped when CAMOUFOX_EXECUTABLE is set",
       "sizeApprox": "300MB",
       "platforms": [
         "linux-x86_64",
@@ -256,7 +261,7 @@
     "cookieImport": "DISABLED by default. Requires CAMOFOX_API_KEY to be explicitly set. Without the key, the server rejects all cookie requests with 403. Cookie files are read from a sandboxed directory (~/.camofox/cookies/) with path traversal protection.",
     "accessControl": "CAMOFOX_ACCESS_KEY provides global bearer auth for all routes (except /health). Recommended for any non-localhost deployment.",
     "crashReporting": "Anonymized via lib/reporter.js (L28-290). Private domains are HMAC-hashed. No page content, cookies, tokens, IPs, or user data is ever sent. Relay source is in-repo and auditable. Verification endpoint: GET /source returns commit hash and sha256.",
-    "binaryDownload": "Camoufox is downloaded at npm install time by camoufox-js (an npm package from the Camoufox project). Downloaded from official GitHub releases with integrity verification by camoufox-js.",
+    "binaryDownload": "Camoufox is downloaded at npm install time by camoufox-js unless CAMOUFOX_EXECUTABLE points to an external Camoufox bundle. Downloaded binaries come from official GitHub releases with integrity verification by camoufox-js.",
     "sessionPersistence": "User sessions are persisted to ~/.camofox/profiles/ so authenticated browsing survives restarts. UserIds are hashed for directory names. Disable via persistence plugin config.",
     "noEmbeddedSecrets": "Zero credentials, private keys, or tokens ship in this package. All secrets are environment variables or Cloudflare Worker secrets."
   }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -14,9 +14,16 @@
 //      is strictly better than a silent runtime crash.
 
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { accessSync, constants, existsSync, statSync } from 'node:fs';
 import { homedir, platform } from 'node:os';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const EXTERNAL_EXECUTABLE_ENV_VARS = [
+  'CAMOUFOX_EXECUTABLE',
+  'CAMOUFOX_EXECUTABLE_PATH',
+  'CAMOFOX_EXECUTABLE_PATH',
+];
 
 function camoufoxCacheDir() {
   const home = homedir();
@@ -36,26 +43,62 @@ function fail(message) {
   process.exit(1);
 }
 
-const childEnv = { ...process.env };
-delete childEnv.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD;
+export function externalExecutableFromEnv(env = process.env) {
+  for (const name of EXTERNAL_EXECUTABLE_ENV_VARS) {
+    const value = (env[name] || '').trim();
+    if (value) return { name, value };
+  }
+  return null;
+}
 
-const isWindows = platform() === 'win32';
-const result = spawnSync(isWindows ? 'npx.cmd' : 'npx', ['camoufox-js', 'fetch'], {
-  stdio: 'inherit',
-  env: childEnv,
-  shell: isWindows,
-});
+function assertExternalExecutable(path) {
+  if (!existsSync(path)) fail(`external Camoufox executable does not exist: ${path}`);
+  const stat = statSync(path);
+  if (!stat.isFile()) fail(`external Camoufox executable is not a file: ${path}`);
+  if (platform() !== 'win32') {
+    try {
+      accessSync(path, constants.X_OK);
+    } catch {
+      fail(`external Camoufox executable is not executable: ${path}`);
+    }
+  }
+}
 
-if (result.error) fail(`failed to spawn npx: ${result.error.message}`);
-if (result.status !== 0) fail(`\`npx camoufox-js fetch\` exited with code ${result.status}`);
+export function main() {
+  const externalExecutable = externalExecutableFromEnv();
+  if (externalExecutable) {
+    assertExternalExecutable(externalExecutable.value);
+    process.stdout.write(
+      `[camofox-browser] postinstall: ${externalExecutable.name} is set; skipping bundled Camoufox download.\n`
+    );
+    return;
+  }
 
-const versionFile = join(camoufoxCacheDir(), 'version.json');
-if (!existsSync(versionFile)) {
-  process.stderr.write('[camofox-browser] postinstall: Camoufox cache not populated.\n');
-  process.stderr.write(`  Expected file: ${versionFile}\n`);
-  process.stderr.write('  Possible causes:\n');
-  process.stderr.write('    - Network failure during binary download (check your connection)\n');
-  process.stderr.write('    - PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD re-exported by a wrapping process\n');
-  process.stderr.write('  Manual fix:  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD= npx camoufox-js fetch\n');
-  process.exit(1);
+  const childEnv = { ...process.env };
+  delete childEnv.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD;
+
+  const isWindows = platform() === 'win32';
+  const result = spawnSync(isWindows ? 'npx.cmd' : 'npx', ['camoufox-js', 'fetch'], {
+    stdio: 'inherit',
+    env: childEnv,
+    shell: isWindows,
+  });
+
+  if (result.error) fail(`failed to spawn npx: ${result.error.message}`);
+  if (result.status !== 0) fail(`\`npx camoufox-js fetch\` exited with code ${result.status}`);
+
+  const versionFile = join(camoufoxCacheDir(), 'version.json');
+  if (!existsSync(versionFile)) {
+    process.stderr.write('[camofox-browser] postinstall: Camoufox cache not populated.\n');
+    process.stderr.write(`  Expected file: ${versionFile}\n`);
+    process.stderr.write('  Possible causes:\n');
+    process.stderr.write('    - Network failure during binary download (check your connection)\n');
+    process.stderr.write('    - PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD re-exported by a wrapping process\n');
+    process.stderr.write('  Manual fix:  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD= npx camoufox-js fetch\n');
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
 }

--- a/scripts/postinstall.test.js
+++ b/scripts/postinstall.test.js
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from '@jest/globals';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { spawnSync } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { externalExecutableFromEnv } from './postinstall.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const tempDirs = [];
+
+function makeExecutable() {
+  const dir = mkdtempSync(join(tmpdir(), 'camofox-postinstall-test-'));
+  tempDirs.push(dir);
+  const executable = join(dir, 'camoufox-bin');
+  writeFileSync(executable, '#!/bin/sh\nexit 0\n');
+  chmodSync(executable, 0o755);
+  return executable;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('postinstall external executable handling', () => {
+  test('uses CAMOUFOX_EXECUTABLE before compatibility aliases', () => {
+    expect(externalExecutableFromEnv({
+      CAMOUFOX_EXECUTABLE: '/primary',
+      CAMOUFOX_EXECUTABLE_PATH: '/compat',
+      CAMOFOX_EXECUTABLE_PATH: '/legacy',
+    })).toEqual({ name: 'CAMOUFOX_EXECUTABLE', value: '/primary' });
+  });
+
+  test('skips bundled download when an external executable is configured', () => {
+    const executable = makeExecutable();
+    const result = spawnSync(process.execPath, ['scripts/postinstall.js'], {
+      cwd: join(__dirname, '..'),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CAMOUFOX_EXECUTABLE: executable,
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1',
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('skipping bundled Camoufox download');
+    expect(result.stderr).toBe('');
+  });
+});

--- a/server.js
+++ b/server.js
@@ -35,6 +35,7 @@ import { cleanupOrphanedTempFiles, cleanupStaleFirefoxProfiles } from './lib/tmp
 import { coalesceInflight } from './lib/inflight.js';
 import { createReporter, createTabHealthTracker, collectResourceSnapshot, classifyProxyError } from './lib/reporter.js';
 import { mountDocs } from './lib/openapi.js';
+import { prepareExternalCamoufoxExecutable } from './lib/camoufox-executable.js';
 
 const CONFIG = loadConfig();
 
@@ -586,6 +587,13 @@ function isFatalInstallError(err) {
   return /Version information not found/i.test(err?.message || '');
 }
 
+function camoufoxInstallRemediation() {
+  if (CONFIG.camoufoxExecutablePath) {
+    return 'verify CAMOUFOX_EXECUTABLE points to a Camoufox bundle with properties.json, version.json, and fontconfig/';
+  }
+  return 'run `npx camoufox-js fetch` then restart the server';
+}
+
 function scheduleBrowserWarmRetry(delayMs = 5000) {
   if (browserWarmRetryTimer || browser || browserLaunchPromise) return;
   browserWarmRetryTimer = setTimeout(async () => {
@@ -598,7 +606,7 @@ function scheduleBrowserWarmRetry(delayMs = 5000) {
       if (isFatalInstallError(err)) {
         log('error', 'browser unavailable: Camoufox binaries are not installed; aborting retry loop', {
           error: err.message,
-          remediation: 'run `npx camoufox-js fetch` then restart the server',
+          remediation: camoufoxInstallRemediation(),
         });
         return;
       }
@@ -668,6 +676,21 @@ function getTotalTabCount() {
 // via Mesa llvmpipe. Without this, WebGL returns "no context" -- a massive bot signal.
 let virtualDisplay = null;
 let browserLaunchProxy = null;
+let externalCamoufoxLaunch = null;
+
+function getExternalCamoufoxLaunch() {
+  if (!CONFIG.camoufoxExecutablePath) return null;
+  if (!externalCamoufoxLaunch) {
+    externalCamoufoxLaunch = prepareExternalCamoufoxExecutable(CONFIG.camoufoxExecutablePath, {
+      cacheDir: CONFIG.camoufoxCacheDir,
+    });
+    log('info', 'using external camoufox executable', {
+      executablePath: externalCamoufoxLaunch.executablePath,
+      resourceDir: externalCamoufoxLaunch.resourceDir,
+    });
+  }
+  return externalCamoufoxLaunch;
+}
 
 async function probeGoogleSearch(candidateBrowser) {
   let context = null;
@@ -871,6 +894,7 @@ async function launchBrowserInstance() {
   const hostOS = getHostOS();
   const maxAttempts = proxyPool?.launchRetries ?? 1;
   let lastError = null;
+  const externalCamoufox = getExternalCamoufoxLaunch();
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const launchProxy = proxyPool
@@ -907,6 +931,7 @@ async function launchBrowserInstance() {
 
     try {
       const options = await launchOptions({
+        executable_path: externalCamoufox?.executablePath,
         headless: useVirtualDisplay ? false : true,
         os: hostOS,
         humanize: true,
@@ -5494,7 +5519,7 @@ const server = app.listen(PORT, async () => {
     if (isFatalInstallError(err)) {
       log('error', 'browser pre-warm aborted: Camoufox binaries are not installed', {
         error: err.message,
-        remediation: 'run `npx camoufox-js fetch` then restart the server',
+        remediation: camoufoxInstallRemediation(),
       });
     } else {
       log('error', 'browser pre-warm failed (will retry in background)', { error: err.message });

--- a/tests/unit/camoufoxExecutable.test.js
+++ b/tests/unit/camoufoxExecutable.test.js
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, test } from '@jest/globals';
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { prepareExternalCamoufoxExecutable } from '../../lib/camoufox-executable.js';
+
+const tempDirs = [];
+
+function makeTempDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'camofox-executable-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  rmSync(join(tmpdir(), 'camofox-browser-external-camoufox'), { recursive: true, force: true });
+});
+
+describe('prepareExternalCamoufoxExecutable', () => {
+  test('creates camoufox-js compatibility links for an external bundle', () => {
+    const bundleDir = makeTempDir();
+    const cacheDir = makeTempDir();
+    const executable = join(bundleDir, 'camoufox-bin');
+
+    writeFileSync(executable, '#!/bin/sh\nexit 0\n');
+    chmodSync(executable, 0o755);
+    writeFileSync(join(bundleDir, 'properties.json'), '[]\n');
+    writeFileSync(join(bundleDir, 'version.json'), '{"version":"135.0.1","release":"beta.24"}\n');
+    mkdirSync(join(bundleDir, 'fontconfig', 'lin'), { recursive: true });
+
+    const prepared = prepareExternalCamoufoxExecutable(executable, { cacheDir });
+
+    expect(prepared.resourceDir).toBe(bundleDir);
+    expect(prepared.executablePath).toContain('camofox-browser-external-camoufox');
+    expect(existsSync(prepared.executablePath)).toBe(true);
+    expect(existsSync(join(cacheDir, 'version.json'))).toBe(true);
+    expect(existsSync(join(cacheDir, 'fontconfig'))).toBe(true);
+    expect(existsSync(join(cacheDir, 'properties.json'))).toBe(true);
+    expect(existsSync(join(cacheDir, 'camoufox-bin'))).toBe(true);
+  });
+
+  test('fails clearly when bundle resources are missing', () => {
+    const bundleDir = makeTempDir();
+    const executable = join(bundleDir, 'camoufox-bin');
+    writeFileSync(executable, '#!/bin/sh\nexit 0\n');
+    chmodSync(executable, 0o755);
+
+    expect(() => prepareExternalCamoufoxExecutable(executable, { cacheDir: makeTempDir() }))
+      .toThrow(/properties\.json/);
+  });
+});

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, test, afterEach } from '@jest/globals';
+import { loadConfig } from '../../lib/config.js';
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('loadConfig', () => {
+  test('prefers CAMOUFOX_EXECUTABLE for external Camoufox executable', () => {
+    process.env.CAMOUFOX_EXECUTABLE = '/nix/store/camoufox/bin/camoufox';
+    process.env.CAMOUFOX_EXECUTABLE_PATH = '/ignored/camoufox';
+    process.env.CAMOFOX_EXECUTABLE_PATH = '/also-ignored/camoufox';
+
+    const config = loadConfig();
+
+    expect(config.camoufoxExecutablePath).toBe('/nix/store/camoufox/bin/camoufox');
+    expect(config.serverEnv.CAMOUFOX_EXECUTABLE).toBe('/nix/store/camoufox/bin/camoufox');
+    expect(config.serverEnv.CAMOUFOX_EXECUTABLE_PATH).toBe('/ignored/camoufox');
+    expect(config.serverEnv.CAMOFOX_EXECUTABLE_PATH).toBe('/also-ignored/camoufox');
+  });
+
+  test('accepts compatibility executable env vars', () => {
+    process.env.CAMOUFOX_EXECUTABLE_PATH = '/compat/camoufox';
+    expect(loadConfig().camoufoxExecutablePath).toBe('/compat/camoufox');
+
+    delete process.env.CAMOUFOX_EXECUTABLE_PATH;
+    process.env.CAMOFOX_EXECUTABLE_PATH = '/legacy/camoufox';
+    expect(loadConfig().camoufoxExecutablePath).toBe('/legacy/camoufox');
+  });
+});


### PR DESCRIPTION
Adds `CAMOUFOX_EXECUTABLE`/`CAMOUFOX_EXECUTABLE_PATH`/`CAMOFOX_EXECUTABLE_PATH` support so NixOS and other externally-managed installs can skip bundled Camoufox download and launch custom executable. Includes runtime bundle-resource shims and unit tests.

Verification:
- `CAMOUFOX_EXECUTABLE=/bin/sh npm install`
- `npm test -- tests/unit/config.test.js tests/unit/camoufoxExecutable.test.js scripts/postinstall.test.js`
- `node --check on changed JS files`
- `git diff --check`