### PR TITLE
fix(plugins): convert plugin path to file:// URL for ESM import on Windows

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -60,7 +60,7 @@
 import { EventEmitter } from 'events';
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.join(__dirname, '..');
@@ -155,7 +155,7 @@ export async function loadPlugins(app, ctx) {
     }
 
     try {
-      const mod = await import(indexPath);
+      const mod = await import(pathToFileURL(indexPath).href);
       const register = mod.default || mod.register;
       if (typeof register !== 'function') {
         ctx.log('warn', `plugin "${name}" does not export a register function, skipping`);


### PR DESCRIPTION
## Summary

On Windows, `npm start` fails to load any plugin with:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

`lib/plugins.js` passes a raw absolute path (e.g. `C:\...\plugins\persistence\index.js`) to `await import(...)`. Node's ESM loader interprets the drive letter as a URL scheme and rejects it. POSIX absolute paths (`/...`) happen to work, which masked the issue.

Fix: convert the path with `pathToFileURL(indexPath).href` so the loader always receives a valid `file://` URL.

## Repro

1. Clone on Windows, `npm install && npm start`
2. Server logs `plugin load failed` for `persistence`, `vnc`, `youtube`

## After this PR

All three plugins load cleanly on Windows. POSIX behavior is unchanged — Node accepts both absolute paths and `file://` URLs equivalently for dynamic `import()`.

## Test plan

- [x] `npm test` plugin and unit suites pass (659/660; one remaining failure is an unrelated pre-existing Windows test expecting `camoufox-bin` without the `.exe` suffix)
- [x] Manual: `POST /tabs` against `example.com` succeeds end-to-end on Windows