### PR TITLE
fix: require API key authentication on /tabs/:tabId/evaluate endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -221,6 +221,27 @@ function validateUrl(url) {
 
 // isLoopbackAddress -- now imported from lib/auth.js (see top of file)
 
+// Middleware: require CAMOFOX_API_KEY via Bearer token.
+// When the key is not set, allow only loopback requests in non-production environments.
+function requireApiKey(req, res, next) {
+  if (CONFIG.apiKey) {
+    const auth = String(req.headers['authorization'] || '');
+    const match = auth.match(/^Bearer\s+(.+)$/i);
+    if (!match || !timingSafeCompare(match[1], CONFIG.apiKey)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+  } else {
+    const remoteAddress = req.socket?.remoteAddress || '';
+    const allowUnauthedLocal = CONFIG.nodeEnv !== 'production' && isLoopbackAddress(remoteAddress);
+    if (!allowUnauthedLocal) {
+      return res.status(403).json({
+        error: 'This endpoint requires CAMOFOX_API_KEY except for loopback requests in non-production environments.',
+      });
+    }
+  }
+  next();
+}
+
 // Import cookies into a user's browser context (Playwright cookies format)
 // POST /sessions/:userId/cookies { cookies: Cookie[] }
 //
@@ -4337,7 +4358,7 @@ app.get('/tabs/:tabId/stats', async (req, res) => {
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-app.post('/tabs/:tabId/evaluate', express.json({ limit: '1mb' }), async (req, res) => {
+app.post('/tabs/:tabId/evaluate', requireApiKey, express.json({ limit: '1mb' }), async (req, res) => {
   try {
     const { userId, expression } = req.body;
     if (!userId) return res.status(400).json({ error: 'userId is required' });

--- a/tests/unit/evaluate-auth.test.js
+++ b/tests/unit/evaluate-auth.test.js
@@ -1,0 +1,102 @@
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
+
+/**
+ * Tests that the /tabs/:tabId/evaluate endpoint requires API key authentication
+ * when CAMOFOX_API_KEY is configured, matching the security model used by the
+ * cookie import endpoint.
+ *
+ * CVE: CWE-94 — Arbitrary JS execution without authentication
+ */
+describe('Evaluate endpoint authentication', () => {
+  const TEST_API_KEY = 'test-secret-key-for-evaluate-auth';
+  let serverUrl;
+  let testSiteUrl;
+
+  beforeAll(async () => {
+    await startServer(0, { CAMOFOX_API_KEY: TEST_API_KEY });
+    serverUrl = getServerUrl();
+    const testPort = await startTestSite();
+    testSiteUrl = getTestSiteUrl();
+  }, 120000);
+
+  afterAll(async () => {
+    await stopTestSite();
+    await stopServer();
+  }, 30000);
+
+  test('rejects evaluate without Bearer token when API key is configured', async () => {
+    const client = createClient(serverUrl);
+    try {
+      const { tabId } = await client.createTab(`${testSiteUrl}/pageA`);
+
+      // Call evaluate directly without auth header
+      const res = await fetch(`${serverUrl}/tabs/${tabId}/evaluate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId: client.userId,
+          expression: 'document.title',
+        }),
+      });
+
+      expect(res.status).toBe(403);
+      const data = await res.json();
+      expect(data.error).toBe('Forbidden');
+    } finally {
+      await client.cleanup();
+    }
+  });
+
+  test('rejects evaluate with wrong Bearer token', async () => {
+    const client = createClient(serverUrl);
+    try {
+      const { tabId } = await client.createTab(`${testSiteUrl}/pageA`);
+
+      const res = await fetch(`${serverUrl}/tabs/${tabId}/evaluate`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer wrong-key',
+        },
+        body: JSON.stringify({
+          userId: client.userId,
+          expression: 'document.title',
+        }),
+      });
+
+      expect(res.status).toBe(403);
+      const data = await res.json();
+      expect(data.error).toBe('Forbidden');
+    } finally {
+      await client.cleanup();
+    }
+  });
+
+  test('allows evaluate with correct Bearer token', async () => {
+    const client = createClient(serverUrl);
+    try {
+      const { tabId } = await client.createTab(`${testSiteUrl}/pageA`);
+
+      const res = await fetch(`${serverUrl}/tabs/${tabId}/evaluate`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${TEST_API_KEY}`,
+        },
+        body: JSON.stringify({
+          userId: client.userId,
+          expression: 'document.title',
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.ok).toBe(true);
+      expect(data.result).toBe('Page A');
+    } finally {
+      await client.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The `POST /tabs/:tabId/evaluate` endpoint accepts a user-supplied `expression` string and passes it directly to Playwright's `page.evaluate()`, executing arbitrary JavaScript in the browser page context. Unlike the `/sessions/:userId/cookies` endpoint (which requires a Bearer token via `CAMOFOX_API_KEY`), the evaluate endpoint had **no authentication**, allowing any network-reachable attacker to run arbitrary JS in any open tab.

**CWE-94 — Improper Control of Generation of Code ("Code Injection")**
**Severity: High** — an unauthenticated attacker with network access can exfiltrate cookies, localStorage, session tokens, and DOM content from authenticated browser sessions, or perform arbitrary same-origin actions.

## Data flow

1. Attacker sends `POST /tabs/:tabId/evaluate` with `{ "expression": "document.cookie" }` — no auth required
2. `server.js` passes `expression` directly to `page.evaluate(expression)` (Playwright)
3. Arbitrary JavaScript executes in the authenticated page context
4. Result (cookies, tokens, DOM data) is returned in the HTTP response

## What changed

**`server.js`** — Extracted a reusable `requireApiKey` middleware (identical logic to the existing cookie-import auth check) and applied it to the `/tabs/:tabId/evaluate` route. The middleware:

- Requires a valid `Bearer <CAMOFOX_API_KEY>` header when the API key is configured
- Uses timing-safe comparison to prevent token leakage via timing side-channels
- Falls back to allowing loopback-only requests in non-production environments (matching the existing policy)
- Returns `403 Forbidden` otherwise

**`tests/unit/evaluate-auth.test.js`** — Three new integration tests verifying:
1. Requests without a token are rejected (403)
2. Requests with a wrong token are rejected (403)
3. Requests with the correct token succeed (200)

## Why this is exploitable

The README documents production deployment via Docker and Fly.io with secrets, meaning the server is internet-exposable. An attacker who can reach the server only needs a valid `tabId` (a UUID, but discoverable via the unauthenticated tab listing endpoints) to execute arbitrary JavaScript. Combined with the authenticated cookie import feature, this means an attacker could exfiltrate session tokens from sites where cookies have been loaded.

Before submitting, we considered whether existing mitigations would prevent exploitation — there is no reverse proxy auth requirement documented, no IP allowlisting, and the server binds to `0.0.0.0` by default. The cookie endpoint already recognized this risk and added auth; the evaluate endpoint was simply missed.

## Test results

All 113 existing tests continue to pass. The 3 new auth tests validate the expected 403/200 behavior with and without valid credentials.