### PR TITLE
fix: add missing await to VirtualDisplay.get() in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -952,7 +952,7 @@ async function launchBrowserInstance() {
     try {
       if (os.platform() === 'linux') {
         localVirtualDisplay = pluginCtx.createVirtualDisplay();
-        vdDisplay = localVirtualDisplay.get();
+        vdDisplay = await localVirtualDisplay.get();
         log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
       }
     } catch (err) {


### PR DESCRIPTION
## Fix: one word — `await`

`VirtualDisplay.get()` returns `Promise<string>`, but line 955 was missing `await`.

### Evidence
- Definition: `camoufox-js/src/virtdisplay.ts:97` → `public async get(): Promise<string>`
- Correct usage: `sync_api.ts:47` → `await virtualDisplay.get()`
- Bug: `server.js:955` → `vdDisplay = localVirtualDisplay.get()`

### Impact
On Linux with xvfb, vdDisplay received a Promise instead of a display number. Log would show undefined/null.

Closes #5408