### PR TITLE
feat: CAMOFOX_USER_DATA_DIR env routes launch to persistent context

### DIFF
--- a/lib/launch-branch.js
+++ b/lib/launch-branch.js
@@ -1,0 +1,17 @@
+// Decides whether the camofox launch should be ephemeral (default
+// firefox.launch) or persistent (firefox.launchPersistentContext against
+// a cloned user profile). Pure function for testability.
+
+export function chooseLaunch(env) {
+  const raw = env.CAMOFOX_USER_DATA_DIR;
+  if (!raw) return 'launch';
+  if (!raw.startsWith('/')) {
+    throw new Error(`CAMOFOX_USER_DATA_DIR must start with /, got: ${raw}`);
+  }
+  if (!raw.startsWith('/tmp/firefox-borrow-')) {
+    throw new Error(
+      `CAMOFOX_USER_DATA_DIR must start with /tmp/firefox-borrow-, got: ${raw}`
+    );
+  }
+  return 'persistent';
+}

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "prepublishOnly": "npm run build",
     "start": "node server.js",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest --runInBand --forceExit",
+    "test:unit": "node --test test/*.test.js",
     "test:e2e": "NODE_OPTIONS='--experimental-vm-modules' jest --runInBand --forceExit tests/e2e",
     "test:plugins": "NODE_OPTIONS='--experimental-vm-modules' jest --forceExit plugins/",
     "test:live": "RUN_LIVE_TESTS=1 NODE_OPTIONS='--experimental-vm-modules' jest --runInBand --forceExit tests/live",

--- a/server.js
+++ b/server.js
@@ -37,6 +37,7 @@ import { createReporter, createTabHealthTracker, collectResourceSnapshot, classi
 import { mountDocs } from './lib/openapi.js';
 import { initSentry, captureException as sentryCaptureException, setupExpressErrorHandler as setupSentryErrorHandler, flush as sentryFlush } from './lib/sentry.js';
 import { prepareExternalCamoufoxExecutable } from './lib/camoufox-executable.js';
+import { chooseLaunch } from './lib/launch-branch.js';
 
 const CONFIG = loadConfig();
 
@@ -105,6 +106,32 @@ function log(level, msg, fields = {}) {
   } else {
     process.stdout.write(line + '\n');
   }
+}
+
+// In persistent mode, firefox.launchPersistentContext returns a
+// BrowserContext (not a Browser). Playwright forbids creating additional
+// contexts on a persistent launch, so newContext() would throw. We use
+// the persistent context itself as the default for any newContext()
+// call — agent code that asks for context isolation gets the same
+// context back, with a one-shot warning logged.
+//
+// Also stub .contexts() to return [self] so downstream iteration works.
+function shimNewContext(browser) {
+  if (typeof browser.newContext !== 'function') {
+    let warned = false;
+    browser.newContext = async () => {
+      if (!warned) {
+        log('warn', 'borrow mode: newContext aliased to default context (Playwright forbids multiple contexts on persistent launch)');
+        warned = true;
+      }
+      return browser;
+    };
+    // BrowserContext has no .contexts(); return [self] so iteration works.
+    if (typeof browser.contexts !== 'function') {
+      browser.contexts = () => [browser];
+    }
+  }
+  return browser;
 }
 
 const app = express();
@@ -982,7 +1009,19 @@ async function launchBrowserInstance() {
       options.proxy = normalizePlaywrightProxy(options.proxy);
       await pluginEvents.emitAsync('browser:launching', { options });
 
-      candidateBrowser = await firefox.launch(options);
+      const launchMode = chooseLaunch(process.env);
+      if (launchMode === 'persistent') {
+        // borrow mode: persistent context against cloned user profile.
+        // Playwright forbids multiple contexts on a persistent launch, so the
+        // returned object behaves as both browser and default context. Downstream
+        // newContext() calls land on shimNewContext() (see shimNewContext above).
+        const userDataDir = process.env.CAMOFOX_USER_DATA_DIR;
+        log('info', 'borrow mode: launching persistent context', { userDataDir });
+        candidateBrowser = await firefox.launchPersistentContext(userDataDir, options);
+      } else {
+        candidateBrowser = await firefox.launch(options);
+      }
+      candidateBrowser = shimNewContext(candidateBrowser);
 
       if (proxyPool?.canRotateSessions) {
         const probe = await probeGoogleSearch(candidateBrowser);

--- a/server.js
+++ b/server.js
@@ -132,6 +132,16 @@ function shimNewContext(browser) {
     if (typeof browser.contexts !== 'function') {
       browser.contexts = () => [browser];
     }
+    // BrowserContext has no .isConnected(); proxy to the underlying browser
+    // via .browser() if available, otherwise assume connected (the context
+    // throws on use if the underlying browser is gone, so true here is a
+    // safe optimistic default).
+    if (typeof browser.isConnected !== 'function') {
+      browser.isConnected = () => {
+        const b = typeof browser.browser === 'function' ? browser.browser() : null;
+        return b ? b.isConnected() : true;
+      };
+    }
   }
   return browser;
 }

--- a/server.js
+++ b/server.js
@@ -114,6 +114,8 @@ function log(level, msg, fields = {}) {
 // the persistent context itself as the default for any newContext()
 // call — agent code that asks for context isolation gets the same
 // context back, with a one-shot warning logged.
+// Arguments passed to newContext (e.g. { viewport, permissions, … })
+// are IGNORED — the default persistent context's settings stand.
 //
 // Also stub .contexts() to return [self] so downstream iteration works.
 function shimNewContext(browser) {
@@ -121,7 +123,7 @@ function shimNewContext(browser) {
     let warned = false;
     browser.newContext = async () => {
       if (!warned) {
-        log('warn', 'borrow mode: newContext aliased to default context (Playwright forbids multiple contexts on persistent launch)');
+        log('warn', 'borrow mode: newContext aliased to default context, options ignored (Playwright forbids multiple contexts on persistent launch)');
         warned = true;
       }
       return browser;

--- a/test/launch-branch.test.js
+++ b/test/launch-branch.test.js
@@ -1,0 +1,40 @@
+// Tests the env-var branch added to server.js's launch block. We don't
+// actually start Camoufox — we exercise the decision function in
+// isolation by importing the helper module added in Step 6.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { chooseLaunch } from '../lib/launch-branch.js';
+
+test('chooseLaunch returns "launch" when env unset', () => {
+  assert.equal(chooseLaunch({}), 'launch');
+});
+
+test('chooseLaunch returns "launch" when env empty string', () => {
+  assert.equal(chooseLaunch({ CAMOFOX_USER_DATA_DIR: '' }), 'launch');
+});
+
+test('chooseLaunch returns "persistent" when env set to a path', () => {
+  assert.equal(
+    chooseLaunch({ CAMOFOX_USER_DATA_DIR: '/tmp/firefox-borrow-abc' }),
+    'persistent'
+  );
+});
+
+test('chooseLaunch rejects paths outside /tmp/firefox-borrow- prefix', () => {
+  assert.throws(
+    () => chooseLaunch({ CAMOFOX_USER_DATA_DIR: '/Users/dave/Library/Application Support/Firefox/Profiles/abc' }),
+    /must start with \/tmp\/firefox-borrow-/
+  );
+  assert.throws(
+    () => chooseLaunch({ CAMOFOX_USER_DATA_DIR: '/tmp/something-else' }),
+    /must start with \/tmp\/firefox-borrow-/
+  );
+});
+
+test('chooseLaunch path must be absolute', () => {
+  assert.throws(
+    () => chooseLaunch({ CAMOFOX_USER_DATA_DIR: 'relative/path' }),
+    /must start with \//
+  );
+});


### PR DESCRIPTION
## Summary

Adds support for a `CAMOFOX_USER_DATA_DIR` env var. When set to a path
matching `/tmp/firefox-borrow-*`, the wrapper switches from
`firefox.launch(options)` to `firefox.launchPersistentContext(userDataDir, options)`.

When unset (default), the wrapper behaves exactly like before — same
`firefox.launch(options)` call, same ephemeral profile. Regression risk
on the default path: zero.

## Motivation

Lets an external orchestrator clone a Firefox profile into a temp dir
and have camofox-browser launch against it, so agents can act on sites
the user is already logged into (cookies, OAuth tokens, etc.) without
the wrapper handling credentials itself. We use this from a hermes-agent
skill on top of an `rsync` clone of the user's daily Firefox profile.

## Changes (3 commits)

1. **feat: env-var branch** (`62332d1`)
   - New `lib/launch-branch.js` with a pure `chooseLaunch(env)` decision
     function. Validates that the env value is absolute and starts with
     the `/tmp/firefox-borrow-` prefix (defense in depth — the consuming
     shell also validates this, but a wrapper-side check protects
     against a maliciously edited plist).
   - `server.js`'s launch block branches on `chooseLaunch(process.env)`.
     The else path is the original `firefox.launch(options)` line
     unchanged.
   - `shimNewContext(browser)` helper aliases `.newContext()` on a
     persistent context to return the context itself (Playwright forbids
     multiple contexts on a persistent launch), with a one-shot warning
     logged. Also stubs `.contexts()` to return `[self]` so downstream
     iteration works.
   - 5 unit tests in `test/launch-branch.test.js` cover the decision
     function (`node --test`; no extra dev deps).

2. **chore: clarify shimNewContext options-ignored semantics** (`0892bbd`)
   - Comment + warning message expanded to say explicitly that arguments
     passed to `newContext({viewport, permissions, …})` are dropped in
     persistent mode. Found while reviewing the shim before merge.

3. **fix: shim browser.isConnected() in persistent mode** (`8ca7001`)
   - `BrowserContext` has no `isConnected()`; the wrapper calls it at
     three sites (session getter, /health route, root route). Without
     the shim the first `/tabs` request 500s with
     `browser.isConnected is not a function` and `/health` perpetually
     reports `browserConnected:false`. Proxies through
     `browser.browser().isConnected()` when available, falls back to
     `true` (the context throws on use if the underlying browser is
     gone — optimistic is safe, the real failure surfaces at next op).
   - Found during end-to-end smoke testing on a real Camoufox instance.

## Test plan

- [x] `node --test test/launch-branch.test.js` — 5/5 pass for the
      branch decision (env unset, empty, valid path, paths outside the
      `/tmp/firefox-borrow-` prefix, relative path).
- [x] Manual smoke against real Camoufox: confirmed
      `firefox.launchPersistentContext` is invoked, agent sees prior
      cookies, env-unset path produces the same launch as before, and
      `/tabs`/`/health` work in both modes.

## Backwards compatibility

Zero regression risk on the default (env-unset) path — the original
`firefox.launch(options)` line runs unchanged.

When `CAMOFOX_USER_DATA_DIR` is set, the wrapper enters a
single-context mode. Agents requesting an isolated `newContext({…})`
get the default context back with a logged warning — sufficient for
single-site agent work, not appropriate for multi-tenant scenarios.
The warning is one-shot per browser instance to avoid log spam.