### PR TITLE
fix: add CAMOFOX_DISABLE_DEFAULT_ADDONS knob to exclude default UBO addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ Reddit macros return JSON directly (no HTML parsing needed):
 | `CAMOUFOX_EXECUTABLE` | External Camoufox executable to use instead of downloading/launching the bundled cache. Must point to a Camoufox bundle with sibling resources. | - |
 | `CAMOUFOX_EXECUTABLE_PATH` | Compatibility alias for `CAMOUFOX_EXECUTABLE` | - |
 | `CAMOFOX_EXECUTABLE_PATH` | Compatibility alias for `CAMOUFOX_EXECUTABLE` | - |
+| `CAMOFOX_DISABLE_DEFAULT_ADDONS` | Set to `1`/`true` to skip downloading and launching the default uBlock Origin (UBO) addon. Useful for deployments where the addons.mozilla.org download is unreliable or unwanted (a failed download otherwise leaves a broken addon cache that blocks startup). | `0` |
 | `CAMOFOX_COOKIES_DIR` | Directory for cookie files | `~/.camofox/cookies` |
 | `CAMOFOX_PROFILE_DIR` | Directory for persisted session profiles | `~/.camofox/profiles` |
 | `CAMOFOX_TRACES_DIR` | Directory for session trace zips | `~/.camofox/traces` |

--- a/lib/config.js
+++ b/lib/config.js
@@ -97,6 +97,7 @@ function loadConfig() {
     camoufoxExecutablePath: externalCamoufoxExecutable,
     camoufoxCacheDir: camoufoxCacheDir(),
     prometheusEnabled: process.env.PROMETHEUS_ENABLED === '1' || process.env.PROMETHEUS_ENABLED === 'true',
+    disableDefaultAddons: process.env.CAMOFOX_DISABLE_DEFAULT_ADDONS === '1' || process.env.CAMOFOX_DISABLE_DEFAULT_ADDONS === 'true',
     proxy: {
       strategy: inferProxyStrategy(process.env.PROXY_STRATEGY || ''),
       providerName: process.env.PROXY_PROVIDER || 'decodo',
@@ -128,6 +129,7 @@ function loadConfig() {
       CAMOFOX_TRACES_DIR: process.env.CAMOFOX_TRACES_DIR,
       CAMOFOX_TRACES_MAX_BYTES: process.env.CAMOFOX_TRACES_MAX_BYTES,
       CAMOFOX_TRACES_TTL_HOURS: process.env.CAMOFOX_TRACES_TTL_HOURS,
+      CAMOFOX_DISABLE_DEFAULT_ADDONS: process.env.CAMOFOX_DISABLE_DEFAULT_ADDONS,
       CAMOUFOX_EXECUTABLE: process.env.CAMOUFOX_EXECUTABLE,
       CAMOUFOX_EXECUTABLE_PATH: process.env.CAMOUFOX_EXECUTABLE_PATH,
       CAMOFOX_EXECUTABLE_PATH: process.env.CAMOFOX_EXECUTABLE_PATH,

--- a/server.js
+++ b/server.js
@@ -974,6 +974,11 @@ async function launchBrowserInstance() {
     });
 
     try {
+      if (CONFIG.disableDefaultAddons) {
+        log('info', 'excluding default UBO addon from launch', {
+          excludeAddons: ['UBO'],
+        });
+      }
       const options = await launchOptions({
         executable_path: externalCamoufox?.executablePath,
         headless: useVirtualDisplay ? false : true,
@@ -983,6 +988,7 @@ async function launchBrowserInstance() {
         proxy: launchProxy,
         geoip: !!launchProxy,
         virtual_display: vdDisplay,
+        exclude_addons: CONFIG.disableDefaultAddons ? ['UBO'] : undefined,
       });
       options.proxy = normalizePlaywrightProxy(options.proxy);
       await pluginEvents.emitAsync('browser:launching', { options });

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -49,6 +49,22 @@ describe('loadConfig', () => {
     expect(loadConfig().browserIdleTimeoutMs).toBe(0);
   });
 
+  test('disables default addons when CAMOFOX_DISABLE_DEFAULT_ADDONS is set', () => {
+    delete process.env.CAMOFOX_DISABLE_DEFAULT_ADDONS;
+    expect(loadConfig().disableDefaultAddons).toBe(false);
+
+    process.env.CAMOFOX_DISABLE_DEFAULT_ADDONS = '0';
+    expect(loadConfig().disableDefaultAddons).toBe(false);
+
+    process.env.CAMOFOX_DISABLE_DEFAULT_ADDONS = '1';
+    expect(loadConfig().disableDefaultAddons).toBe(true);
+
+    process.env.CAMOFOX_DISABLE_DEFAULT_ADDONS = 'true';
+    const config = loadConfig();
+    expect(config.disableDefaultAddons).toBe(true);
+    expect(config.serverEnv.CAMOFOX_DISABLE_DEFAULT_ADDONS).toBe('true');
+  });
+
   test('forwards VNC env vars to server subprocess whitelist', () => {
     process.env.ENABLE_VNC = '1';
     process.env.VNC_RESOLUTION = '1280x720';


### PR DESCRIPTION
## Summary

Adds a server-side `CAMOFOX_DISABLE_DEFAULT_ADDONS` env knob (`1`/`true`) that passes `exclude_addons: ['UBO']` into the existing `launchOptions()` call, so camoufox-js skips the default uBlock Origin addon download/extract entirely.

- `lib/config.js`: new `disableDefaultAddons` boolean (mirrors the `prometheusEnabled` env pattern) and forwards `CAMOFOX_DISABLE_DEFAULT_ADDONS` through the server-subprocess env whitelist.
- `server.js`: conditionally passes `exclude_addons: ['UBO']` to `launchOptions()` when the flag is set (undefined otherwise), plus a one-line info log.
- `tests/unit/config.test.js`: parsing test for set/unset/`0`/`true` plus serverEnv forwarding.
- `README.md`: documents the new env var.

## Why this matters

Issue #5067 reports that when the default UBO download from addons.mozilla.org fails, camoufox-js leaves a broken addon directory behind. On the next launch, `confirmPaths()` throws `manifest.json is missing...`, permanently wedging startup (`/health` reports `browserConnected: false`) until the user manually deletes the cache dir. The reporter explicitly asks for "a supported server-side option to disable default addons, or at least the default UBO addon" for deployments where the AMO download is unreliable or unwanted.

Setting `exclude_addons: ['UBO']` means the UBO download/extract is never attempted, so the broken-cache path can't be hit. The upstream cache-healing fix lives in the `camoufox-js` package; this PR provides the requested opt-out, which is fully in-scope here.

Default behavior is unchanged: with the flag unset, no `exclude_addons` key is passed and UBO is requested exactly as before.

## Testing

- `npx jest tests/unit/config.test.js` — 6 passed (including the new parsing + serverEnv-forwarding case).
- `node --check server.js` / `node --check lib/config.js` — syntax clean.
- `npm run build` — passes.

Fixes #5067

AI was used for assistance.
