### PR TITLE
fix: respect existing DISPLAY instead of always spawning Xvfb

### DIFF
--- a/server.js
+++ b/server.js
@@ -946,9 +946,14 @@ async function launchBrowserInstance() {
 
     try {
       if (os.platform() === 'linux') {
-        localVirtualDisplay = pluginCtx.createVirtualDisplay();
-        vdDisplay = localVirtualDisplay.get();
-        log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
+        if (process.env.DISPLAY) {
+          vdDisplay = process.env.DISPLAY;
+          log('info', 'using existing display', { display: vdDisplay, attempt });
+        } else {
+          localVirtualDisplay = pluginCtx.createVirtualDisplay();
+          vdDisplay = localVirtualDisplay.get();
+          log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
+        }
       }
     } catch (err) {
       log('warn', 'xvfb not available, falling back to headless', { error: err.message, attempt });


### PR DESCRIPTION
## Problem

On Linux the server always spawns a new Xvfb virtual display, even when `DISPLAY` is already set (WSLg, X11 forwarding, desktop environments). This forces the browser onto the invisible virtual display instead of the user's real screen.

## Fix

Check `process.env.DISPLAY` before creating Xvfb. If set, reuse it directly. If not set, fall back to Xvfb as before.

No new env vars, no config changes. Fully backward compatible.

## Testing

- Unit tests: 676/676 passing
- With `DISPLAY` set (WSLg): browser launches on real screen, logs `using existing display`
- Without `DISPLAY` (Docker, CI): Xvfb created as before, no behavior change