### PR TITLE
fix: honor BROWSER_IDLE_TIMEOUT_MS=0 as never

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -67,6 +67,7 @@ function camoufoxExecutablePath(env = process.env) {
 
 function loadConfig() {
   const externalCamoufoxExecutable = camoufoxExecutablePath();
+  const browserIdleTimeoutMs = parseInt(process.env.BROWSER_IDLE_TIMEOUT_MS, 10);
   return {
     port: parseInt(process.env.CAMOFOX_PORT || process.env.PORT || '9377', 10),
     nodeEnv: process.env.NODE_ENV || 'development',
@@ -90,7 +91,7 @@ function loadConfig() {
     maxTabsGlobal: parseInt(process.env.MAX_TABS_GLOBAL) || 50,
     navigateTimeoutMs: parseInt(process.env.NAVIGATE_TIMEOUT_MS) || 25000,
     buildrefsTimeoutMs: parseInt(process.env.BUILDREFS_TIMEOUT_MS) || 12000,
-    browserIdleTimeoutMs: parseInt(process.env.BROWSER_IDLE_TIMEOUT_MS) || 300000,
+    browserIdleTimeoutMs: Number.isFinite(browserIdleTimeoutMs) ? browserIdleTimeoutMs : 300000,
     nativeMemRestartThresholdMb: parseInt(process.env.NATIVE_MEM_RESTART_THRESHOLD_MB) || 300,
     browserRssRestartThresholdMb: parseInt(process.env.BROWSER_RSS_RESTART_THRESHOLD_MB) || 1500,
     camoufoxExecutablePath: externalCamoufoxExecutable,

--- a/server.js
+++ b/server.js
@@ -561,7 +561,12 @@ let browserIdleTimer = null;
 let browserLaunchPromise = null;
 let browserWarmRetryTimer = null;
 
+if (BROWSER_IDLE_TIMEOUT_MS <= 0) {
+  log('info', 'browser idle shutdown disabled (BROWSER_IDLE_TIMEOUT_MS=0)');
+}
+
 function scheduleBrowserIdleShutdown() {
+  if (BROWSER_IDLE_TIMEOUT_MS <= 0) return;
   if (browserIdleTimer || sessions.size > 0 || !browser) return;
   browserIdleTimer = setTimeout(async () => {
     browserIdleTimer = null;

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -37,4 +37,15 @@ describe('loadConfig', () => {
     process.env.BROWSER_RSS_RESTART_THRESHOLD_MB = '2048';
     expect(loadConfig().browserRssRestartThresholdMb).toBe(2048);
   });
+
+  test('preserves zero browser idle timeout and falls back for invalid values', () => {
+    delete process.env.BROWSER_IDLE_TIMEOUT_MS;
+    expect(loadConfig().browserIdleTimeoutMs).toBe(300000);
+
+    process.env.BROWSER_IDLE_TIMEOUT_MS = 'not-a-number';
+    expect(loadConfig().browserIdleTimeoutMs).toBe(300000);
+
+    process.env.BROWSER_IDLE_TIMEOUT_MS = '0';
+    expect(loadConfig().browserIdleTimeoutMs).toBe(0);
+  });
 });

--- a/tests/unit/idleShutdown.test.js
+++ b/tests/unit/idleShutdown.test.js
@@ -10,6 +10,7 @@ function createIdleShutdownScheduler({ getSessionsSize, hasBrowser, closeBrowser
   let browserIdleTimer = null;
 
   function scheduleBrowserIdleShutdown(timeoutMs) {
+    if (timeoutMs <= 0) return;
     if (browserIdleTimer || getSessionsSize() > 0 || !hasBrowser()) return;
     browserIdleTimer = setTimeoutFn(async () => {
       browserIdleTimer = null;
@@ -100,6 +101,22 @@ describe('idle browser shutdown scheduler', () => {
     sessionsSize = 0;
     browserAlive = false;
     scheduler.scheduleBrowserIdleShutdown(300_000);
+    expect(scheduler.hasTimer).toBe(false);
+  });
+
+  test('zero timeout disables idle shutdown scheduling', () => {
+    let setTimeoutCalls = 0;
+    const scheduler = createIdleShutdownScheduler({
+      getSessionsSize: () => 0,
+      hasBrowser: () => true,
+      closeBrowser: () => {},
+      setTimeoutFn: () => { setTimeoutCalls++; return setTimeoutCalls; },
+      clearTimeoutFn: () => {},
+    });
+
+    scheduler.scheduleBrowserIdleShutdown(0);
+
+    expect(setTimeoutCalls).toBe(0);
     expect(scheduler.hasTimer).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
`BROWSER_IDLE_TIMEOUT_MS=0` now disables idle browser shutdown, matching the README's documented "0 = never".

## Why this matters
The README documents `BROWSER_IDLE_TIMEOUT_MS=0` as "never" (env-var table), but `lib/config.js` parsed it with `parseInt(...) || 300000`. Because `0` is falsy, an explicit `0` was silently replaced by the 5-minute default, and `scheduleBrowserIdleShutdown()` had no zero guard, so it would still arm a timer even if parsing were fixed.

`lib/config.js` now parses with `Number.isFinite`, preserving `0` while still falling back to `300000` for unset or non-numeric values, and `scheduleBrowserIdleShutdown()` returns early when the timeout is `<= 0` (logging once at startup). The default is unchanged, so existing users see no difference.

## Testing
`npm test` (unit). Added cases asserting `0` is preserved and invalid values fall back to the default, and that the scheduler arms no timer when the timeout is `0`.

Closes #4942

AI was used for assistance.
