### PR TITLE
fix: don't treat 429 as success in sendToRelay

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -492,7 +492,7 @@ export async function sendToRelay(payload) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    return resp.ok || resp.status === 429; // rate-limited is fine, not an error
+    return resp.ok; // 429 returns false — rate-limited reports are not accepted, let callers decide whether to retry
   } catch {
     return false;
   }


### PR DESCRIPTION
## What

`sendToRelay` in `lib/reporter.js` was returning `true` when the relay responded with 429, treating a rate-limited request as accepted.

```js
// Before
return resp.ok || resp.status === 429; // rate-limited is fine, not an error

// After
return resp.ok; // 429 returns false — let callers decide whether to retry
```

## Why this matters

A 429 means the relay did not accept the report. Returning `true` silently dropped crash reports under sustained rate limiting — giving callers false confidence that reporting succeeded when data was lost.

## Fix shape

Return `false` on 429. Preserves the never-throws contract. No blocking retry logic added. Callers decide whether to retry.