### PR TITLE
fix(vnc): maximize browser window with a window manager (no more black border)

### DIFF
--- a/plugins/vnc/apt.txt
+++ b/plugins/vnc/apt.txt
@@ -5,3 +5,6 @@ python3-websockify
 # Utilities for display detection
 net-tools
 procps
+# Minimal window manager: maximizes the browser window to fill the Xvfb root
+# (no WM => windows sit at Camoufox's spawn size and leave a black border in VNC)
+matchbox-window-manager

--- a/plugins/vnc/vnc-watcher.sh
+++ b/plugins/vnc/vnc-watcher.sh
@@ -20,6 +20,7 @@ log() { printf '[vnc-watcher] %s\n' "$*" >&2; }
 
 CURRENT_DISPLAY=""
 X11VNC_PID=""
+WM_PID=""
 
 # Prepare password file if requested
 PASSFILE=""
@@ -57,6 +58,8 @@ while true; do
     if [ -n "$X11VNC_PID" ] && kill -0 "$X11VNC_PID" 2>/dev/null; then
       log "Camoufox display changed ($CURRENT_DISPLAY -> $FOUND), restarting x11vnc"
       kill "$X11VNC_PID" 2>/dev/null || true
+      [ -n "$WM_PID" ] && kill "$WM_PID" 2>/dev/null || true
+      WM_PID=""
       sleep 0.5
     fi
 
@@ -76,6 +79,16 @@ while true; do
     sleep 1
     X11VNC_PID=$(pgrep -f "x11vnc.*-display $CURRENT_DISPLAY" | head -1)
     log "x11vnc running (pid=$X11VNC_PID) on DISPLAY=$CURRENT_DISPLAY"
+
+    # Start a minimal window manager on this display so the browser window is
+    # maximized to fill the Xvfb root. Without a WM, Camoufox windows sit at
+    # their spawn size and leave a black border around them in the VNC view.
+    # matchbox auto-maximizes top-level windows; -use_titlebar no = borderless.
+    if command -v matchbox-window-manager >/dev/null 2>&1; then
+      DISPLAY="$CURRENT_DISPLAY" matchbox-window-manager -use_titlebar no -use_cursor no >/var/log/matchbox.log 2>&1 &
+      WM_PID=$!
+      log "window manager started (pid=$WM_PID) on DISPLAY=$CURRENT_DISPLAY"
+    fi
   fi
 
   sleep 2


### PR DESCRIPTION
## Summary

The VNC plugin runs Camoufox on an Xvfb display with **no window manager**, so Firefox windows stay at whatever size Camoufox spawns them (sized for fingerprinting, e.g. `1536×796`) and are never maximized to the display. In noVNC this shows up as the browser in the top-left with a **black border** filling the rest of the Xvfb root.

Raising the page viewport doesn't help — that controls content size, not the OS window's size/placement on the display. The fix is a window manager that maximizes the window.

## What changed

- **`plugins/vnc/apt.txt`** — add `matchbox-window-manager` (tiny, kiosk-style, auto-maximizes top-level windows; pulled in by the existing `install-plugin-deps.sh` only when the VNC plugin is enabled).
- **`plugins/vnc/vnc-watcher.sh`** — start the WM on the detected display alongside `x11vnc` (`-use_titlebar no -use_cursor no` → borderless), track its PID, and restart it when the display changes. Guarded by `command -v`, so it's a no-op if the package isn't present.

16 lines added, no behaviour change when the VNC plugin is disabled.

## Anti-detection note

This does **not** affect fingerprinting: Camoufox spoofs the JS-level `screen`/`window` values independently of the real OS window, so maximizing the OS window only changes what VNC renders, not what the page sees.

## Verification

Built the image with the VNC plugin enabled and opened a tab:

- **Before:** `Navigator` window at `1536×796+0+0` on a `1920×1080` display → black border.
- **After:** matchbox running, `Navigator` window at `1920×1080+0+0` → fills the display, no black border.

## Relationship to #4781

Complementary to #4781 (re-attach `x11vnc` after browser idle shutdown) — different concern, different part of the loop, no overlap. This PR is intentionally scoped to just the window-manager fix and does not include that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
