### PR TITLE
fix(vnc-watcher): detect Xvfb display when launched with -displayfd

### DIFF
--- a/plugins/vnc/vnc-watcher.sh
+++ b/plugins/vnc/vnc-watcher.sh
@@ -10,7 +10,7 @@
 #   VNC_PORT        VNC port (default: 5900)
 #   NOVNC_PORT      noVNC websocket port (default: 6080)
 
-set -e
+# set -e # remove set -e so watcher survives x11vnc failures
 
 VNC_PORT="${VNC_PORT:-5900}"
 NOVNC_PORT="${NOVNC_PORT:-6080}"
@@ -44,13 +44,36 @@ websockify --web "$NOVNC_DIR" "$VNC_BIND:$NOVNC_PORT" "127.0.0.1:$VNC_PORT" >/va
 
 log "VNC watcher started -- will attach x11vnc when Camoufox's Xvfb appears"
 
-while true; do
-  # Find Xvfb with our patched resolution
-  FOUND=$(ps -eo args= 2>/dev/null | awk -v res="$VNC_RESOLUTION" '
-    /\/Xvfb :[0-9]+/ && index($0, res) {
+# Detect Xvfb display number from /tmp/.X*-lock or ps args
+detect_display() {
+  # First try: Xvfb with hardcoded :N in command line
+  local disp
+  disp=$(ps -eo args= 2>/dev/null | awk -v res="$VNC_RESOLUTION" '
+    /\/Xvfb / && index($0, res) {
       for (i=1;i<=NF;i++) if ($i ~ /^:[0-9]+$/) { print $i; exit }
     }
   ' | head -1)
+  [ -n "$disp" ] && echo "$disp" && return
+
+  # Second try: Xvfb in -displayfd mode, detect from lock files
+  local lockfile
+  lockfile=$(ls /tmp/.X*-lock 2>/dev/null | head -1)
+  if [ -n "$lockfile" ]; then
+    local num
+    num=$(echo "$lockfile" | grep -o 'X[0-9]*' | tr -d 'X')
+    [ -n "$num" ] && echo ":$num" && return
+  fi
+
+  # Third try: any /tmp/.X* socket or file
+  local xsock
+  xsock=$(ls /tmp/.X* 2>/dev/null | grep -o 'X[0-9]*$' | head -1 | tr -d 'X')
+  [ -n "$xsock" ] && echo ":$xsock" && return
+
+  echo ""
+}
+
+while true; do
+  FOUND=$(detect_display)
 
   if [ -n "$FOUND" ] && [ "$FOUND" != "$CURRENT_DISPLAY" ]; then
     # New or changed display -- (re)attach x11vnc
@@ -72,9 +95,13 @@ while true; do
     fi
 
     # shellcheck disable=SC2086
-    x11vnc $X11VNC_ARGS
+    x11vnc $X11VNC_ARGS || true
     sleep 1
     X11VNC_PID=$(pgrep -f "x11vnc.*-display $CURRENT_DISPLAY" | head -1)
+    if [ -z "$X11VNC_PID" ]; then
+      log "x11vnc failed to connect, clearing display for retry"
+      CURRENT_DISPLAY=""
+    fi
     log "x11vnc running (pid=$X11VNC_PID) on DISPLAY=$CURRENT_DISPLAY"
   fi
 


### PR DESCRIPTION
Disclaimer: PR made with AI but I verified locally that it fixes the issue for me.

# Bug Description

When Camofox runs with VNC enabled (ENABLE_VNC=1), noVNC fails with "Failed to connect to 127.0.0.1:5900: Connection refused" because x11vnc never starts. The VNC watcher script loops forever unable to detect the Xvfb display.
Root Cause

The VNC watcher script uses the awk regex /\Xvfb :[0-9]+/ to find Xvfb, which only matches when Xvfb is launched with a hardcoded display number (e.g. Xvfb :0 -screen ...). The camoufox-js VirtualDisplay class launches Xvfb with -displayfd 3 (dynamic display assignment), so the command line looks like Xvfb -displayfd 3 -screen ... — no :0 in argv. The watcher never finds it, x11vnc never attaches, and noVNC stays permanently disconnected.
Fix

Replace the inline awk detection with a detect_display() function that tries three fallbacks in order:

1. Xvfb with hardcoded :N display in argv (original method, regex relaxed to /\Xvfb /)
2. /tmp/.X*-lock files — the traditional X lock file that contains the display number
3. /tmp/.X* sockets — fallback via /tmp/.X11-unix/X* files when no lock file exists

# How to Verify

1. Start with ENABLE_VNC=1: docker run -d -p 9377:9377 -p 6080:6080 -p 5901:5900 -e ENABLE_VNC=1 camofox-browser:135.0.1-x86_64
2. Wait for the browser to pre-warm (check curl http://localhost:9377/health for browserConnected:true)
3. Open http://localhost:6080/vnc.html in a browser and click Connect
4. Confirm you see the Camofox browser window live
