### PR TITLE
fix(vnc-watcher): re-attach x11vnc after browser idle shutdown

### DIFF
--- a/plugins/vnc/vnc-watcher.sh
+++ b/plugins/vnc/vnc-watcher.sh
@@ -45,6 +45,11 @@ websockify --web "$NOVNC_DIR" "$VNC_BIND:$NOVNC_PORT" "127.0.0.1:$VNC_PORT" >/va
 log "VNC watcher started -- will attach x11vnc when Camoufox's Xvfb appears"
 
 while true; do
+  if [ -n "$X11VNC_PID" ] && ! kill -0 "$X11VNC_PID" 2>/dev/null; then
+    CURRENT_DISPLAY=""
+    X11VNC_PID=""
+  fi
+
   # Find Xvfb with our patched resolution
   FOUND=$(ps -eo args= 2>/dev/null | awk -v res="$VNC_RESOLUTION" '
     /\/Xvfb :[0-9]+/ && index($0, res) {


### PR DESCRIPTION
### Summary

After the browser idle shutdown (`BROWSER_IDLE_TIMEOUT_MS`, default 5 min) tears down Camoufox's Xvfb, `plugins/vnc/vnc-watcher.sh` never re-attaches `x11vnc` when a new browser launch creates a fresh Xvfb on the same display number. The watcher considers the display "unchanged" and stays idle, so port `5900` is never re-bound. VNC viewers see "connection refused" or a frozen frame until the service is restarted manually.

This patch resets the watcher's internal state when the tracked `x11vnc` PID is gone, so the next display detection triggers a clean re-attach.

### Reproduction

1. Start `camofox-browser` with the VNC plugin enabled.
2. Open at least one tab to spin up Xvfb + x11vnc.
3. Close all sessions and wait `BROWSER_IDLE_TIMEOUT_MS` (default 5 min). The browser shuts down and Xvfb is killed.
4. Open a new tab. Camoufox starts a fresh Xvfb (often on the same display, e.g. `:99`).
5. Observe `ss -tlnp | grep 5900` → port is **not** listening. The watcher loop logs nothing.

### Root cause

In `plugins/vnc/vnc-watcher.sh`, the main loop re-attaches `x11vnc` only when the detected Xvfb display **differs** from `$CURRENT_DISPLAY`:

```sh
if [ -n "$FOUND" ] && [ "$FOUND" != "$CURRENT_DISPLAY" ]; then
  ...
```

When the browser shuts down:
- Xvfb dies → `$FOUND` becomes empty on the next iteration.
- `$X11VNC_PID` is no longer alive but `$CURRENT_DISPLAY` is never cleared.
- When the browser restarts and Xvfb appears again on the same display number, `$FOUND == $CURRENT_DISPLAY`, so the re-attach branch is skipped.

### Fix

Reset `$CURRENT_DISPLAY` and `$X11VNC_PID` at the top of each loop iteration if the previously-tracked `x11vnc` process is no longer alive. The next iteration that finds an Xvfb will then attach normally.

```sh
while true; do
  if [ -n "$X11VNC_PID" ] && ! kill -0 "$X11VNC_PID" 2>/dev/null; then
    CURRENT_DISPLAY=""
    X11VNC_PID=""
  fi

  # ... existing detection logic unchanged
```

### Verification

Tested locally on Kali Linux with `BROWSER_IDLE_TIMEOUT_MS=300000` (default):

1. Service start → Xvfb on `:99`, x11vnc bound to `0.0.0.0:5900` ✅
2. Wait 5 min idle → browser shuts down, Xvfb killed, x11vnc dies ✅ (expected)
3. `POST /tabs` → new Xvfb on `:99`, watcher logs `Attaching x11vnc to DISPLAY=:99`, `x11vnc running` ✅
4. `ss -tlnp | grep 5900` → port listening again ✅
5. VNC viewer reconnects and sees the browser ✅

Without the fix, step 3 silently does nothing and step 4 returns no result.

### Compatibility

- Pure shell (POSIX `sh`), no new dependencies.
- No behaviour change when the browser stays alive — `$X11VNC_PID` remains valid, the new guard is a no-op.
- No impact on the existing display-change handling (the original `$FOUND != $CURRENT_DISPLAY` branch still triggers when Camoufox picks a different display number).
