### PR TITLE
fix: await async VirtualDisplay.get() so DISPLAY is not "[object Promise]"

### DIFF
--- a/server.js
+++ b/server.js
@@ -952,7 +952,11 @@ async function launchBrowserInstance() {
     try {
       if (os.platform() === 'linux') {
         localVirtualDisplay = pluginCtx.createVirtualDisplay();
-        vdDisplay = localVirtualDisplay.get();
+        // camoufox-js >=0.11 made VirtualDisplay.get() async (it resolves to ":<n>").
+        // Without await, vdDisplay is a Promise -> DISPLAY becomes "[object Promise]"
+        // and the browser dies with "cannot open display". Awaiting also lets the
+        // catch below correctly fall back to headless if Xvfb genuinely fails.
+        vdDisplay = await localVirtualDisplay.get();
         log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

The browser never launches when running under a virtual display (the default
on Linux/Docker). `server.js` calls `VirtualDisplay.get()` **synchronously**,
but `camoufox-js@0.11.0` made `get()` **async**. The unresolved Promise is
passed through as the display, so Camoufox is launched with
`DISPLAY="[object Promise]"` and dies immediately.

This is a one-line fix: `await` the call.

## Symptom

With the stock Docker image, `/health` stays at `browserRunning:false` and the
logs loop on:

```
Error: cannot open display: [object Promise]
camoufox launch attempt failed ... browserType.launch: Failed to launch the browser process.
browser pre-warm failed (will retry in background)
```

## Root cause

`camoufox-js@0.11.0`'s `VirtualDisplay.get()` is `async` — it spawns Xvfb with
`-displayfd 3`, reads the kernel-assigned display number from fd 3
asynchronously, and resolves to `":<n>"`.

In `server.js` (browser launch loop):

```js
localVirtualDisplay = pluginCtx.createVirtualDisplay();
vdDisplay = localVirtualDisplay.get();   // <-- Promise, not ":<n>"
...
const useVirtualDisplay = !!vdDisplay;    // a Promise is truthy
...
const options = await launchOptions({
  headless: useVirtualDisplay ? false : true,  // headless never enabled
  virtual_display: vdDisplay,                   // Promise passed through
});
```

Because the Promise is truthy, headless mode is never selected, and the Promise
is forwarded as `virtual_display`, which stringifies to `[object Promise]` when
it becomes the `DISPLAY` env var for the Firefox/Camoufox process.

A side effect: the surrounding `try/catch` that is meant to *fall back to
headless when Xvfb is unavailable* can never trigger, because `get()` is never
awaited and therefore never rejects in this scope.

## Fix

```diff
       localVirtualDisplay = pluginCtx.createVirtualDisplay();
-      vdDisplay = localVirtualDisplay.get();
+      vdDisplay = await localVirtualDisplay.get();
       log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
```

The enclosing function is already `async` (it `await`s `launchOptions(...)` and
`firefox.launch(...)` a few lines below), so awaiting here is safe and also
restores the intended headless fallback on Xvfb failure.

## Verification

Built the stock `Dockerfile` (`node:22-slim`, `camoufox-js@0.11.0`,
Camoufox `135.0.1-beta.24`, linux/amd64) and ran the container.

**Before:** `/health` -> `browserConnected:false, browserRunning:false`; retry loop with `cannot open display: [object Promise]`.

**After:**
```
{"msg":"xvfb virtual display started","display":":0"}
{"msg":"camoufox launched"}
{"msg":"browser pre-warmed","ms":2387}
```
`GET /health` -> `{"ok":true,"browserConnected":true,"browserRunning":true,...}`
and a live `POST /tabs/open {"userId":"...","url":"https://example.com"}` returns
`{"ok":true,"url":"https://example.com/","title":"Example Domain"}`.

## Notes

- Scope: 1 line (plus an explanatory comment).
- No API or behavior change beyond making the virtual-display path actually work
  and re-enabling the headless fallback.
