### PR TITLE
fix: whitelist child env in postinstall instead of spreading process.env

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -31,6 +31,65 @@ const EXTERNAL_EXECUTABLE_ENV_VARS = [
   'CAMOFOX_EXECUTABLE_PATH',
 ];
 
+const FETCH_CHILD_ENV_VARS = [
+  'PATH',
+  'Path',
+  'HOME',
+  'USERPROFILE',
+  'APPDATA',
+  'LOCALAPPDATA',
+  'XDG_CACHE_HOME',
+  'TMPDIR',
+  'TEMP',
+  'TMP',
+  'SystemRoot',
+  'WINDIR',
+  'ComSpec',
+  'PATHEXT',
+  'CI',
+  'NODE_EXTRA_CA_CERTS',
+  'SSL_CERT_FILE',
+  'SSL_CERT_DIR',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'ALL_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'no_proxy',
+  'all_proxy',
+  'npm_config_proxy',
+  'npm_config_https_proxy',
+  'npm_config_http_proxy',
+  'npm_config_noproxy',
+  'npm_config_no_proxy',
+  'npm_config_registry',
+  'npm_config_cache',
+  'npm_config_fetch_retries',
+  'npm_config_fetch_retry_factor',
+  'npm_config_fetch_retry_mintimeout',
+  'npm_config_fetch_retry_maxtimeout',
+  'npm_config_fetch_timeout',
+  'NPM_CONFIG_PROXY',
+  'NPM_CONFIG_HTTPS_PROXY',
+  'NPM_CONFIG_HTTP_PROXY',
+  'NPM_CONFIG_NOPROXY',
+  'NPM_CONFIG_NO_PROXY',
+  'NPM_CONFIG_REGISTRY',
+  'NPM_CONFIG_CACHE',
+  'NPM_CONFIG_FETCH_RETRIES',
+  'NPM_CONFIG_FETCH_RETRY_FACTOR',
+  'NPM_CONFIG_FETCH_RETRY_MINTIMEOUT',
+  'NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT',
+  'NPM_CONFIG_FETCH_TIMEOUT',
+  'CAMOFOX_SKIP_DOWNLOAD',
+  'CAMOUFOX_EXECUTABLE',
+  'CAMOUFOX_EXECUTABLE_PATH',
+  'CAMOFOX_EXECUTABLE_PATH',
+  'CAMOUFOX_CACHE_DIR',
+  'GITHUB_TOKEN',
+];
+
 function camoufoxCacheDir() {
   const home = homedir();
   const plat = platform();
@@ -61,6 +120,14 @@ export function externalExecutableFromEnv(env = process.env) {
     if (value) return { name, value };
   }
   return null;
+}
+
+export function childEnvForFetch(env = process.env) {
+  const childEnv = {};
+  for (const name of FETCH_CHILD_ENV_VARS) {
+    if (env[name] !== undefined) childEnv[name] = env[name];
+  }
+  return childEnv;
 }
 
 function assertExternalExecutable(path) {
@@ -104,13 +171,10 @@ export async function main() {
   // names like spawn/spawnSync/exec/execSync in the same file as "child_process".
   const { spawnSync: run } = await import('node:child_process');
 
-  const childEnv = { ...process.env };
-  delete childEnv.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD;
-
   const isWindows = platform() === 'win32';
   const result = run(isWindows ? 'npx.cmd' : 'npx', ['camoufox-js', 'fetch'], {
     stdio: 'inherit',
-    env: childEnv,
+    env: childEnvForFetch(),
     shell: isWindows,
   });
 

--- a/scripts/postinstall.test.js
+++ b/scripts/postinstall.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from 'os';
 import { spawnSync } from 'child_process';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { externalExecutableFromEnv } from './postinstall.js';
+import { childEnvForFetch, externalExecutableFromEnv } from './postinstall.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const tempDirs = [];
@@ -17,6 +17,28 @@ function makeExecutable() {
   writeFileSync(executable, '#!/bin/sh\nexit 0\n');
   chmodSync(executable, 0o755);
   return executable;
+}
+
+function postinstallTestEnv(overrides = {}) {
+  const env = {};
+  for (const name of [
+    'PATH',
+    'Path',
+    'HOME',
+    'USERPROFILE',
+    'APPDATA',
+    'LOCALAPPDATA',
+    'TMPDIR',
+    'TEMP',
+    'TMP',
+    'SystemRoot',
+    'WINDIR',
+    'ComSpec',
+    'PATHEXT',
+  ]) {
+    if (process.env[name] !== undefined) env[name] = process.env[name];
+  }
+  return { ...env, ...overrides };
 }
 
 afterEach(() => {
@@ -39,15 +61,54 @@ describe('postinstall external executable handling', () => {
     const result = spawnSync(process.execPath, ['scripts/postinstall.js'], {
       cwd: join(__dirname, '..'),
       encoding: 'utf8',
-      env: {
-        ...process.env,
+      env: postinstallTestEnv({
         CAMOUFOX_EXECUTABLE: executable,
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1',
-      },
+      }),
     });
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('skipping bundled Camoufox download');
     expect(result.stderr).toBe('');
+  });
+});
+
+describe('postinstall fetch child env', () => {
+  test('passes an explicit whitelist to the downloader child', () => {
+    const childEnv = childEnvForFetch({
+      PATH: '/bin',
+      HOME: '/home/agent',
+      XDG_CACHE_HOME: '/home/agent/.cache',
+      LOCALAPPDATA: 'C:\\Users\\agent\\AppData\\Local',
+      HTTPS_PROXY: 'http://proxy.example:8080',
+      npm_config_https_proxy: 'http://npm-proxy.example:8080',
+      NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org/',
+      CAMOFOX_SKIP_DOWNLOAD: '0',
+      CAMOUFOX_EXECUTABLE: '/opt/camoufox/camoufox-bin',
+      CAMOUFOX_EXECUTABLE_PATH: '/compat/camoufox-bin',
+      CAMOFOX_EXECUTABLE_PATH: '/legacy/camoufox-bin',
+      CAMOUFOX_CACHE_DIR: '/opt/camoufox-cache',
+      GITHUB_TOKEN: 'github-token',
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1',
+      AWS_ACCESS_KEY_ID: 'should-not-leak',
+      SOME_RANDOM_SECRET: 'should-not-leak',
+      npm_config__authToken: 'should-not-leak',
+    });
+
+    expect(childEnv).toEqual({
+      PATH: '/bin',
+      HOME: '/home/agent',
+      LOCALAPPDATA: 'C:\\Users\\agent\\AppData\\Local',
+      XDG_CACHE_HOME: '/home/agent/.cache',
+      HTTPS_PROXY: 'http://proxy.example:8080',
+      npm_config_https_proxy: 'http://npm-proxy.example:8080',
+      NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org/',
+      CAMOFOX_SKIP_DOWNLOAD: '0',
+      CAMOUFOX_EXECUTABLE: '/opt/camoufox/camoufox-bin',
+      CAMOUFOX_EXECUTABLE_PATH: '/compat/camoufox-bin',
+      CAMOFOX_EXECUTABLE_PATH: '/legacy/camoufox-bin',
+      CAMOUFOX_CACHE_DIR: '/opt/camoufox-cache',
+      GITHUB_TOKEN: 'github-token',
+    });
   });
 });


### PR DESCRIPTION
## Summary
`postinstall.js` now passes an explicit env whitelist to the `npx camoufox-js fetch` child instead of spreading the full host environment, which unblocks `openclaw plugins install @askjo/camofox-browser` on v1.11.2.

## Why this matters
CONTRIBUTING.md states as a hard rule: "Do not pass the host environment to child processes ... Never use `...process.env`." `postinstall.js` did exactly that (`const childEnv = { ...process.env }`) when spawning the binary downloader. That environment-access-combined-with-network-send pattern is what OpenClaw's plugin scanner flags as possible credential harvesting, which blocks installation:

> Plugin "camofox-browser" installation blocked: dangerous code patterns detected: Environment variable access combined with network send — possible credential harvesting (#4958)

The child now receives only the variables the downloader needs: PATH/HOME and cross-platform equivalents, proxy and npm-config vars, TLS cert vars, `GITHUB_TOKEN` (the downloader recommends it for release rate limits), and the `CAMOFOX_*`/`CAMOUFOX_*` controls. The `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` defense is preserved by leaving it out of the whitelist. This closes a real host-env leak and clears the scanner block as a result; the added test asserts an `AWS_ACCESS_KEY_ID`-style secret does not reach the child.

`plugins/persistence/index.js` is also flagged by the scanner, but it only reads `CAMOFOX_PROFILE_DIR` (a path) and performs no network send — that reads as a heuristic false positive and is left for maintainer judgment rather than worked around here.

## Testing
`npm test` (postinstall). Added a case asserting the child env is the explicit whitelist: needed vars pass through, arbitrary host secrets do not.

Closes #4958

AI was used for assistance.
