### PR TITLE
fix: await VirtualDisplay.get() — Promise was serialized as {}

### DIFF
--- a/server.js
+++ b/server.js
@@ -952,7 +952,11 @@ async function launchBrowserInstance() {
     try {
       if (os.platform() === 'linux') {
         localVirtualDisplay = pluginCtx.createVirtualDisplay();
-        vdDisplay = localVirtualDisplay.get();
+        // camoufox-js >=0.x uses -displayfd + Promise-based get() so the kernel
+        // picks a free display number atomically. We MUST await it; otherwise
+        // vdDisplay becomes a Promise object, JSON.stringify renders it as "{}"
+        // and the camoufox launch fails with "Error: cannot open display".
+        vdDisplay = await localVirtualDisplay.get();
         log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
       }
     } catch (err) {


### PR DESCRIPTION
## Bug

`VirtualDisplay.get()` in `camoufox-js/dist/virtdisplay.js` is async — it spawns Xvfb with `-displayfd 3` and resolves to the display number once Xvfb writes the lock file.

`launchBrowserInstance()` in `server.js` was calling it **without await**, so `vdDisplay` was a `Promise<":N">` object instead of the `":N"` string itself.

The downstream code then did:

```js
const useVirtualDisplay = !!vdDisplay;        // !!<Promise> === true
log('info', 'xvfb virtual display started', { display: vdDisplay, ... });   // "display": {}
// later, passed to camoufox's launchOptions as virtual_display: vdDisplay
```

`JSON.stringify(<Promise>)` renders as `"{}"`, and Playwright launches Firefox in non-headless mode without a real DISPLAY, so it crashes:

```
[pid=...][err] Error: cannot open display: [object Promise]
[pid=...] <process did exit: exitCode=1, signal=null>
```

Every `POST /tabs` returned 500, and the background pre-warm kept failing forever with `nextDelayMs: 30000`.

## Fix

Add the missing `await` in `server.js` line 955:

```diff
-        vdDisplay = localVirtualDisplay.get();
+        vdDisplay = await localVirtualDisplay.get();
```

`launchBrowserInstance()` is already `async`, so the `await` is in scope.

## Verification

Before:
- `POST /tabs` → `{"error":"Internal server error"}` 500
- Health: `browserConnected: false`, `browserRunning: false`
- Logs repeat `camoufox launch attempt failed ... cannot open display: [object Promise]`

After:
- `POST /tabs` → `{"tabId":"bd967731-...","url":"https://news.google.com/..."}` 200
- Health: `browserConnected: true`, `browserRunning: true`, `activeTabs: 1`
- Logs: `"xvfb virtual display started","display":":0"` (string, not `{}`), then `"camoufox launched"`, then `"browser pre-warmed","ms":1116`

Repro: `docker run -p 9377:9377 camofox-browser` on a stock Linux host, then `curl -X POST localhost:9377/tabs -H "Content-Type: application/json" -d '{"userId":"x","sessionKey":"y","url":"https://example.com"}'`.

## Notes

- The same bug likely affects every existing tag, including `master`, `next`, and `sync/jo-browser-*` branches — none of them await `.get()`.
- I considered also patching `camoufox-js/dist/virtdisplay.js` to add a sync `getSync()` escape hatch, but the upstream async API is correct (it avoids userspace display-number races), so the right fix is at the call site.