### PR TITLE
Declare OpenClaw tool contracts

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -178,9 +178,25 @@
     "camofox_scroll",
     "camofox_screenshot",
     "camofox_close_tab",
+    "camofox_evaluate",
     "camofox_list_tabs",
     "camofox_import_cookies"
   ],
+  "contracts": {
+    "tools": [
+      "camofox_create_tab",
+      "camofox_snapshot",
+      "camofox_click",
+      "camofox_type",
+      "camofox_navigate",
+      "camofox_scroll",
+      "camofox_screenshot",
+      "camofox_close_tab",
+      "camofox_evaluate",
+      "camofox_list_tabs",
+      "camofox_import_cookies"
+    ]
+  },
   "runtimeDependencies": {
     "camoufox": {
       "description": "Camoufox anti-detection browser (Firefox fork). Downloaded at install time by camoufox-js unless CAMOUFOX_EXECUTABLE points to an external bundle.",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,10 @@
         "description": "Close a browser tab"
       },
       {
+        "name": "camofox_evaluate",
+        "description": "Execute JavaScript in a Camoufox tab page context"
+      },
+      {
         "name": "camofox_list_tabs",
         "description": "List open tabs for a user"
       },

--- a/tests/unit/openclawManifest.test.js
+++ b/tests/unit/openclawManifest.test.js
@@ -1,0 +1,23 @@
+import { describe, test, expect } from '@jest/globals';
+import fs from 'fs';
+
+const RUNTIME_TOOL_RE = /name:\s*["'](camofox_[^"']+)["']/g;
+
+function runtimeToolNames() {
+  const plugin = fs.readFileSync(new URL('../../plugin.js', import.meta.url), 'utf8');
+  return [...plugin.matchAll(RUNTIME_TOOL_RE)].map(match => match[1]);
+}
+
+describe('OpenClaw manifest', () => {
+  test('declares ownership contracts for every runtime tool', () => {
+    const manifest = JSON.parse(fs.readFileSync(new URL('../../openclaw.plugin.json', import.meta.url), 'utf8'));
+    const pkg = JSON.parse(fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf8'));
+    const runtimeTools = runtimeToolNames();
+    const packageTools = pkg.openclaw.tools.map(tool => tool.name);
+
+    expect(manifest.contracts).toBeDefined();
+    expect(manifest.contracts.tools).toEqual(runtimeTools);
+    expect(manifest.tools).toEqual(runtimeTools);
+    expect(packageTools).toEqual(runtimeTools);
+  });
+});


### PR DESCRIPTION
## Summary
- add `contracts.tools` to `openclaw.plugin.json` so OpenClaw >=2026.5 can authorize runtime tool registration
- keep manifest, package metadata, and runtime `plugin.js` tool names in sync
- include the currently registered `camofox_evaluate` tool in both metadata lists

Fixes #3141.

## Testing
- `NODE_OPTIONS='--experimental-vm-modules' npx jest --runInBand --forceExit tests/unit/openclawManifest.test.js tests/unit/screenshotToolResult.test.js`
