### PR TITLE
feat: low-level interaction endpoints (mouse-wheel, init-script, capture-network, capture-requests)

### DIFF
--- a/lib/interaction-params.js
+++ b/lib/interaction-params.js
@@ -1,0 +1,173 @@
+/**
+ * Client-input validation for the low-level interaction and capture endpoints
+ * (/tabs/:tabId/mouse-wheel, /capture-network, /capture-requests).
+ *
+ * These routes take user-supplied regular expressions and numeric limits. Every
+ * invalid value must surface as a 400 with an actionable message, never as an
+ * internal error: `new RegExp(userInput)` throws a SyntaxError that would
+ * otherwise reach sendError() as a 500, and out-of-range durations/limits would
+ * either silently clamp or blow the handler budget.
+ *
+ * Validators live here (rather than inline in server.js) so the unit tests
+ * exercise the real guards instead of a copy that can drift.
+ */
+
+export const MAX_URL_PATTERN_LENGTH = 200;
+export const MAX_WHEEL_DELTA = 100000;
+export const MAX_WHEEL_COORD = 20000;
+
+export const CAPTURE_DURATION_MS = { min: 100, max: 60000, default: 15000 };
+export const CAPTURE_MAX_CAPTURES = { min: 1, max: 500, default: 100 };
+export const CAPTURE_MAX_BODY_BYTES = { min: 1024, max: 5000000, default: 1000000 };
+// Request post-data is far smaller than a response body, so /capture-requests
+// keeps a tighter default. Both stay within CAPTURE_MAX_BODY_BYTES bounds.
+export const REQUEST_MAX_BODY_BYTES_DEFAULT = 200000;
+
+function invalid(error, code) {
+  return { ok: false, error, code };
+}
+
+/**
+ * Best-effort catastrophic-backtracking guard: flags a quantified group that is
+ * itself quantified, e.g. `(a+)+`, `(.*)*`, `(x{2,}){3,}`. This is a heuristic,
+ * not a proof of safety -- it exists so a trivially exponential pattern can't be
+ * pushed through page.on('response') for every URL the browser sees.
+ */
+export function hasNestedQuantifier(pattern) {
+  return /\([^()]*(?:[*+]|\{\d+,\d*\})[^()]*\)\s*(?:[*+]|\{\d+,\d*\})/.test(pattern);
+}
+
+/**
+ * Validate and compile a user-supplied URL filter.
+ * @returns {{ok: true, regex: RegExp, urlPattern: string}|{ok: false, error: string, code: string}}
+ */
+export function compileUrlPattern(urlPattern) {
+  if (typeof urlPattern !== 'string' || !urlPattern.trim()) {
+    return invalid('urlPattern must be a non-empty string', 'invalid_url_pattern');
+  }
+  if (urlPattern.length > MAX_URL_PATTERN_LENGTH) {
+    return invalid(`urlPattern too long (max ${MAX_URL_PATTERN_LENGTH} characters)`, 'invalid_url_pattern');
+  }
+  if (hasNestedQuantifier(urlPattern)) {
+    return invalid(
+      'urlPattern rejected: nested quantifier (e.g. "(a+)+") risks catastrophic backtracking. Rewrite without a quantified group inside a quantifier.',
+      'invalid_url_pattern'
+    );
+  }
+  let regex;
+  try {
+    regex = new RegExp(urlPattern, 'i');
+  } catch (e) {
+    return invalid(`urlPattern is not a valid regular expression: ${e.message}`, 'invalid_url_pattern');
+  }
+  return { ok: true, regex, urlPattern };
+}
+
+/**
+ * Validate an optional numeric client parameter against an inclusive range.
+ * Absent (undefined/null) falls back to the default; anything else must be a
+ * finite in-range number -- strings, NaN and out-of-range values are rejected
+ * rather than coerced or clamped, so a caller asking for durationMs: 600000
+ * learns the cap instead of silently getting 60s.
+ */
+export function validateRange(name, raw, { min, max, default: fallback }) {
+  if (raw === undefined || raw === null) return { ok: true, value: fallback };
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+    return invalid(`${name} must be a finite number`, 'invalid_param');
+  }
+  if (raw < min || raw > max) {
+    return invalid(`${name} out of range (${min}..${max})`, 'invalid_param');
+  }
+  return { ok: true, value: raw };
+}
+
+function validateOptionalBoolean(name, raw, fallback) {
+  if (raw === undefined || raw === null) return { ok: true, value: fallback };
+  if (typeof raw !== 'boolean') return invalid(`${name} must be a boolean`, 'invalid_param');
+  return { ok: true, value: raw };
+}
+
+/**
+ * Parse the shared body of /capture-network and /capture-requests.
+ * @param {object} body request body
+ * @param {object} [opts] per-route defaults (capture-requests keeps smaller bodies)
+ * @returns {{ok: true, params: object}|{ok: false, error: string, code: string}}
+ */
+export function parseCaptureParams(body = {}, opts = {}) {
+  const { maxBodyBytesDefault = CAPTURE_MAX_BODY_BYTES.default } = opts;
+
+  const pattern = compileUrlPattern(body.urlPattern === undefined ? 'graphql' : body.urlPattern);
+  if (!pattern.ok) return pattern;
+
+  const duration = validateRange('durationMs', body.durationMs, CAPTURE_DURATION_MS);
+  if (!duration.ok) return duration;
+
+  const maxCaptures = validateRange('maxCaptures', body.maxCaptures, CAPTURE_MAX_CAPTURES);
+  if (!maxCaptures.ok) return maxCaptures;
+
+  const maxBodyBytes = validateRange('maxBodyBytes', body.maxBodyBytes, {
+    ...CAPTURE_MAX_BODY_BYTES,
+    default: maxBodyBytesDefault,
+  });
+  if (!maxBodyBytes.ok) return maxBodyBytes;
+
+  const includeHeaders = validateOptionalBoolean('includeHeaders', body.includeHeaders, true);
+  if (!includeHeaders.ok) return includeHeaders;
+
+  return {
+    ok: true,
+    params: {
+      urlPattern: pattern.urlPattern,
+      regex: pattern.regex,
+      durationMs: duration.value,
+      maxCaptures: maxCaptures.value,
+      maxBodyBytes: maxBodyBytes.value,
+      includeHeaders: includeHeaders.value,
+    },
+  };
+}
+
+/**
+ * Parse the body of /tabs/:tabId/mouse-wheel.
+ * @returns {{ok: true, params: object}|{ok: false, error: string, code: string}}
+ */
+export function parseWheelParams(body = {}) {
+  const { ref, x, y } = body;
+
+  if (ref !== undefined && ref !== null && (typeof ref !== 'string' || !ref.trim())) {
+    return invalid('ref must be a non-empty string', 'invalid_param');
+  }
+
+  const deltaX = validateRange('deltaX', body.deltaX, { min: -MAX_WHEEL_DELTA, max: MAX_WHEEL_DELTA, default: 0 });
+  if (!deltaX.ok) return deltaX;
+  const deltaY = validateRange('deltaY', body.deltaY, { min: -MAX_WHEEL_DELTA, max: MAX_WHEEL_DELTA, default: 0 });
+  if (!deltaY.ok) return deltaY;
+  if (deltaX.value === 0 && deltaY.value === 0) {
+    return invalid('deltaX or deltaY required (at least one must be non-zero)', 'invalid_param');
+  }
+
+  const hasX = x !== undefined && x !== null;
+  const hasY = y !== undefined && y !== null;
+  if (hasX !== hasY) {
+    return invalid('x and y must be provided together', 'invalid_param');
+  }
+
+  let coords = null;
+  if (hasX) {
+    const vx = validateRange('x', x, { min: 0, max: MAX_WHEEL_COORD, default: 0 });
+    if (!vx.ok) return vx;
+    const vy = validateRange('y', y, { min: 0, max: MAX_WHEEL_COORD, default: 0 });
+    if (!vy.ok) return vy;
+    coords = { x: vx.value, y: vy.value };
+  }
+
+  return {
+    ok: true,
+    params: {
+      ref: ref ? ref.trim() : null,
+      coords,
+      deltaX: deltaX.value,
+      deltaY: deltaY.value,
+    },
+  };
+}

--- a/lib/network-capture.js
+++ b/lib/network-capture.js
@@ -1,0 +1,158 @@
+/**
+ * Browser-level network capture used by /tabs/:tabId/capture-network and
+ * /tabs/:tabId/capture-requests.
+ *
+ * The subtle part is response bodies. `response.text()` is async, so a response
+ * that arrives just before the capture window closes still has its body in
+ * flight when the timer fires. Detaching the listener and responding at that
+ * point silently drops it. Every started read is therefore tracked and awaited
+ * (under its own bounded grace period) before the captures are returned; a slot
+ * is pushed synchronously on arrival so ordering and the maxCaptures budget are
+ * decided at event time, not at completion time.
+ */
+
+export const BODY_DRAIN_TIMEOUT_MS = 5000;
+export const PENDING_BODY_MARKER = '__BODY_PENDING__';
+export const BODY_ERROR_PREFIX = '__BODY_ERROR__:';
+export const TRUNCATED_MARKER = '__TRUNCATED__';
+
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Promise.race against a timer that is always cleared, so no handle leaks. */
+async function raceWithTimeout(promise, ms) {
+  let timer;
+  const timeout = new Promise((resolve) => { timer = setTimeout(resolve, ms); });
+  try {
+    await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function truncate(body, maxBodyBytes) {
+  const text = typeof body === 'string' ? body : String(body ?? '');
+  return text.length > maxBodyBytes ? text.slice(0, maxBodyBytes) + TRUNCATED_MARKER : text;
+}
+
+/**
+ * Attach a page.on('response') listener for `durationMs` and return matching
+ * responses with their bodies.
+ *
+ * @param {object} page Playwright page (only on/off are used)
+ * @param {object} opts
+ * @param {RegExp} opts.regex compiled URL filter (validated by compileUrlPattern)
+ * @param {number} opts.durationMs capture window
+ * @param {number} opts.maxBodyBytes per-body cap before truncation
+ * @param {number} opts.maxCaptures hard cap on captured responses
+ * @param {number} [opts.drainTimeoutMs] grace period for in-flight body reads
+ * @param {(ms: number) => Promise<void>} [opts.sleep] injectable for tests
+ * @returns {Promise<{captures: object[], captureCount: number, droppedByLimit: number, pendingBodies: number}>}
+ */
+export async function captureResponses(page, opts) {
+  const {
+    regex,
+    durationMs,
+    maxBodyBytes,
+    maxCaptures,
+    drainTimeoutMs = BODY_DRAIN_TIMEOUT_MS,
+    sleep = defaultSleep,
+  } = opts;
+
+  const captures = [];
+  const pending = new Set();
+  let droppedByLimit = 0;
+
+  const handler = (response) => {
+    let url;
+    try {
+      url = response.url();
+    } catch {
+      return; // response object already disposed with the page
+    }
+    if (!regex.test(url)) return;
+    if (captures.length >= maxCaptures) { droppedByLimit++; return; }
+
+    let status = 0;
+    try { status = response.status(); } catch { /* keep 0 */ }
+
+    // Reserve the slot synchronously: ordering and the cap must not depend on
+    // which body read finishes first.
+    const slot = { url, status, len: 0, body: PENDING_BODY_MARKER };
+    captures.push(slot);
+
+    const read = (async () => {
+      try {
+        // Truncation applies to the body only: a failed read is a diagnostic,
+        // and slicing it to maxBodyBytes would mangle the reason.
+        slot.body = truncate(await response.text(), maxBodyBytes);
+      } catch (e) {
+        slot.body = `${BODY_ERROR_PREFIX}${e.message}`;
+      }
+      slot.len = slot.body.length;
+    })();
+    pending.add(read);
+    read.finally(() => pending.delete(read));
+  };
+
+  page.on('response', handler);
+  try {
+    await sleep(durationMs);
+  } finally {
+    page.off('response', handler);
+  }
+
+  // Responses that landed near the deadline still have their body in flight.
+  if (pending.size > 0) {
+    await raceWithTimeout(Promise.allSettled([...pending]), drainTimeoutMs);
+  }
+
+  const pendingBodies = captures.reduce((n, c) => n + (c.body === PENDING_BODY_MARKER ? 1 : 0), 0);
+  return { captures, captureCount: captures.length, droppedByLimit, pendingBodies };
+}
+
+/**
+ * Attach a page.on('request') listener for `durationMs` and return matching
+ * requests. Request post-data is synchronous, so there is nothing to drain.
+ *
+ * @returns {Promise<{captures: object[], captureCount: number, droppedByLimit: number}>}
+ */
+export async function captureRequests(page, opts) {
+  const {
+    regex,
+    durationMs,
+    maxBodyBytes,
+    maxCaptures,
+    includeHeaders = true,
+    sleep = defaultSleep,
+  } = opts;
+
+  const captures = [];
+  let droppedByLimit = 0;
+
+  const handler = (request) => {
+    try {
+      const url = request.url();
+      if (!regex.test(url)) return;
+      if (captures.length >= maxCaptures) { droppedByLimit++; return; }
+      const body = truncate(request.postData() || '', maxBodyBytes);
+      captures.push({
+        url,
+        method: request.method(),
+        len: body.length,
+        body,
+        headers: includeHeaders ? request.headers() : {},
+      });
+    } catch (e) {
+      captures.push({ err: e.message });
+    }
+  };
+
+  page.on('request', handler);
+  try {
+    await sleep(durationMs);
+  } finally {
+    page.off('request', handler);
+  }
+
+  return { captures, captureCount: captures.length, droppedByLimit };
+}

--- a/lib/openapi.js
+++ b/lib/openapi.js
@@ -43,6 +43,7 @@ const swaggerDefinition = {
     { name: 'Navigation', description: 'Navigate tabs to URLs or via search macros.' },
     { name: 'Interaction', description: 'Click, type, scroll, press keys, evaluate JS.' },
     { name: 'Content', description: 'Accessibility snapshots, screenshots, links, images, downloads.' },
+    { name: 'Network', description: 'Browser-level capture of requests and responses.' },
     { name: 'Sessions', description: 'Per-user session state: cookies, teardown.' },
     { name: 'Browser', description: 'Global browser lifecycle (start/stop).' },
     { name: 'Legacy', description: 'OpenClaw-compatible endpoints (deprecated).' },

--- a/openapi.json
+++ b/openapi.json
@@ -42,6 +42,10 @@
       "description": "Accessibility snapshots, screenshots, links, images, downloads."
     },
     {
+      "name": "Network",
+      "description": "Browser-level capture of requests and responses."
+    },
+    {
       "name": "Sessions",
       "description": "Per-user session state: cookies, teardown."
     },
@@ -1207,6 +1211,513 @@
                       "type": "boolean"
                     }
                   }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tabs/{tabId}/mouse-wheel": {
+      "post": {
+        "tags": [
+          "Interaction"
+        ],
+        "summary": "Dispatch a real wheel event at element or coordinate",
+        "description": "Moves the mouse to a target (resolved from a ref's bounding-box centre, an explicit (x, y) pair, or the viewport centre) and dispatches a real Playwright wheel event. Useful for nested scrollable containers that ignore programmatic scrollTop or JS-dispatched WheelEvents.\n",
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "ref": {
+                    "type": "string",
+                    "description": "Element ref (e.g. \"e22\"). Wheel is dispatched at its bounding-box centre."
+                  },
+                  "x": {
+                    "type": "number",
+                    "description": "Explicit x coordinate (ignored if ref is set)."
+                  },
+                  "y": {
+                    "type": "number",
+                    "description": "Explicit y coordinate (ignored if ref is set)."
+                  },
+                  "deltaX": {
+                    "type": "number",
+                    "default": 0,
+                    "description": "Horizontal scroll delta (-100000..100000). At least one delta must be non-zero."
+                  },
+                  "deltaY": {
+                    "type": "number",
+                    "default": 0,
+                    "description": "Vertical scroll delta (-100000..100000). At least one delta must be non-zero."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Wheel dispatched.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "x": {
+                      "type": "number"
+                    },
+                    "y": {
+                      "type": "number"
+                    },
+                    "deltaX": {
+                      "type": "number"
+                    },
+                    "deltaY": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing userId, invalid coordinates/deltas, or both deltas are zero.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Ref is stale or the element has no bounding box.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tabs/{tabId}/capture-network": {
+      "post": {
+        "tags": [
+          "Network"
+        ],
+        "summary": "Capture matching network responses for a bounded window",
+        "description": "Attaches a browser-level response listener for durationMs and returns every response whose URL matches urlPattern, with its body. Runs below the page's JavaScript, so it sees traffic that in-page fetch/XHR hooks miss (Service Workers, closure-cached fetch references). Response bodies that are still being read when the window closes are awaited before the response is sent; a body that does not arrive within the grace period is returned as \"__BODY_PENDING__\" and counted in pendingBodies.\n",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "urlPattern": {
+                    "type": "string",
+                    "default": "graphql",
+                    "maxLength": 200,
+                    "description": "Case-insensitive regular expression matched against the response URL."
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "default": 15000,
+                    "minimum": 100,
+                    "maximum": 60000
+                  },
+                  "maxCaptures": {
+                    "type": "integer",
+                    "default": 100,
+                    "minimum": 1,
+                    "maximum": 500
+                  },
+                  "maxBodyBytes": {
+                    "type": "integer",
+                    "default": 1000000,
+                    "minimum": 1024,
+                    "maximum": 5000000,
+                    "description": "Bodies longer than this are truncated with a \"__TRUNCATED__\" marker."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Captured responses.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "captureCount": {
+                      "type": "integer"
+                    },
+                    "droppedByLimit": {
+                      "type": "integer",
+                      "description": "Matching responses discarded because maxCaptures was reached."
+                    },
+                    "pendingBodies": {
+                      "type": "integer",
+                      "description": "Captures whose body did not finish reading within the grace period."
+                    },
+                    "captures": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "integer"
+                          },
+                          "len": {
+                            "type": "integer"
+                          },
+                          "body": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing userId, invalid urlPattern, or a limit out of range.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing or invalid bearer token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tabs/{tabId}/capture-requests": {
+      "post": {
+        "tags": [
+          "Network"
+        ],
+        "summary": "Capture matching outgoing requests for a bounded window",
+        "description": "Attaches a browser-level request listener for durationMs and returns every request whose URL matches urlPattern, with its POST body and (optionally) its headers. Runs below the page's JavaScript, so it sees requests even when in-page hooks on window.fetch / XMLHttpRequest are bypassed.\n",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "urlPattern": {
+                    "type": "string",
+                    "default": "graphql",
+                    "maxLength": 200,
+                    "description": "Case-insensitive regular expression matched against the request URL."
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "default": 15000,
+                    "minimum": 100,
+                    "maximum": 60000
+                  },
+                  "maxCaptures": {
+                    "type": "integer",
+                    "default": 100,
+                    "minimum": 1,
+                    "maximum": 500
+                  },
+                  "maxBodyBytes": {
+                    "type": "integer",
+                    "default": 200000,
+                    "minimum": 1024,
+                    "maximum": 5000000
+                  },
+                  "includeHeaders": {
+                    "type": "boolean",
+                    "default": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Captured requests.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "captureCount": {
+                      "type": "integer"
+                    },
+                    "droppedByLimit": {
+                      "type": "integer",
+                      "description": "Matching requests discarded because maxCaptures was reached."
+                    },
+                    "captures": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          },
+                          "method": {
+                            "type": "string"
+                          },
+                          "len": {
+                            "type": "integer"
+                          },
+                          "body": {
+                            "type": "string"
+                          },
+                          "headers": {
+                            "type": "object"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing userId, invalid urlPattern, or a limit out of range.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing or invalid bearer token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tabs/{tabId}/init-script": {
+      "post": {
+        "tags": [
+          "Interaction"
+        ],
+        "summary": "Register a script that runs before every navigation",
+        "description": "Adds a persistent init script to the tab's page. It executes in the page context before any page script on every subsequent navigation, which is the only reliable way to install fetch/XHR hooks that must catch the first request after a full reload. Scripts accumulate: each call adds one more, and they are dropped when the tab is destroyed. Requires the same bearer token as /tabs/{tabId}/evaluate, since the script runs arbitrary JS.\n",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId",
+                  "script"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "script": {
+                    "type": "string",
+                    "description": "JavaScript source evaluated in the page context before every navigation."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Init script registered.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "scriptLen": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing userId or empty script.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing or invalid bearer token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
                 }
               }
             }

--- a/server.js
+++ b/server.js
@@ -3786,6 +3786,79 @@ app.post('/tabs/:tabId/mouse-wheel', async (req, res) => {
   }
 });
 
+// Network response capture: attaches a Playwright page.on("response") listener for the
+// requested duration and returns all matching responses. Operates at the browser network
+// layer, bypassing any in-page JS, Service Worker, or closure-cached fetch references.
+app.post('/tabs/:tabId/capture-network', authMiddleware(), express.json({ limit: '64kb' }), async (req, res) => {
+  try {
+    const { userId, urlPattern = 'graphql', durationMs = 15000, maxBodyBytes = 1000000, maxCaptures = 100 } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, req.params.tabId);
+    if (!found) return tabNotFoundResponse(res, req.params.tabId || req.body?.tabId);
+    session.lastAccess = Date.now();
+
+    const { tabState } = found;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
+
+    const re = new RegExp(urlPattern, 'i');
+    const captures = [];
+    const handler = async (response) => {
+      try {
+        const url = response.url();
+        if (!re.test(url)) return;
+        if (captures.length >= maxCaptures) return;
+        const status = response.status();
+        let body = '';
+        try { body = await response.text(); } catch (e) { body = `__BODY_ERROR__:${e.message}`; }
+        if (body.length > maxBodyBytes) body = body.slice(0, maxBodyBytes) + '__TRUNCATED__';
+        captures.push({ url, status, len: body.length, body });
+      } catch (e) {
+        captures.push({ err: e.message });
+      }
+    };
+    tabState.page.on('response', handler);
+    await new Promise(r => setTimeout(r, Math.min(durationMs, 60000)));
+    tabState.page.off('response', handler);
+
+    pluginEvents.emit('tab:capture-network', { userId, tabId: req.params.tabId, captureCount: captures.length });
+    res.json({ ok: true, captureCount: captures.length, captures });
+  } catch (err) {
+    log('error', 'capture-network failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
+// Persistent init script that runs before every navigation in the tab's page context.
+// Useful for installing fetch/XHR hooks that must catch the very first request after
+// a full-page reload, where evaluate() injection arrives too late.
+app.post('/tabs/:tabId/init-script', authMiddleware(), express.json({ limit: '256kb' }), async (req, res) => {
+  try {
+    const { userId, script } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    if (typeof script !== 'string' || !script.trim()) return res.status(400).json({ error: 'script (string) required' });
+
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, req.params.tabId);
+    if (!found) return tabNotFoundResponse(res, req.params.tabId || req.body?.tabId);
+    session.lastAccess = Date.now();
+
+    const { tabState } = found;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
+
+    await withTabLock(req.params.tabId, async () => {
+      await tabState.page.addInitScript({ content: script });
+    });
+
+    pluginEvents.emit('tab:init-script', { userId, tabId: req.params.tabId, scriptLen: script.length });
+    res.json({ ok: true, scriptLen: script.length });
+  } catch (err) {
+    log('error', 'init-script failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
 // Viewport
 /**
  * @openapi

--- a/server.js
+++ b/server.js
@@ -3830,6 +3830,52 @@ app.post('/tabs/:tabId/capture-network', authMiddleware(), express.json({ limit:
   }
 });
 
+// Network request capture: attaches a Playwright page.on("request") listener for the
+// requested duration and returns matching requests with their POST body + headers.
+// Operates at the browser network layer, so it sees requests even when in-page hooks
+// on window.fetch / XMLHttpRequest are bypassed (e.g. when the bundle captured the
+// original references in a closure before any user JS could run).
+app.post('/tabs/:tabId/capture-requests', authMiddleware(), express.json({ limit: '64kb' }), async (req, res) => {
+  try {
+    const { userId, urlPattern = 'graphql', durationMs = 15000, maxBodyBytes = 200000, maxCaptures = 100, includeHeaders = true } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, req.params.tabId);
+    if (!found) return tabNotFoundResponse(res, req.params.tabId || req.body?.tabId);
+    session.lastAccess = Date.now();
+
+    const { tabState } = found;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
+
+    const re = new RegExp(urlPattern, 'i');
+    const captures = [];
+    const handler = (request) => {
+      try {
+        const url = request.url();
+        if (!re.test(url)) return;
+        if (captures.length >= maxCaptures) return;
+        const method = request.method();
+        let body = request.postData() || '';
+        if (body.length > maxBodyBytes) body = body.slice(0, maxBodyBytes) + '__TRUNCATED__';
+        const headers = includeHeaders ? request.headers() : {};
+        captures.push({ url, method, len: body.length, body, headers });
+      } catch (e) {
+        captures.push({ err: e.message });
+      }
+    };
+    tabState.page.on('request', handler);
+    await new Promise(r => setTimeout(r, Math.min(durationMs, 60000)));
+    tabState.page.off('request', handler);
+
+    pluginEvents.emit('tab:capture-requests', { userId, tabId: req.params.tabId, captureCount: captures.length });
+    res.json({ ok: true, captureCount: captures.length, captures });
+  } catch (err) {
+    log('error', 'capture-requests failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
 // Persistent init script that runs before every navigation in the tab's page context.
 // Useful for installing fetch/XHR hooks that must catch the very first request after
 // a full-page reload, where evaluate() injection arrives too late.

--- a/server.js
+++ b/server.js
@@ -3674,6 +3674,118 @@ app.post('/tabs/:tabId/scroll', async (req, res) => {
   }
 });
 
+// Element-scoped mouse wheel (real Playwright wheel event at specific coordinates).
+// Use this when page-level /scroll doesn't reach a nested scrollable container
+// (e.g. virtualised feeds with anti-automation guards).
+/**
+ * @openapi
+ * /tabs/{tabId}/mouse-wheel:
+ *   post:
+ *     tags: [Interaction]
+ *     summary: Dispatch a real wheel event at element or coordinate
+ *     description: >
+ *       Moves the mouse to a target (resolved from a ref's bounding-box centre,
+ *       an explicit (x, y) pair, or the viewport centre) and dispatches a real
+ *       Playwright wheel event. Useful for nested scrollable containers that
+ *       ignore programmatic scrollTop or JS-dispatched WheelEvents.
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *               ref:
+ *                 type: string
+ *                 description: Element ref (e.g. "e22"). Wheel is dispatched at its bounding-box centre.
+ *               x:
+ *                 type: number
+ *                 description: Explicit x coordinate (ignored if ref is set).
+ *               y:
+ *                 type: number
+ *                 description: Explicit y coordinate (ignored if ref is set).
+ *               deltaX:
+ *                 type: number
+ *                 default: 0
+ *               deltaY:
+ *                 type: number
+ *                 default: 0
+ *     responses:
+ *       200:
+ *         description: Wheel dispatched.
+ *       400:
+ *         description: Missing userId or both deltas are zero.
+ *       404:
+ *         description: Tab not found.
+ */
+app.post('/tabs/:tabId/mouse-wheel', async (req, res) => {
+  try {
+    const { userId, ref, x, y, deltaX = 0, deltaY = 0 } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    if (!deltaX && !deltaY) return res.status(400).json({ error: 'deltaX or deltaY required' });
+
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, req.params.tabId);
+    if (!found) return tabNotFoundResponse(res, req.params.tabId || req.body?.tabId);
+    session.lastAccess = Date.now();
+
+    const { tabState } = found;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
+
+    const result = await withTabLock(req.params.tabId, async () => {
+      let targetX, targetY;
+      if (ref) {
+        let locator = refToLocator(tabState.page, ref, tabState.refs);
+        if (!locator) {
+          try {
+            tabState.refs = await refreshTabRefs(tabState, { reason: 'pre_wheel', timeoutMs: 4000 });
+          } catch (e) {
+            if (e.message !== 'pre_click_refs_timeout' && e.message !== 'buildRefs_timeout') throw e;
+          }
+          locator = refToLocator(tabState.page, ref, tabState.refs);
+        }
+        if (!locator) {
+          const maxRef = tabState.refs.size > 0 ? `e${tabState.refs.size}` : 'none';
+          throw new StaleRefsError(ref, maxRef, tabState.refs.size);
+        }
+        const box = await locator.boundingBox();
+        if (!box) throw new Error('Element not visible (no bounding box)');
+        targetX = box.x + box.width / 2;
+        targetY = box.y + box.height / 2;
+      } else if (typeof x === 'number' && typeof y === 'number') {
+        targetX = x;
+        targetY = y;
+      } else {
+        const vs = tabState.page.viewportSize();
+        targetX = vs.width / 2;
+        targetY = vs.height / 2;
+      }
+
+      await tabState.page.mouse.move(targetX, targetY);
+      await tabState.page.waitForTimeout(50);
+      await tabState.page.mouse.wheel(deltaX, deltaY);
+      await tabState.page.waitForTimeout(300);
+
+      return { x: Math.round(targetX), y: Math.round(targetY) };
+    });
+
+    pluginEvents.emit('tab:mouse-wheel', { userId, tabId: req.params.tabId, ref, deltaX, deltaY, ...result });
+    res.json({ ok: true, ...result, deltaX, deltaY });
+  } catch (err) {
+    log('error', 'mouse-wheel failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
 // Viewport
 /**
  * @openapi

--- a/server.js
+++ b/server.js
@@ -4217,6 +4217,79 @@ app.post('/tabs/:tabId/mouse-wheel', async (req, res) => {
   }
 });
 
+// Network response capture: attaches a Playwright page.on("response") listener for the
+// requested duration and returns all matching responses. Operates at the browser network
+// layer, bypassing any in-page JS, Service Worker, or closure-cached fetch references.
+app.post('/tabs/:tabId/capture-network', authMiddleware(), express.json({ limit: '64kb' }), async (req, res) => {
+  try {
+    const { userId, urlPattern = 'graphql', durationMs = 15000, maxBodyBytes = 1000000, maxCaptures = 100 } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, req.params.tabId);
+    if (!found) return tabNotFoundResponse(res, req.params.tabId || req.body?.tabId);
+    session.lastAccess = Date.now();
+
+    const { tabState } = found;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
+
+    const re = new RegExp(urlPattern, 'i');
+    const captures = [];
+    const handler = async (response) => {
+      try {
+        const url = response.url();
+        if (!re.test(url)) return;
+        if (captures.length >= maxCaptures) return;
+        const status = response.status();
+        let body = '';
+        try { body = await response.text(); } catch (e) { body = `__BODY_ERROR__:${e.message}`; }
+        if (body.length > maxBodyBytes) body = body.slice(0, maxBodyBytes) + '__TRUNCATED__';
+        captures.push({ url, status, len: body.length, body });
+      } catch (e) {
+        captures.push({ err: e.message });
+      }
+    };
+    tabState.page.on('response', handler);
+    await new Promise(r => setTimeout(r, Math.min(durationMs, 60000)));
+    tabState.page.off('response', handler);
+
+    pluginEvents.emit('tab:capture-network', { userId, tabId: req.params.tabId, captureCount: captures.length });
+    res.json({ ok: true, captureCount: captures.length, captures });
+  } catch (err) {
+    log('error', 'capture-network failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
+// Persistent init script that runs before every navigation in the tab's page context.
+// Useful for installing fetch/XHR hooks that must catch the very first request after
+// a full-page reload, where evaluate() injection arrives too late.
+app.post('/tabs/:tabId/init-script', authMiddleware(), express.json({ limit: '256kb' }), async (req, res) => {
+  try {
+    const { userId, script } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    if (typeof script !== 'string' || !script.trim()) return res.status(400).json({ error: 'script (string) required' });
+
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, req.params.tabId);
+    if (!found) return tabNotFoundResponse(res, req.params.tabId || req.body?.tabId);
+    session.lastAccess = Date.now();
+
+    const { tabState } = found;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
+
+    await withTabLock(req.params.tabId, async () => {
+      await tabState.page.addInitScript({ content: script });
+    });
+
+    pluginEvents.emit('tab:init-script', { userId, tabId: req.params.tabId, scriptLen: script.length });
+    res.json({ ok: true, scriptLen: script.length });
+  } catch (err) {
+    log('error', 'init-script failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
 // Viewport
 /**
  * @openapi

--- a/server.js
+++ b/server.js
@@ -4261,6 +4261,52 @@ app.post('/tabs/:tabId/capture-network', authMiddleware(), express.json({ limit:
   }
 });
 
+// Network request capture: attaches a Playwright page.on("request") listener for the
+// requested duration and returns matching requests with their POST body + headers.
+// Operates at the browser network layer, so it sees requests even when in-page hooks
+// on window.fetch / XMLHttpRequest are bypassed (e.g. when the bundle captured the
+// original references in a closure before any user JS could run).
+app.post('/tabs/:tabId/capture-requests', authMiddleware(), express.json({ limit: '64kb' }), async (req, res) => {
+  try {
+    const { userId, urlPattern = 'graphql', durationMs = 15000, maxBodyBytes = 200000, maxCaptures = 100, includeHeaders = true } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, req.params.tabId);
+    if (!found) return tabNotFoundResponse(res, req.params.tabId || req.body?.tabId);
+    session.lastAccess = Date.now();
+
+    const { tabState } = found;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
+
+    const re = new RegExp(urlPattern, 'i');
+    const captures = [];
+    const handler = (request) => {
+      try {
+        const url = request.url();
+        if (!re.test(url)) return;
+        if (captures.length >= maxCaptures) return;
+        const method = request.method();
+        let body = request.postData() || '';
+        if (body.length > maxBodyBytes) body = body.slice(0, maxBodyBytes) + '__TRUNCATED__';
+        const headers = includeHeaders ? request.headers() : {};
+        captures.push({ url, method, len: body.length, body, headers });
+      } catch (e) {
+        captures.push({ err: e.message });
+      }
+    };
+    tabState.page.on('request', handler);
+    await new Promise(r => setTimeout(r, Math.min(durationMs, 60000)));
+    tabState.page.off('request', handler);
+
+    pluginEvents.emit('tab:capture-requests', { userId, tabId: req.params.tabId, captureCount: captures.length });
+    res.json({ ok: true, captureCount: captures.length, captures });
+  } catch (err) {
+    log('error', 'capture-requests failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
 // Persistent init script that runs before every navigation in the tab's page context.
 // Useful for installing fetch/XHR hooks that must catch the very first request after
 // a full-page reload, where evaluate() injection arrives too late.

--- a/server.js
+++ b/server.js
@@ -35,6 +35,8 @@ import { cleanupOrphanedTempFiles, cleanupStaleFirefoxProfiles } from './lib/tmp
 import { coalesceInflight } from './lib/inflight.js';
 import { createPageWithSessionRecovery } from './lib/new-page-recovery.js';
 import { resolveUploadPaths } from './lib/upload-paths.js';
+import { parseCaptureParams, parseWheelParams, CAPTURE_MAX_BODY_BYTES, REQUEST_MAX_BODY_BYTES_DEFAULT } from './lib/interaction-params.js';
+import { captureResponses, captureRequests } from './lib/network-capture.js';
 import { acquirePageLease, hasActivePageLeases, isPageLeased, releasePageLease, setLeasedPage } from './lib/page-lease.js';
 import { createReporter, createTabHealthTracker, collectResourceSnapshot, classifyProxyError, browserProcessTreeRssMb, browserProcessNameRssMb } from './lib/reporter.js';
 import { mountDocs } from './lib/openapi.js';
@@ -4147,22 +4149,56 @@ app.post('/tabs/:tabId/scroll', async (req, res) => {
  *               deltaX:
  *                 type: number
  *                 default: 0
+ *                 description: Horizontal scroll delta (-100000..100000). At least one delta must be non-zero.
  *               deltaY:
  *                 type: number
  *                 default: 0
+ *                 description: Vertical scroll delta (-100000..100000). At least one delta must be non-zero.
  *     responses:
  *       200:
  *         description: Wheel dispatched.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                 x:
+ *                   type: number
+ *                 y:
+ *                   type: number
+ *                 deltaX:
+ *                   type: number
+ *                 deltaY:
+ *                   type: number
  *       400:
- *         description: Missing userId or both deltas are zero.
+ *         description: Missing userId, invalid coordinates/deltas, or both deltas are zero.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  *       404:
  *         description: Tab not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       422:
+ *         description: Ref is stale or the element has no bounding box.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 app.post('/tabs/:tabId/mouse-wheel', async (req, res) => {
   try {
-    const { userId, ref, x, y, deltaX = 0, deltaY = 0 } = req.body;
+    const { userId } = req.body;
     if (!userId) return res.status(400).json({ error: 'userId required' });
-    if (!deltaX && !deltaY) return res.status(400).json({ error: 'deltaX or deltaY required' });
+
+    const parsed = parseWheelParams(req.body);
+    if (!parsed.ok) return res.status(400).json({ error: parsed.error, code: parsed.code });
+    const { ref, coords, deltaX, deltaY } = parsed.params;
 
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, req.params.tabId);
@@ -4173,14 +4209,17 @@ app.post('/tabs/:tabId/mouse-wheel', async (req, res) => {
     tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
 
     const result = await withTabLock(req.params.tabId, async () => {
+      const wheelStart = Date.now();
+      const remainingBudget = () => Math.max(0, HANDLER_TIMEOUT_MS - 2000 - (Date.now() - wheelStart));
       let targetX, targetY;
       if (ref) {
         let locator = refToLocator(tabState.page, ref, tabState.refs);
         if (!locator) {
           try {
-            tabState.refs = await refreshTabRefs(tabState, { reason: 'pre_wheel', timeoutMs: 4000 });
+            const preWheelBudget = Math.min(4000, remainingBudget());
+            tabState.refs = await refreshTabRefs(tabState, { reason: 'pre_wheel', timeoutMs: preWheelBudget });
           } catch (e) {
-            if (e.message !== 'pre_click_refs_timeout' && e.message !== 'buildRefs_timeout') throw e;
+            if (e.message !== 'pre_wheel_refs_timeout' && e.message !== 'buildRefs_timeout') throw e;
           }
           locator = refToLocator(tabState.page, ref, tabState.refs);
         }
@@ -4188,13 +4227,26 @@ app.post('/tabs/:tabId/mouse-wheel', async (req, res) => {
           const maxRef = tabState.refs.size > 0 ? `e${tabState.refs.size}` : 'none';
           throw new StaleRefsError(ref, maxRef, tabState.refs.size);
         }
-        const box = await locator.boundingBox();
+        // Same bounded lookup as the click path: an unbounded boundingBox()
+        // inherits Playwright's 30s default and eats the whole handler budget
+        // when the element detached, turning a 422 into a 500. The message
+        // avoids 'timed out after' so isTimeoutError() doesn't classify a
+        // detached element as a navigation timeout and destroy the session.
+        const bboxTimeout = Math.max(500, Math.min(3000, remainingBudget()));
+        let box;
+        try {
+          box = await locator.boundingBox({ timeout: bboxTimeout });
+        } catch {
+          const detachedErr = new Error(`Element not actionable: no bounding box within ${bboxTimeout}ms (element likely detached after page change). Call snapshot to refresh refs and retry.`);
+          detachedErr.statusCode = 422;
+          throw detachedErr;
+        }
         if (!box) throw new Error('Element not visible (no bounding box)');
         targetX = box.x + box.width / 2;
         targetY = box.y + box.height / 2;
-      } else if (typeof x === 'number' && typeof y === 'number') {
-        targetX = x;
-        targetY = y;
+      } else if (coords) {
+        targetX = coords.x;
+        targetY = coords.y;
       } else {
         const vs = tabState.page.viewportSize();
         targetX = vs.width / 2;
@@ -4220,10 +4272,116 @@ app.post('/tabs/:tabId/mouse-wheel', async (req, res) => {
 // Network response capture: attaches a Playwright page.on("response") listener for the
 // requested duration and returns all matching responses. Operates at the browser network
 // layer, bypassing any in-page JS, Service Worker, or closure-cached fetch references.
+/**
+ * @openapi
+ * /tabs/{tabId}/capture-network:
+ *   post:
+ *     tags: [Network]
+ *     summary: Capture matching network responses for a bounded window
+ *     description: >
+ *       Attaches a browser-level response listener for durationMs and returns every
+ *       response whose URL matches urlPattern, with its body. Runs below the page's
+ *       JavaScript, so it sees traffic that in-page fetch/XHR hooks miss (Service
+ *       Workers, closure-cached fetch references). Response bodies that are still
+ *       being read when the window closes are awaited before the response is sent;
+ *       a body that does not arrive within the grace period is returned as
+ *       "__BODY_PENDING__" and counted in pendingBodies.
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *               urlPattern:
+ *                 type: string
+ *                 default: graphql
+ *                 maxLength: 200
+ *                 description: Case-insensitive regular expression matched against the response URL.
+ *               durationMs:
+ *                 type: integer
+ *                 default: 15000
+ *                 minimum: 100
+ *                 maximum: 60000
+ *               maxCaptures:
+ *                 type: integer
+ *                 default: 100
+ *                 minimum: 1
+ *                 maximum: 500
+ *               maxBodyBytes:
+ *                 type: integer
+ *                 default: 1000000
+ *                 minimum: 1024
+ *                 maximum: 5000000
+ *                 description: Bodies longer than this are truncated with a "__TRUNCATED__" marker.
+ *     responses:
+ *       200:
+ *         description: Captured responses.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                 captureCount:
+ *                   type: integer
+ *                 droppedByLimit:
+ *                   type: integer
+ *                   description: Matching responses discarded because maxCaptures was reached.
+ *                 pendingBodies:
+ *                   type: integer
+ *                   description: Captures whose body did not finish reading within the grace period.
+ *                 captures:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       url:
+ *                         type: string
+ *                       status:
+ *                         type: integer
+ *                       len:
+ *                         type: integer
+ *                       body:
+ *                         type: string
+ *       400:
+ *         description: Missing userId, invalid urlPattern, or a limit out of range.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       403:
+ *         description: Missing or invalid bearer token.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: Tab not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 app.post('/tabs/:tabId/capture-network', authMiddleware(), express.json({ limit: '64kb' }), async (req, res) => {
   try {
-    const { userId, urlPattern = 'graphql', durationMs = 15000, maxBodyBytes = 1000000, maxCaptures = 100 } = req.body;
+    const { userId } = req.body;
     if (!userId) return res.status(400).json({ error: 'userId required' });
+
+    const parsed = parseCaptureParams(req.body, { maxBodyBytesDefault: CAPTURE_MAX_BODY_BYTES.default });
+    if (!parsed.ok) return res.status(400).json({ error: parsed.error, code: parsed.code });
 
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, req.params.tabId);
@@ -4233,28 +4391,10 @@ app.post('/tabs/:tabId/capture-network', authMiddleware(), express.json({ limit:
     const { tabState } = found;
     tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
 
-    const re = new RegExp(urlPattern, 'i');
-    const captures = [];
-    const handler = async (response) => {
-      try {
-        const url = response.url();
-        if (!re.test(url)) return;
-        if (captures.length >= maxCaptures) return;
-        const status = response.status();
-        let body = '';
-        try { body = await response.text(); } catch (e) { body = `__BODY_ERROR__:${e.message}`; }
-        if (body.length > maxBodyBytes) body = body.slice(0, maxBodyBytes) + '__TRUNCATED__';
-        captures.push({ url, status, len: body.length, body });
-      } catch (e) {
-        captures.push({ err: e.message });
-      }
-    };
-    tabState.page.on('response', handler);
-    await new Promise(r => setTimeout(r, Math.min(durationMs, 60000)));
-    tabState.page.off('response', handler);
+    const { captures, captureCount, droppedByLimit, pendingBodies } = await captureResponses(tabState.page, parsed.params);
 
-    pluginEvents.emit('tab:capture-network', { userId, tabId: req.params.tabId, captureCount: captures.length });
-    res.json({ ok: true, captureCount: captures.length, captures });
+    pluginEvents.emit('tab:capture-network', { userId, tabId: req.params.tabId, captureCount });
+    res.json({ ok: true, captureCount, droppedByLimit, pendingBodies, captures });
   } catch (err) {
     log('error', 'capture-network failed', { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
@@ -4266,10 +4406,114 @@ app.post('/tabs/:tabId/capture-network', authMiddleware(), express.json({ limit:
 // Operates at the browser network layer, so it sees requests even when in-page hooks
 // on window.fetch / XMLHttpRequest are bypassed (e.g. when the bundle captured the
 // original references in a closure before any user JS could run).
+/**
+ * @openapi
+ * /tabs/{tabId}/capture-requests:
+ *   post:
+ *     tags: [Network]
+ *     summary: Capture matching outgoing requests for a bounded window
+ *     description: >
+ *       Attaches a browser-level request listener for durationMs and returns every
+ *       request whose URL matches urlPattern, with its POST body and (optionally)
+ *       its headers. Runs below the page's JavaScript, so it sees requests even when
+ *       in-page hooks on window.fetch / XMLHttpRequest are bypassed.
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *               urlPattern:
+ *                 type: string
+ *                 default: graphql
+ *                 maxLength: 200
+ *                 description: Case-insensitive regular expression matched against the request URL.
+ *               durationMs:
+ *                 type: integer
+ *                 default: 15000
+ *                 minimum: 100
+ *                 maximum: 60000
+ *               maxCaptures:
+ *                 type: integer
+ *                 default: 100
+ *                 minimum: 1
+ *                 maximum: 500
+ *               maxBodyBytes:
+ *                 type: integer
+ *                 default: 200000
+ *                 minimum: 1024
+ *                 maximum: 5000000
+ *               includeHeaders:
+ *                 type: boolean
+ *                 default: true
+ *     responses:
+ *       200:
+ *         description: Captured requests.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                 captureCount:
+ *                   type: integer
+ *                 droppedByLimit:
+ *                   type: integer
+ *                   description: Matching requests discarded because maxCaptures was reached.
+ *                 captures:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       url:
+ *                         type: string
+ *                       method:
+ *                         type: string
+ *                       len:
+ *                         type: integer
+ *                       body:
+ *                         type: string
+ *                       headers:
+ *                         type: object
+ *       400:
+ *         description: Missing userId, invalid urlPattern, or a limit out of range.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       403:
+ *         description: Missing or invalid bearer token.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: Tab not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 app.post('/tabs/:tabId/capture-requests', authMiddleware(), express.json({ limit: '64kb' }), async (req, res) => {
   try {
-    const { userId, urlPattern = 'graphql', durationMs = 15000, maxBodyBytes = 200000, maxCaptures = 100, includeHeaders = true } = req.body;
+    const { userId } = req.body;
     if (!userId) return res.status(400).json({ error: 'userId required' });
+
+    const parsed = parseCaptureParams(req.body, { maxBodyBytesDefault: REQUEST_MAX_BODY_BYTES_DEFAULT });
+    if (!parsed.ok) return res.status(400).json({ error: parsed.error, code: parsed.code });
 
     const session = sessions.get(normalizeUserId(userId));
     const found = session && findTab(session, req.params.tabId);
@@ -4279,28 +4523,10 @@ app.post('/tabs/:tabId/capture-requests', authMiddleware(), express.json({ limit
     const { tabState } = found;
     tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
 
-    const re = new RegExp(urlPattern, 'i');
-    const captures = [];
-    const handler = (request) => {
-      try {
-        const url = request.url();
-        if (!re.test(url)) return;
-        if (captures.length >= maxCaptures) return;
-        const method = request.method();
-        let body = request.postData() || '';
-        if (body.length > maxBodyBytes) body = body.slice(0, maxBodyBytes) + '__TRUNCATED__';
-        const headers = includeHeaders ? request.headers() : {};
-        captures.push({ url, method, len: body.length, body, headers });
-      } catch (e) {
-        captures.push({ err: e.message });
-      }
-    };
-    tabState.page.on('request', handler);
-    await new Promise(r => setTimeout(r, Math.min(durationMs, 60000)));
-    tabState.page.off('request', handler);
+    const { captures, captureCount, droppedByLimit } = await captureRequests(tabState.page, parsed.params);
 
-    pluginEvents.emit('tab:capture-requests', { userId, tabId: req.params.tabId, captureCount: captures.length });
-    res.json({ ok: true, captureCount: captures.length, captures });
+    pluginEvents.emit('tab:capture-requests', { userId, tabId: req.params.tabId, captureCount });
+    res.json({ ok: true, captureCount, droppedByLimit, captures });
   } catch (err) {
     log('error', 'capture-requests failed', { reqId: req.reqId, error: err.message });
     handleRouteError(err, req, res);
@@ -4310,6 +4536,71 @@ app.post('/tabs/:tabId/capture-requests', authMiddleware(), express.json({ limit
 // Persistent init script that runs before every navigation in the tab's page context.
 // Useful for installing fetch/XHR hooks that must catch the very first request after
 // a full-page reload, where evaluate() injection arrives too late.
+/**
+ * @openapi
+ * /tabs/{tabId}/init-script:
+ *   post:
+ *     tags: [Interaction]
+ *     summary: Register a script that runs before every navigation
+ *     description: >
+ *       Adds a persistent init script to the tab's page. It executes in the page
+ *       context before any page script on every subsequent navigation, which is the
+ *       only reliable way to install fetch/XHR hooks that must catch the first
+ *       request after a full reload. Scripts accumulate: each call adds one more,
+ *       and they are dropped when the tab is destroyed. Requires the same bearer
+ *       token as /tabs/{tabId}/evaluate, since the script runs arbitrary JS.
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId, script]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *               script:
+ *                 type: string
+ *                 description: JavaScript source evaluated in the page context before every navigation.
+ *     responses:
+ *       200:
+ *         description: Init script registered.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                 scriptLen:
+ *                   type: integer
+ *       400:
+ *         description: Missing userId or empty script.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       403:
+ *         description: Missing or invalid bearer token.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: Tab not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 app.post('/tabs/:tabId/init-script', authMiddleware(), express.json({ limit: '256kb' }), async (req, res) => {
   try {
     const { userId, script } = req.body;

--- a/server.js
+++ b/server.js
@@ -4105,6 +4105,118 @@ app.post('/tabs/:tabId/scroll', async (req, res) => {
   }
 });
 
+// Element-scoped mouse wheel (real Playwright wheel event at specific coordinates).
+// Use this when page-level /scroll doesn't reach a nested scrollable container
+// (e.g. virtualised feeds with anti-automation guards).
+/**
+ * @openapi
+ * /tabs/{tabId}/mouse-wheel:
+ *   post:
+ *     tags: [Interaction]
+ *     summary: Dispatch a real wheel event at element or coordinate
+ *     description: >
+ *       Moves the mouse to a target (resolved from a ref's bounding-box centre,
+ *       an explicit (x, y) pair, or the viewport centre) and dispatches a real
+ *       Playwright wheel event. Useful for nested scrollable containers that
+ *       ignore programmatic scrollTop or JS-dispatched WheelEvents.
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *               ref:
+ *                 type: string
+ *                 description: Element ref (e.g. "e22"). Wheel is dispatched at its bounding-box centre.
+ *               x:
+ *                 type: number
+ *                 description: Explicit x coordinate (ignored if ref is set).
+ *               y:
+ *                 type: number
+ *                 description: Explicit y coordinate (ignored if ref is set).
+ *               deltaX:
+ *                 type: number
+ *                 default: 0
+ *               deltaY:
+ *                 type: number
+ *                 default: 0
+ *     responses:
+ *       200:
+ *         description: Wheel dispatched.
+ *       400:
+ *         description: Missing userId or both deltas are zero.
+ *       404:
+ *         description: Tab not found.
+ */
+app.post('/tabs/:tabId/mouse-wheel', async (req, res) => {
+  try {
+    const { userId, ref, x, y, deltaX = 0, deltaY = 0 } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    if (!deltaX && !deltaY) return res.status(400).json({ error: 'deltaX or deltaY required' });
+
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, req.params.tabId);
+    if (!found) return tabNotFoundResponse(res, req.params.tabId || req.body?.tabId);
+    session.lastAccess = Date.now();
+
+    const { tabState } = found;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
+
+    const result = await withTabLock(req.params.tabId, async () => {
+      let targetX, targetY;
+      if (ref) {
+        let locator = refToLocator(tabState.page, ref, tabState.refs);
+        if (!locator) {
+          try {
+            tabState.refs = await refreshTabRefs(tabState, { reason: 'pre_wheel', timeoutMs: 4000 });
+          } catch (e) {
+            if (e.message !== 'pre_click_refs_timeout' && e.message !== 'buildRefs_timeout') throw e;
+          }
+          locator = refToLocator(tabState.page, ref, tabState.refs);
+        }
+        if (!locator) {
+          const maxRef = tabState.refs.size > 0 ? `e${tabState.refs.size}` : 'none';
+          throw new StaleRefsError(ref, maxRef, tabState.refs.size);
+        }
+        const box = await locator.boundingBox();
+        if (!box) throw new Error('Element not visible (no bounding box)');
+        targetX = box.x + box.width / 2;
+        targetY = box.y + box.height / 2;
+      } else if (typeof x === 'number' && typeof y === 'number') {
+        targetX = x;
+        targetY = y;
+      } else {
+        const vs = tabState.page.viewportSize();
+        targetX = vs.width / 2;
+        targetY = vs.height / 2;
+      }
+
+      await tabState.page.mouse.move(targetX, targetY);
+      await tabState.page.waitForTimeout(50);
+      await tabState.page.mouse.wheel(deltaX, deltaY);
+      await tabState.page.waitForTimeout(300);
+
+      return { x: Math.round(targetX), y: Math.round(targetY) };
+    });
+
+    pluginEvents.emit('tab:mouse-wheel', { userId, tabId: req.params.tabId, ref, deltaX, deltaY, ...result });
+    res.json({ ok: true, ...result, deltaX, deltaY });
+  } catch (err) {
+    log('error', 'mouse-wheel failed', { reqId: req.reqId, error: err.message });
+    handleRouteError(err, req, res);
+  }
+});
+
 // Viewport
 /**
  * @openapi

--- a/tests/unit/interactionEndpoints.test.js
+++ b/tests/unit/interactionEndpoints.test.js
@@ -1,0 +1,164 @@
+import crypto from 'crypto';
+import path from 'path';
+import { fileURLToPath } from 'node:url';
+import { launchServer } from '../../lib/launcher.js';
+import { loadConfig } from '../../lib/config.js';
+
+// Endpoint-level contract for the low-level interaction/capture routes.
+//
+// Every case here is rejected before any tab lookup, so the tests exercise the
+// real Express wiring (auth, body parsing, validators, status codes) without
+// launching a browser. The point is that bad client input surfaces as 400 --
+// an unvalidated `new RegExp(urlPattern)` or a NaN delta used to reach the
+// handler and come back as a 500.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEST_API_KEY = 'test-interaction-key-' + crypto.randomUUID();
+
+let serverProcess = null;
+let baseUrl = null;
+
+async function waitForServer(port, maxRetries = 30) {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const res = await fetch(`http://localhost:${port}/health`);
+      if (res.ok) return;
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error(`Server failed to start on port ${port}`);
+}
+
+async function post(routePath, body, { auth = true } = {}) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (auth) headers.Authorization = `Bearer ${TEST_API_KEY}`;
+  const res = await fetch(`${baseUrl}${routePath}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  let data = null;
+  try { data = await res.json(); } catch { /* empty body */ }
+  return { status: res.status, data };
+}
+
+const TAB = 'no-such-tab';
+const UNKNOWN_USER = 'unknown-user-' + crypto.randomUUID();
+
+beforeAll(async () => {
+  const cfg = loadConfig();
+  const port = Math.floor(3100 + Math.random() * 900);
+  serverProcess = launchServer({
+    pluginDir: path.join(__dirname, '../..'),
+    port,
+    env: { ...cfg.serverEnv, CAMOFOX_API_KEY: TEST_API_KEY, DEBUG_RESPONSES: 'false' },
+    log: { info: () => {}, error: () => {} },
+  });
+  baseUrl = `http://localhost:${port}`;
+  await waitForServer(port);
+}, 120000);
+
+afterAll(async () => {
+  if (!serverProcess) return;
+  await new Promise((resolve) => {
+    serverProcess.on('close', resolve);
+    serverProcess.kill('SIGTERM');
+    setTimeout(() => { serverProcess.kill('SIGKILL'); resolve(); }, 5000);
+  });
+  serverProcess = null;
+}, 30000);
+
+describe('POST /tabs/:tabId/mouse-wheel', () => {
+  test('requires userId', async () => {
+    const { status, data } = await post(`/tabs/${TAB}/mouse-wheel`, { deltaY: 500 });
+    expect(status).toBe(400);
+    expect(data.error).toMatch(/userId required/i);
+  });
+
+  test.each([
+    ['both deltas zero', { deltaX: 0, deltaY: 0 }, /non-zero/i],
+    ['no deltas at all', {}, /non-zero/i],
+    ['non-numeric deltaY', { deltaY: '500' }, /finite number/i],
+    ['NaN deltaY', { deltaY: null, deltaX: 'NaN' }, /finite number/i],
+    ['delta out of range', { deltaY: 1e9 }, /out of range/i],
+    ['x without y', { deltaY: 100, x: 10 }, /provided together/i],
+    ['negative coordinate', { deltaY: 100, x: -5, y: 10 }, /out of range/i],
+    ['non-string ref', { deltaY: 100, ref: 7 }, /non-empty string/i],
+  ])('rejects %s with 400', async (_label, body, expected) => {
+    const { status, data } = await post(`/tabs/${TAB}/mouse-wheel`, { userId: UNKNOWN_USER, ...body });
+    expect(status).toBe(400);
+    expect(data.error).toMatch(expected);
+  });
+
+  test('returns 404 for an unknown tab once input is valid', async () => {
+    const { status } = await post(`/tabs/${TAB}/mouse-wheel`, { userId: UNKNOWN_USER, deltaY: 500 });
+    expect(status).toBe(404);
+  });
+});
+
+describe.each([
+  ['/capture-network'],
+  ['/capture-requests'],
+])('POST /tabs/:tabId%s', (route) => {
+  test('requires a bearer token', async () => {
+    const { status } = await post(`/tabs/${TAB}${route}`, { userId: UNKNOWN_USER }, { auth: false });
+    expect(status).toBe(403);
+  });
+
+  test('requires userId', async () => {
+    const { status, data } = await post(`/tabs/${TAB}${route}`, {});
+    expect(status).toBe(400);
+    expect(data.error).toMatch(/userId required/i);
+  });
+
+  test.each([
+    ['an invalid regular expression', { urlPattern: 'graphql(' }, /not a valid regular expression/i],
+    ['an empty urlPattern', { urlPattern: '' }, /non-empty string/i],
+    ['an over-long urlPattern', { urlPattern: 'a'.repeat(201) }, /too long/i],
+    ['a catastrophic-backtracking pattern', { urlPattern: '(a+)+$' }, /nested quantifier/i],
+    ['durationMs above the cap', { durationMs: 600000 }, /durationMs out of range/i],
+    ['durationMs below the floor', { durationMs: 5 }, /durationMs out of range/i],
+    ['a non-numeric durationMs', { durationMs: '15000' }, /finite number/i],
+    ['maxCaptures out of range', { maxCaptures: 0 }, /maxCaptures out of range/i],
+    ['maxBodyBytes out of range', { maxBodyBytes: 50000000 }, /maxBodyBytes out of range/i],
+  ])('rejects %s with 400', async (_label, body, expected) => {
+    const { status, data } = await post(`/tabs/${TAB}${route}`, { userId: UNKNOWN_USER, ...body });
+    expect(status).toBe(400);
+    expect(data.error).toMatch(expected);
+  });
+
+  test('returns 404 for an unknown tab once input is valid', async () => {
+    const { status } = await post(`/tabs/${TAB}${route}`, { userId: UNKNOWN_USER, durationMs: 100 });
+    expect(status).toBe(404);
+  });
+});
+
+describe('POST /tabs/:tabId/init-script', () => {
+  test('requires a bearer token', async () => {
+    const { status } = await post(`/tabs/${TAB}/init-script`, { userId: UNKNOWN_USER, script: 'void 0' }, { auth: false });
+    expect(status).toBe(403);
+  });
+
+  test('requires userId', async () => {
+    const { status, data } = await post(`/tabs/${TAB}/init-script`, { script: 'void 0' });
+    expect(status).toBe(400);
+    expect(data.error).toMatch(/userId required/i);
+  });
+
+  test.each([
+    ['a missing script', {}],
+    ['an empty script', { script: '   ' }],
+    ['a non-string script', { script: { toString: 1 } }],
+  ])('rejects %s with 400', async (_label, body) => {
+    const { status, data } = await post(`/tabs/${TAB}/init-script`, { userId: UNKNOWN_USER, ...body });
+    expect(status).toBe(400);
+    expect(data.error).toMatch(/script/i);
+  });
+
+  test('returns 404 for an unknown tab once input is valid', async () => {
+    const { status } = await post(`/tabs/${TAB}/init-script`, { userId: UNKNOWN_USER, script: 'window.__x = 1;' });
+    expect(status).toBe(404);
+  });
+});

--- a/tests/unit/interactionParams.test.js
+++ b/tests/unit/interactionParams.test.js
@@ -1,0 +1,159 @@
+import { describe, test, expect } from '@jest/globals';
+import {
+  compileUrlPattern,
+  hasNestedQuantifier,
+  parseCaptureParams,
+  parseWheelParams,
+  validateRange,
+  MAX_URL_PATTERN_LENGTH,
+} from '../../lib/interaction-params.js';
+
+// Guards for /tabs/:tabId/mouse-wheel, /capture-network and /capture-requests.
+// The endpoints import these same functions, so there is no copy to drift.
+
+describe('compileUrlPattern', () => {
+  test('compiles a valid case-insensitive pattern', () => {
+    const result = compileUrlPattern('graphql|/api/v2');
+    expect(result.ok).toBe(true);
+    expect(result.regex.test('https://x.test/API/V2/list')).toBe(true);
+    expect(result.regex.test('https://x.test/static/app.js')).toBe(false);
+  });
+
+  test('rejects an invalid regular expression instead of throwing', () => {
+    const result = compileUrlPattern('graphql(');
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('invalid_url_pattern');
+    expect(result.error).toMatch(/not a valid regular expression/i);
+  });
+
+  test.each([
+    ['empty string', ''],
+    ['whitespace only', '   '],
+    ['non-string', 42],
+    ['null', null],
+  ])('rejects %s', (_label, value) => {
+    const result = compileUrlPattern(value);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/non-empty string/i);
+  });
+
+  test('rejects a pattern longer than the cap', () => {
+    const result = compileUrlPattern('a'.repeat(MAX_URL_PATTERN_LENGTH + 1));
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/too long/i);
+  });
+
+  test('rejects nested quantifiers that risk catastrophic backtracking', () => {
+    for (const pattern of ['(a+)+$', '(.*)*x', '(ab{2,}){3,}']) {
+      const result = compileUrlPattern(pattern);
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/nested quantifier/i);
+    }
+  });
+
+  test('accepts ordinary alternation and quantifiers', () => {
+    for (const pattern of ['(graphql|api)+', 'https://[^/]+/graphql', 'v\\d+/batch']) {
+      expect(hasNestedQuantifier(pattern)).toBe(false);
+      expect(compileUrlPattern(pattern).ok).toBe(true);
+    }
+  });
+});
+
+describe('validateRange', () => {
+  const range = { min: 100, max: 60000, default: 15000 };
+
+  test('falls back to the default when absent', () => {
+    expect(validateRange('durationMs', undefined, range)).toEqual({ ok: true, value: 15000 });
+    expect(validateRange('durationMs', null, range)).toEqual({ ok: true, value: 15000 });
+  });
+
+  test('accepts an in-range number', () => {
+    expect(validateRange('durationMs', 100, range)).toEqual({ ok: true, value: 100 });
+    expect(validateRange('durationMs', 60000, range)).toEqual({ ok: true, value: 60000 });
+  });
+
+  test.each([['NaN', NaN], ['Infinity', Infinity], ['string', '5000'], ['object', {}]])(
+    'rejects %s as non-finite',
+    (_label, value) => {
+      const result = validateRange('durationMs', value, range);
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/finite number/i);
+    }
+  );
+
+  test('rejects out-of-range instead of clamping', () => {
+    const tooBig = validateRange('durationMs', 600000, range);
+    expect(tooBig.ok).toBe(false);
+    expect(tooBig.error).toBe('durationMs out of range (100..60000)');
+    expect(validateRange('durationMs', 0, range).ok).toBe(false);
+    expect(validateRange('durationMs', -1, range).ok).toBe(false);
+  });
+});
+
+describe('parseCaptureParams', () => {
+  test('applies documented defaults', () => {
+    const result = parseCaptureParams({ userId: 'u1' });
+    expect(result.ok).toBe(true);
+    expect(result.params).toMatchObject({
+      urlPattern: 'graphql',
+      durationMs: 15000,
+      maxCaptures: 100,
+      maxBodyBytes: 1000000,
+      includeHeaders: true,
+    });
+  });
+
+  test('honours the per-route maxBodyBytes default', () => {
+    const result = parseCaptureParams({ userId: 'u1' }, { maxBodyBytesDefault: 200000 });
+    expect(result.params.maxBodyBytes).toBe(200000);
+  });
+
+  test.each([
+    ['durationMs above cap', { durationMs: 120000 }, /durationMs out of range/],
+    ['durationMs below floor', { durationMs: 10 }, /durationMs out of range/],
+    ['maxCaptures above cap', { maxCaptures: 5000 }, /maxCaptures out of range/],
+    ['maxCaptures zero', { maxCaptures: 0 }, /maxCaptures out of range/],
+    ['maxBodyBytes above cap', { maxBodyBytes: 50000000 }, /maxBodyBytes out of range/],
+    ['maxBodyBytes as string', { maxBodyBytes: '1000' }, /finite number/],
+    ['invalid regex', { urlPattern: '[' }, /not a valid regular expression/],
+    ['non-boolean includeHeaders', { includeHeaders: 'yes' }, /must be a boolean/],
+  ])('rejects %s', (_label, body, expected) => {
+    const result = parseCaptureParams({ userId: 'u1', ...body });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(expected);
+  });
+});
+
+describe('parseWheelParams', () => {
+  test('accepts a ref with a vertical delta', () => {
+    const result = parseWheelParams({ ref: 'e22', deltaY: 500 });
+    expect(result.ok).toBe(true);
+    expect(result.params).toEqual({ ref: 'e22', coords: null, deltaX: 0, deltaY: 500 });
+  });
+
+  test('accepts explicit coordinates', () => {
+    const result = parseWheelParams({ x: 100, y: 200, deltaY: -300 });
+    expect(result.params.coords).toEqual({ x: 100, y: 200 });
+  });
+
+  test('rejects when both deltas are zero or absent', () => {
+    expect(parseWheelParams({}).error).toMatch(/at least one must be non-zero/i);
+    expect(parseWheelParams({ deltaX: 0, deltaY: 0 }).error).toMatch(/at least one must be non-zero/i);
+  });
+
+  test.each([
+    ['non-finite deltaY', { deltaY: NaN }, /deltaY must be a finite number/],
+    ['string deltaY', { deltaY: '500' }, /deltaY must be a finite number/],
+    ['delta out of range', { deltaY: 1e9 }, /deltaY out of range/],
+    ['x without y', { x: 10, deltaY: 100 }, /x and y must be provided together/],
+    ['y without x', { y: 10, deltaY: 100 }, /x and y must be provided together/],
+    ['negative coordinate', { x: -1, y: 10, deltaY: 100 }, /x out of range/],
+    ['non-finite coordinate', { x: 10, y: Infinity, deltaY: 100 }, /y must be a finite number/],
+    ['empty ref', { ref: '  ', deltaY: 100 }, /ref must be a non-empty string/],
+    ['non-string ref', { ref: 22, deltaY: 100 }, /ref must be a non-empty string/],
+  ])('rejects %s', (_label, body, expected) => {
+    const result = parseWheelParams(body);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(expected);
+  });
+});

--- a/tests/unit/networkCapture.test.js
+++ b/tests/unit/networkCapture.test.js
@@ -1,0 +1,233 @@
+import { describe, test, expect } from '@jest/globals';
+import {
+  captureResponses,
+  captureRequests,
+  PENDING_BODY_MARKER,
+  BODY_ERROR_PREFIX,
+  TRUNCATED_MARKER,
+} from '../../lib/network-capture.js';
+
+// Minimal stand-in for a Playwright page: only on/off are used by the capture
+// helpers, plus emit/listenerCount so the tests can drive and inspect them.
+function fakePage() {
+  const listeners = new Map();
+  return {
+    on(event, fn) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event).add(fn);
+    },
+    off(event, fn) {
+      listeners.get(event)?.delete(fn);
+    },
+    emit(event, arg) {
+      for (const fn of [...(listeners.get(event) ?? [])]) fn(arg);
+    },
+    listenerCount(event) {
+      return listeners.get(event)?.size ?? 0;
+    },
+  };
+}
+
+function fakeResponse(url, { status = 200, text } = {}) {
+  return { url: () => url, status: () => status, text };
+}
+
+function fakeRequest(url, { method = 'POST', postData = '', headers = {} } = {}) {
+  return { url: () => url, method: () => method, postData: () => postData, headers: () => headers };
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+const baseOpts = {
+  regex: /graphql/i,
+  durationMs: 0,
+  maxBodyBytes: 1000,
+  maxCaptures: 10,
+  drainTimeoutMs: 1000,
+};
+
+describe('captureResponses', () => {
+  test('awaits a body still in flight when the capture window closes', async () => {
+    const page = fakePage();
+    let releaseBody;
+    const body = new Promise((resolve) => { releaseBody = resolve; });
+
+    // The response lands at the very end of the window: the listener is detached
+    // immediately after, while response.text() is still pending.
+    const pending = captureResponses(page, {
+      ...baseOpts,
+      sleep: async () => { page.emit('response', fakeResponse('https://x.test/graphql', { text: () => body })); },
+    });
+
+    await flush();
+    releaseBody('{"data":{"ok":true}}');
+    const result = await pending;
+
+    expect(result.captureCount).toBe(1);
+    expect(result.pendingBodies).toBe(0);
+    expect(result.captures[0]).toMatchObject({
+      url: 'https://x.test/graphql',
+      status: 200,
+      body: '{"data":{"ok":true}}',
+      len: 20,
+    });
+  });
+
+  test('detaches the listener even though it waits for in-flight bodies', async () => {
+    const page = fakePage();
+    let releaseBody;
+    const body = new Promise((resolve) => { releaseBody = resolve; });
+
+    const pending = captureResponses(page, {
+      ...baseOpts,
+      sleep: async () => { page.emit('response', fakeResponse('https://x.test/graphql', { text: () => body })); },
+    });
+
+    await flush();
+    expect(page.listenerCount('response')).toBe(0);
+
+    // A response arriving after the window is ignored, not captured.
+    page.emit('response', fakeResponse('https://x.test/graphql?late=1', { text: async () => 'late' }));
+    releaseBody('ok');
+    const result = await pending;
+    expect(result.captureCount).toBe(1);
+  });
+
+  test('bounds the drain and marks bodies that never arrive', async () => {
+    const page = fakePage();
+    const started = Date.now();
+
+    const result = await captureResponses(page, {
+      ...baseOpts,
+      drainTimeoutMs: 50,
+      sleep: async () => {
+        page.emit('response', fakeResponse('https://x.test/graphql', { text: () => new Promise(() => {}) }));
+      },
+    });
+
+    expect(Date.now() - started).toBeLessThan(2000);
+    expect(result.pendingBodies).toBe(1);
+    expect(result.captures[0].body).toBe(PENDING_BODY_MARKER);
+  });
+
+  test('only captures URLs matching the pattern', async () => {
+    const page = fakePage();
+    const result = await captureResponses(page, {
+      ...baseOpts,
+      sleep: async () => {
+        page.emit('response', fakeResponse('https://x.test/static/app.js', { text: async () => 'js' }));
+        page.emit('response', fakeResponse('https://x.test/GraphQL', { text: async () => 'hit' }));
+      },
+    });
+
+    expect(result.captures.map((c) => c.url)).toEqual(['https://x.test/GraphQL']);
+  });
+
+  test('enforces maxCaptures at arrival time and reports the drops', async () => {
+    const page = fakePage();
+    const result = await captureResponses(page, {
+      ...baseOpts,
+      maxCaptures: 2,
+      sleep: async () => {
+        for (let i = 0; i < 5; i++) {
+          page.emit('response', fakeResponse(`https://x.test/graphql?i=${i}`, { text: async () => `b${i}` }));
+        }
+      },
+    });
+
+    expect(result.captureCount).toBe(2);
+    expect(result.droppedByLimit).toBe(3);
+    expect(result.captures.map((c) => c.body)).toEqual(['b0', 'b1']);
+  });
+
+  test('preserves arrival order when bodies resolve out of order', async () => {
+    const page = fakePage();
+    let releaseFirst;
+    const first = new Promise((resolve) => { releaseFirst = resolve; });
+
+    const pending = captureResponses(page, {
+      ...baseOpts,
+      sleep: async () => {
+        page.emit('response', fakeResponse('https://x.test/graphql/1', { text: () => first }));
+        page.emit('response', fakeResponse('https://x.test/graphql/2', { text: async () => 'second' }));
+      },
+    });
+
+    await flush();
+    releaseFirst('first');
+    const result = await pending;
+    expect(result.captures.map((c) => c.url)).toEqual(['https://x.test/graphql/1', 'https://x.test/graphql/2']);
+    expect(result.captures.map((c) => c.body)).toEqual(['first', 'second']);
+  });
+
+  test('truncates oversized bodies and records a failed read', async () => {
+    const page = fakePage();
+    const result = await captureResponses(page, {
+      ...baseOpts,
+      maxBodyBytes: 8,
+      sleep: async () => {
+        page.emit('response', fakeResponse('https://x.test/graphql/big', { text: async () => 'x'.repeat(50) }));
+        page.emit('response', fakeResponse('https://x.test/graphql/err', {
+          text: async () => { throw new Error('body unavailable'); },
+        }));
+      },
+    });
+
+    expect(result.captures[0].body).toBe('x'.repeat(8) + TRUNCATED_MARKER);
+    expect(result.captures[1].body).toBe(`${BODY_ERROR_PREFIX}body unavailable`);
+    expect(result.pendingBodies).toBe(0);
+  });
+});
+
+describe('captureRequests', () => {
+  test('captures matching requests with body and headers', async () => {
+    const page = fakePage();
+    const result = await captureRequests(page, {
+      ...baseOpts,
+      sleep: async () => {
+        page.emit('request', fakeRequest('https://x.test/graphql', {
+          postData: '{"query":"{me}"}',
+          headers: { authorization: 'Bearer x' },
+        }));
+        page.emit('request', fakeRequest('https://x.test/ping'));
+      },
+    });
+
+    expect(result.captureCount).toBe(1);
+    expect(result.captures[0]).toMatchObject({
+      url: 'https://x.test/graphql',
+      method: 'POST',
+      body: '{"query":"{me}"}',
+      headers: { authorization: 'Bearer x' },
+    });
+    expect(page.listenerCount('request')).toBe(0);
+  });
+
+  test('omits headers when includeHeaders is false', async () => {
+    const page = fakePage();
+    const result = await captureRequests(page, {
+      ...baseOpts,
+      includeHeaders: false,
+      sleep: async () => {
+        page.emit('request', fakeRequest('https://x.test/graphql', { headers: { cookie: 'secret' } }));
+      },
+    });
+
+    expect(result.captures[0].headers).toEqual({});
+  });
+
+  test('enforces maxCaptures and reports the drops', async () => {
+    const page = fakePage();
+    const result = await captureRequests(page, {
+      ...baseOpts,
+      maxCaptures: 1,
+      sleep: async () => {
+        page.emit('request', fakeRequest('https://x.test/graphql?a'));
+        page.emit('request', fakeRequest('https://x.test/graphql?b'));
+      },
+    });
+
+    expect(result.captureCount).toBe(1);
+    expect(result.droppedByLimit).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Four new endpoints that fill gaps in the existing interaction surface, all needed in practice to drive modern anti-automation web apps (e.g. Instagram DMs):

1. `POST /tabs/:tabId/mouse-wheel` — real `page.mouse.wheel()` dispatched at a specific element or coordinate
2. `POST /tabs/:tabId/init-script` — wraps `page.addInitScript()` so a hook runs on every navigation before any page script
3. `POST /tabs/:tabId/capture-network` — wraps `page.on("response")` for a bounded duration, captures matching response bodies at the browser network layer (above the Service Worker, above any in-page closure)
4. `POST /tabs/:tabId/capture-requests` — wraps `page.on("request")` for the symmetric request side, exposing URL + method + POST body + headers (essential when the page bundle hides outgoing payloads behind closure-cached primitives)

Each addresses a distinct interception level. Together they cover the full stack: DOM events → page lifecycle → network (both directions).

---

## 1. `/tabs/:tabId/mouse-wheel`

```
POST /tabs/:tabId/mouse-wheel
{
  "userId": "...",
  "ref": "e22",          // optional: element ref → wheel at bbox centre
  "x": 810, "y": 363,    // optional: explicit page coords (ignored if ref is set)
  "deltaX": 0,
  "deltaY": -1500
}
→ { "ok": true, "x": 810, "y": 363, "deltaX": 0, "deltaY": -1500 }
```

The existing `/scroll` endpoint calls `mouse.wheel()` without prior cursor positioning, so it targets wherever the cursor happens to be — too coarse for nested scrollable containers. Some sites (notably Instagram DMs) virtualise their message lists and ignore both programmatic `scrollTop` and JS-dispatched `WheelEvent`s; only a real wheel at the inner container's coordinates triggers their lazy load.

Three coordinate modes (priority): `ref` > `(x, y)` > viewport centre.

- **Ref handling**: same path as `/click` — `refToLocator`, falls back to `refreshTabRefs` with `pre_wheel` reason, throws `StaleRefsError` if still unresolvable
- **Concurrency**: wrapped in `withTabLock`
- **Settle delays**: 50 ms after move, 300 ms after wheel
- **Plugin event**: emits `tab:mouse-wheel`
- **OpenAPI**: annotated

## 2. `/tabs/:tabId/init-script` (authMiddleware)

```
POST /tabs/:tabId/init-script
{
  "userId": "...",
  "script": "window.__caps = []; const origFetch = window.fetch; window.fetch = ..."
}
→ { "ok": true, "scriptLen": 815 }
```

Wraps `page.addInitScript({ content: script })`. The script is evaluated in the page world before any other script on every navigation in the tab. Useful for hooks that must beat first-byte JS (e.g. install a `fetch` wrapper before the bundle imports it).

- **Auth-gated** (arbitrary JS in the page world)
- 256 KB body limit
- Single-script per call; multiple calls stack

## 3. `/tabs/:tabId/capture-network` (authMiddleware)

```
POST /tabs/:tabId/capture-network
{
  "userId": "...",
  "urlPattern": "graphql",    // optional, default "graphql" (regex, case-insensitive)
  "durationMs": 15000,        // capped at 60000
  "maxBodyBytes": 1000000,    // per capture
  "maxCaptures": 100
}
→ { "ok": true, "captureCount": 35, "captures": [ { "url", "status", "len", "body" }, ... ] }
```

Attaches `page.on("response")` for `durationMs`, then detaches and returns every matching response. Operates at the browser network layer, so it captures:
- Fetches from `window.fetch` references the page bundle cached before any in-page hook had a chance
- Fetches routed through a Service Worker
- XHR fetches that bypass monkey-patched prototypes

In practice this is the only reliable way to observe outgoing API traffic of SPAs that aggressively cache primitives at bundle init time.

- **Auth-gated** (response bodies may contain sensitive data)
- Per-capture and total-count caps prevent unbounded memory use

## 4. `/tabs/:tabId/capture-requests` (authMiddleware)

```
POST /tabs/:tabId/capture-requests
{
  "userId": "...",
  "urlPattern": "graphql",    // optional, default "graphql" (regex, case-insensitive)
  "durationMs": 15000,        // capped at 60000
  "maxBodyBytes": 200000,     // per capture
  "maxCaptures": 100,
  "includeHeaders": true      // optional, default true
}
→ {
    "ok": true,
    "captureCount": 36,
    "captures": [
      { "url", "method", "len", "body", "headers": { ... } },
      ...
    ]
  }
```

Symmetric counterpart to `/capture-network`: `page.on("request")` instead of `page.on("response")`. Returns POST body + headers for each matching request, captured at the browser network layer.

Motivation: `/capture-network` reveals what data the page receives, but is silent on what the page sends. Without the outgoing payload (CSRF tokens, doc IDs, pagination cursors, signed query params), it's impossible to replay or extend a captured GraphQL operation from outside the page. Hook-based approaches (`window.fetch` override, `XMLHttpRequest.prototype.send` override) fail against bundles that cache the original references at module init — verified empirically against Instagram's web client. Only a Playwright-level listener catches every outbound request.

- **Auth-gated** (request bodies / cookies / signed tokens are sensitive)
- `headers` returns the resolved request headers including `cookie`, `x-csrftoken`, `x-fb-lsd`, `x-fb-friendly-name`, etc. Set `includeHeaders: false` to omit them
- Per-capture and total-count caps prevent unbounded memory use
- Mirror code path of `/capture-network` (same handler shape, same lifecycle, same cleanup) for review symmetry

## Verification

All four endpoints exercised on an Instagram DM thread that:
- Virtualises its message list (defeats `/scroll`'s page-level wheel)
- Bundles React with a `fetch` reference captured at module init (defeats any in-page hook on either `window.fetch` or `XMLHttpRequest.prototype`)
- Uses a Service Worker for `/api/graphql` (defeats most network observers)

Results:
- `/mouse-wheel` at the container's centre coords with `deltaY=-1500`: `scrollHeight` grew from 1230 → 5382 in 8 batches (lazy load triggered)
- `/init-script` installed a `fetch` wrapper that captured a manual `fetch("/api/graphql")` call (verified hook installation), but missed all 35 of the page's own GraphQL fetches (confirms the closure-cache problem)
- `/capture-network` for 25 s while navigating to the thread: captured all 35 GraphQL responses (827 KB), including the one carrying the message list
- `/capture-requests` for 15 s while refreshing the thread: captured 36 GraphQL requests with full POST bodies + headers, including one `IGDMessageListOffMsysQuery` with its `doc_id`, `fb_dtsg`, `lsd` and pagination `variables`. The captured body was then used as a template — replacing only the `variables.after` cursor — to drive a full 14-batch pagination loop through the same `/api/graphql` endpoint, yielding 286 unique messages (the complete thread history). With only `/capture-network`, the same extraction would have stopped at the first 20 messages.

Also verified:
- `node --check server.js` passes
- All four endpoints return 400 on missing `userId`
- 404 on unknown `tabId`