### PR TITLE
chore(config): make vnc plugin entry explicitly enabled

### DIFF
--- a/camofox.config.json
+++ b/camofox.config.json
@@ -5,6 +5,6 @@
   "plugins": {
     "youtube": { "enabled": true },
     "persistence": { "enabled": true },
-    "vnc": { "resolution": "1920x1080" }
+    "vnc": { "enabled": true, "resolution": "1920x1080" }
   }
 }


### PR DESCRIPTION
Tiny consistency fix. The `vnc` plugin entry in `camofox.config.json` is missing the explicit `"enabled": true` that `youtube` and `persistence` both carry.

The loader (`lib/plugins.js`) treats a missing `enabled` field as not-disabled, so this is a **no-op at runtime** — purely a docs/consistency change that makes the config self-describing.

```diff
-    "vnc": { "resolution": "1920x1080" }
+    "vnc": { "enabled": true, "resolution": "1920x1080" }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)