### PR TITLE
fix: await VirtualDisplay.get() (async since camoufox-js 0.11.0)

### DIFF
--- a/server.js
+++ b/server.js
@@ -952,7 +952,7 @@ async function launchBrowserInstance() {
     try {
       if (os.platform() === 'linux') {
         localVirtualDisplay = pluginCtx.createVirtualDisplay();
-        vdDisplay = localVirtualDisplay.get();
+        vdDisplay = await localVirtualDisplay.get();
         log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
       }
     } catch (err) {


### PR DESCRIPTION
Currently, running `make up` does not work for me.

In `camoufox-js@0.11.0`, VirtualDisplay.get() became async:

```js
// 0.10.x — synchronous, returns ":99"
get() { ...; return `:${this.display}`; }
```
```js
// 0.11.0 — now async, returns a Promise
async get() { ...; return `:${this._display}`; }

// But camofox-browser's server.js (line 955) still calls it synchronously:
jslocalVirtualDisplay = pluginCtx.createVirtualDisplay();
vdDisplay = localVirtualDisplay.get();   // <-- no await, now a Promise
```

There is no package lock, so this broke.
