### PR TITLE
fix(vnc): honor ENABLE_VNC=1 over config enabled:false

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -112,6 +112,9 @@ function loadConfig() {
       zip: process.env.PROXY_ZIP || '',
       sessionDurationMinutes: parseInt(process.env.PROXY_SESSION_DURATION_MINUTES || '10', 10),
     },
+    pluginEnv: {
+      ENABLE_VNC: process.env.ENABLE_VNC,
+    },
     // Env vars forwarded to the server subprocess
     serverEnv: {
       PATH: process.env.PATH,
@@ -141,6 +144,13 @@ function loadConfig() {
       PROXY_CITY: process.env.PROXY_CITY,
       PROXY_ZIP: process.env.PROXY_ZIP,
       PROXY_SESSION_DURATION_MINUTES: process.env.PROXY_SESSION_DURATION_MINUTES,
+      ENABLE_VNC: process.env.ENABLE_VNC,
+      VNC_RESOLUTION: process.env.VNC_RESOLUTION,
+      VNC_PASSWORD: process.env.VNC_PASSWORD,
+      VIEW_ONLY: process.env.VIEW_ONLY,
+      VNC_PORT: process.env.VNC_PORT,
+      NOVNC_PORT: process.env.NOVNC_PORT,
+      VNC_BIND: process.env.VNC_BIND,
     },
     // Crash reporter (opt-in, reports sent to Cloudflare Worker relay)
     crashReportEnabled:   process.env.CAMOFOX_CRASH_REPORT_ENABLED !== 'false',

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -67,6 +67,25 @@ const ROOT_DIR = path.join(__dirname, '..');
 const PLUGINS_DIR = path.join(ROOT_DIR, 'plugins');
 const CONFIG_PATH = path.join(ROOT_DIR, 'camofox.config.json');
 
+function envFlagEnabled(value) {
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').toLowerCase());
+}
+
+function readPluginMetadata(pluginsDir, name) {
+  try {
+    const raw = fs.readFileSync(path.join(pluginsDir, name, 'plugin.json'), 'utf-8');
+    const metadata = JSON.parse(raw);
+    return metadata && typeof metadata === 'object' ? metadata : {};
+  } catch {
+    return {};
+  }
+}
+
+function pluginEnabledByEnv(metadata, env) {
+  const { enableEnvVar } = metadata;
+  return typeof enableEnvVar === 'string' && enableEnvVar.length > 0 && envFlagEnabled(env[enableEnvVar]);
+}
+
 /**
  * Read plugin configuration from camofox.config.json.
  * Supports two formats:
@@ -74,10 +93,10 @@ const CONFIG_PATH = path.join(ROOT_DIR, 'camofox.config.json');
  *   - Object with per-plugin config: { "youtube": { "enabled": true }, "persistence": { "enabled": true, "profileDir": "/data" } }
  * Returns { list: string[] | null, configs: Map<string, object> }
  */
-function readPluginConfig() {
+function readPluginConfig(configPath = CONFIG_PATH) {
   const configs = new Map();
   try {
-    const raw = fs.readFileSync(CONFIG_PATH, 'utf-8');
+    const raw = fs.readFileSync(configPath, 'utf-8');
     const config = JSON.parse(raw);
     if (!config.plugins) return { list: null, configs };
     if (Array.isArray(config.plugins)) {
@@ -86,9 +105,10 @@ function readPluginConfig() {
     if (typeof config.plugins === 'object') {
       const list = [];
       for (const [name, pluginConf] of Object.entries(config.plugins)) {
-        if (pluginConf === false || (typeof pluginConf === 'object' && pluginConf.enabled === false)) continue;
+        const isObjectConfig = pluginConf && typeof pluginConf === 'object';
+        if (isObjectConfig) configs.set(name, pluginConf);
+        if (pluginConf === false || (isObjectConfig && pluginConf.enabled === false)) continue;
         list.push(name);
-        if (typeof pluginConf === 'object') configs.set(name, pluginConf);
       }
       return { list, configs };
     }
@@ -124,16 +144,19 @@ export function createPluginEvents() {
  *                       Mutable -- plugins can replace ctx.createVirtualDisplay etc.
  * @returns {string[]} - Names of loaded plugins
  */
-export async function loadPlugins(app, ctx) {
+export async function loadPlugins(app, ctx, options = {}) {
   const loaded = [];
+  const pluginsDir = options.pluginsDir || PLUGINS_DIR;
+  const configPath = options.configPath || CONFIG_PATH;
+  const env = options.env || ctx.config?.pluginEnv || {};
 
-  if (!fs.existsSync(PLUGINS_DIR)) {
+  if (!fs.existsSync(pluginsDir)) {
     ctx.log('info', 'no plugins directory found, skipping plugin load');
     return loaded;
   }
 
-  const { list: allowList, configs: pluginConfigs } = readPluginConfig();
-  const entries = fs.readdirSync(PLUGINS_DIR, { withFileTypes: true });
+  const { list: allowList, configs: pluginConfigs } = readPluginConfig(configPath);
+  const entries = fs.readdirSync(pluginsDir, { withFileTypes: true });
 
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
@@ -144,11 +167,16 @@ export async function loadPlugins(app, ctx) {
 
     // If camofox.config.json specifies a plugins list, only load those
     if (allowList && !allowList.includes(name)) {
-      ctx.log('debug', `plugin "${name}" not in camofox.config.json plugins list, skipping`);
-      continue;
+      const metadata = readPluginMetadata(pluginsDir, name);
+      if (pluginEnabledByEnv(metadata, env)) {
+        ctx.log('info', 'plugin enabled by environment', { plugin: name, envVar: metadata.enableEnvVar });
+      } else {
+        ctx.log('debug', `plugin "${name}" not in camofox.config.json plugins list, skipping`);
+        continue;
+      }
     }
 
-    const indexPath = path.join(PLUGINS_DIR, name, 'index.js');
+    const indexPath = path.join(pluginsDir, name, 'index.js');
     if (!fs.existsSync(indexPath)) {
       ctx.log('warn', `plugin "${name}" has no index.js, skipping`);
       continue;

--- a/plugins/vnc/plugin.json
+++ b/plugins/vnc/plugin.json
@@ -1,0 +1,3 @@
+{
+  "enableEnvVar": "ENABLE_VNC"
+}

--- a/plugins/vnc/vnc-launcher.js
+++ b/plugins/vnc/vnc-launcher.js
@@ -9,24 +9,49 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+function envFlagEnabled(value) {
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').toLowerCase());
+}
+
+function compactEnv(env) {
+  return Object.fromEntries(
+    Object.entries(env)
+      .filter(([, value]) => value !== undefined && value !== null)
+      .map(([key, value]) => [key, String(value)])
+  );
+}
+
 /**
  * Resolve VNC configuration from pluginConfig + env var fallbacks.
  * All process.env reads live here -- callers get a plain config object.
  */
-export function resolveVncConfig(pluginConfig = {}) {
-  const enabled = process.env.ENABLE_VNC === '1' || pluginConfig.enabled === true;
+export function resolveVncConfig(pluginConfig = {}, env = process.env) {
+  const enabled = envFlagEnabled(env.ENABLE_VNC) || pluginConfig.enabled === true;
 
-  const rawResolution = process.env.VNC_RESOLUTION || pluginConfig.resolution || '1920x1080';
+  const rawResolution = env.VNC_RESOLUTION || pluginConfig.resolution || '1920x1080';
   const resolution = rawResolution.includes('x', rawResolution.indexOf('x') + 1)
     ? rawResolution
     : `${rawResolution}x24`;
 
-  const vncPassword = process.env.VNC_PASSWORD || pluginConfig.password || '';
-  const viewOnly = process.env.VIEW_ONLY === '1' || pluginConfig.viewOnly === true;
-  const vncPort = process.env.VNC_PORT || pluginConfig.vncPort || '5900';
-  const novncPort = process.env.NOVNC_PORT || pluginConfig.novncPort || '6080';
+  const vncPassword = env.VNC_PASSWORD || pluginConfig.password || '';
+  const viewOnly = envFlagEnabled(env.VIEW_ONLY) || pluginConfig.viewOnly === true;
+  const vncPort = env.VNC_PORT || pluginConfig.vncPort || '5900';
+  const novncPort = env.NOVNC_PORT || pluginConfig.novncPort || '6080';
 
   return { enabled, resolution, vncPassword, viewOnly, vncPort, novncPort };
+}
+
+export function buildWatcherEnv({ resolution, vncPassword, viewOnly, vncPort, novncPort }, env = process.env) {
+  return compactEnv({
+    PATH: env.PATH,
+    HOME: env.HOME,
+    VNC_BIND: env.VNC_BIND,
+    VNC_PASSWORD: vncPassword,
+    VNC_RESOLUTION: resolution,
+    VIEW_ONLY: viewOnly ? '1' : '0',
+    VNC_PORT: vncPort,
+    NOVNC_PORT: novncPort,
+  });
 }
 
 /**
@@ -36,14 +61,7 @@ export function resolveVncConfig(pluginConfig = {}) {
 export function startWatcher({ resolution, vncPassword, viewOnly, vncPort, novncPort, log, events }) {
   const watcherPath = path.join(__dirname, 'vnc-watcher.sh');
   const watcher = spawn('sh', [watcherPath], {
-    env: {
-      ...process.env,
-      VNC_PASSWORD: vncPassword,
-      VNC_RESOLUTION: resolution,
-      VIEW_ONLY: viewOnly ? '1' : '0',
-      VNC_PORT: String(vncPort),
-      NOVNC_PORT: String(novncPort),
-    },
+    env: buildWatcherEnv({ resolution, vncPassword, viewOnly, vncPort, novncPort }),
     stdio: ['ignore', 'inherit', 'inherit'],
     detached: false,
   });

--- a/plugins/vnc/vnc-launcher.test.js
+++ b/plugins/vnc/vnc-launcher.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, test } from '@jest/globals';
+import { buildWatcherEnv, resolveVncConfig } from './vnc-launcher.js';
+
+describe('vnc launcher config', () => {
+  test('ENABLE_VNC enables the plugin over disabled config', () => {
+    const config = resolveVncConfig(
+      { enabled: false, resolution: '1280x720' },
+      { ENABLE_VNC: '1' }
+    );
+
+    expect(config.enabled).toBe(true);
+    expect(config.resolution).toBe('1280x720x24');
+  });
+
+  test('buildWatcherEnv only includes watcher env whitelist', () => {
+    const env = buildWatcherEnv(
+      {
+        resolution: '1920x1080x24',
+        vncPassword: 'secret',
+        viewOnly: true,
+        vncPort: 5901,
+        novncPort: 6081,
+      },
+      {
+        PATH: '/usr/bin',
+        HOME: '/home/camofox',
+        VNC_BIND: '0.0.0.0',
+        SECRET_TOKEN: 'do-not-forward',
+      }
+    );
+
+    expect(env).toEqual({
+      PATH: '/usr/bin',
+      HOME: '/home/camofox',
+      VNC_BIND: '0.0.0.0',
+      VNC_PASSWORD: 'secret',
+      VNC_RESOLUTION: '1920x1080x24',
+      VIEW_ONLY: '1',
+      VNC_PORT: '5901',
+      NOVNC_PORT: '6081',
+    });
+  });
+});

--- a/scripts/install-plugin-deps.sh
+++ b/scripts/install-plugin-deps.sh
@@ -15,10 +15,7 @@ if [ -f "$CONFIG" ] && command -v node >/dev/null 2>&1; then
     if (Array.isArray(c.plugins)) {
       console.log(c.plugins.join(' '));
     } else if (c.plugins && typeof c.plugins === 'object') {
-      console.log(Object.entries(c.plugins)
-        .filter(([, v]) => v && v.enabled !== false)
-        .map(([k]) => k)
-        .join(' '));
+      console.log(Object.keys(c.plugins).join(' '));
     }
   " 2>/dev/null || echo "")
 fi

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -37,4 +37,27 @@ describe('loadConfig', () => {
     process.env.BROWSER_RSS_RESTART_THRESHOLD_MB = '2048';
     expect(loadConfig().browserRssRestartThresholdMb).toBe(2048);
   });
+
+  test('forwards VNC env vars to server subprocess whitelist', () => {
+    process.env.ENABLE_VNC = '1';
+    process.env.VNC_RESOLUTION = '1280x720';
+    process.env.VNC_PASSWORD = 'secret';
+    process.env.VIEW_ONLY = '1';
+    process.env.VNC_PORT = '5901';
+    process.env.NOVNC_PORT = '6081';
+    process.env.VNC_BIND = '0.0.0.0';
+
+    const config = loadConfig();
+
+    expect(config.pluginEnv).toEqual({ ENABLE_VNC: '1' });
+    expect(config.serverEnv).toMatchObject({
+      ENABLE_VNC: '1',
+      VNC_RESOLUTION: '1280x720',
+      VNC_PASSWORD: 'secret',
+      VIEW_ONLY: '1',
+      VNC_PORT: '5901',
+      NOVNC_PORT: '6081',
+      VNC_BIND: '0.0.0.0',
+    });
+  });
 });

--- a/tests/unit/plugins.test.js
+++ b/tests/unit/plugins.test.js
@@ -97,6 +97,90 @@ describe('lib/plugins', () => {
       };
     }
 
+    function makePlugin(pluginsDir, name, source, metadata = null) {
+      const pluginDir = path.join(pluginsDir, name);
+      fs.mkdirSync(pluginDir, { recursive: true });
+      fs.writeFileSync(path.join(pluginDir, 'index.js'), source);
+      if (metadata) {
+        fs.writeFileSync(path.join(pluginDir, 'plugin.json'), JSON.stringify(metadata));
+      }
+    }
+
+    test('loads config-disabled plugin when its enable env var is set', async () => {
+      const pluginsDir = path.join(tmpDir, 'plugins');
+      const configPath = path.join(tmpDir, 'camofox.config.json');
+      fs.mkdirSync(pluginsDir);
+      makePlugin(
+        pluginsDir,
+        'env-enabled',
+        'export async function register(app, _ctx, pluginConfig) { app.loaded.push(pluginConfig); }\n',
+        { enableEnvVar: 'ENABLE_TEST_PLUGIN' }
+      );
+      makePlugin(
+        pluginsDir,
+        'disabled',
+        'export async function register(app) { app.loaded.push("disabled"); }\n'
+      );
+      fs.writeFileSync(configPath, JSON.stringify({
+        plugins: {
+          'env-enabled': { enabled: false, resolution: '1280x720' },
+          disabled: { enabled: false },
+        },
+      }));
+
+      const ctx = makeMockCtx();
+      const app = { loaded: [] };
+      await loadPlugins(app, ctx, {
+        pluginsDir,
+        configPath,
+        env: { ENABLE_TEST_PLUGIN: '1' },
+      });
+
+      // Assert the load/skip decision, which is the unit under test: the
+      // env-override gate runs (and logs) before the plugin's index.js is
+      // imported. We do not assert on the registration itself because jest's
+      // experimental VM modules cannot dynamic-import an ESM file from the
+      // temp dir, which would make the test flaky for reasons unrelated to
+      // the gate. The "plugin enabled by environment" log fires only when the
+      // gate decides to load a config-disabled plugin from its env var.
+      expect(ctx.log).toHaveBeenCalledWith('info', 'plugin enabled by environment', {
+        plugin: 'env-enabled',
+        envVar: 'ENABLE_TEST_PLUGIN',
+      });
+      // The sibling plugin has no enable env var, so it stays skipped.
+      expect(ctx.log).toHaveBeenCalledWith(
+        'debug',
+        'plugin "disabled" not in camofox.config.json plugins list, skipping'
+      );
+    });
+
+    test('skips config-disabled plugin when its enable env var is not set', async () => {
+      const pluginsDir = path.join(tmpDir, 'plugins');
+      const configPath = path.join(tmpDir, 'camofox.config.json');
+      fs.mkdirSync(pluginsDir);
+      makePlugin(
+        pluginsDir,
+        'env-enabled',
+        'export async function register(app) { app.loaded.push("env-enabled"); }\n',
+        { enableEnvVar: 'ENABLE_TEST_PLUGIN' }
+      );
+      fs.writeFileSync(configPath, JSON.stringify({
+        plugins: {
+          'env-enabled': { enabled: false },
+        },
+      }));
+
+      const app = { loaded: [] };
+      const loaded = await loadPlugins(app, makeMockCtx(), {
+        pluginsDir,
+        configPath,
+        env: {},
+      });
+
+      expect(loaded).toEqual([]);
+      expect(app.loaded).toEqual([]);
+    });
+
     test('returns empty array when plugins directory does not exist', async () => {
       // loadPlugins checks the hardcoded PLUGINS_DIR, not tmpDir.
       // We test by providing a mock ctx -- if no plugins/ dir exists


### PR DESCRIPTION
## Summary
`ENABLE_VNC=1` again enables VNC at runtime even when `camofox.config.json` sets `plugins.vnc.enabled=false`, restoring the documented Docker workflow.

## Why this matters
> The custom config workaround alone isn't enough as it enables the plugin but the v1.11 image is still missing the VNC system dependencies since `install-plugin-deps.sh` skips disabled plugins — @lucagiacometti19 (#4314)

VNC worked in 1.10 via `-e ENABLE_VNC=1`, and `plugins/vnc/README.md` states environment takes precedence. In 1.11, shipping `plugins.vnc.enabled=false` in the default config broke that at two layers:

- `lib/plugins.js` skipped any plugin not in the config's plugin list before its `ENABLE_VNC` override could run.
- `scripts/install-plugin-deps.sh` filtered out `enabled:false` plugins, so the Docker image shipped without noVNC/websockify (`/usr/share/novnc not found`).

A plugin can now declare an enable env var in its `plugin.json` (`plugins/vnc/plugin.json` -> `{"enableEnvVar": "ENABLE_VNC"}`); the loader honors it for config-disabled plugins. Dependency installation no longer filters on enabled state, so an env-enablable plugin keeps its system deps baked into the image. `vnc-launcher` also now passes an explicit watcher env whitelist instead of spreading `process.env`, per CONTRIBUTING.md. Default behavior (VNC off when neither config nor env enables it) is unchanged.

## Testing
`npm test` (unit). Added coverage for the loader's env-override decision, the VNC env whitelist forwarded to the server subprocess, and `resolveVncConfig` / `buildWatcherEnv`.

Closes #4933, closes #4314

AI was used for assistance.
