### PR TITLE
fix: await virtual display initialization

### DIFF
--- a/server.js
+++ b/server.js
@@ -952,7 +952,7 @@ async function launchBrowserInstance() {
     try {
       if (os.platform() === 'linux') {
         localVirtualDisplay = pluginCtx.createVirtualDisplay();
-        vdDisplay = localVirtualDisplay.get();
+        vdDisplay = await localVirtualDisplay.get();
         log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

Fixes a Linux launch failure where the virtual display value is passed as a Promise instead of the resolved display string.

## Problem

When creating a browser tab on Linux, Camoufox failed to launch with:

```text
Error: cannot open display: [object Promise]
```

The `/tabs` request then returned `500`.

The log also showed the virtual display value as an object:

```text
"xvfb virtual display started","display":{}
```

## Cause

`VirtualDisplay.get()` returns a Promise, but the result was used without `await`:

```js
vdDisplay = localVirtualDisplay.get();
```

As a result, `vdDisplay` contained a Promise object instead of the actual Xvfb display string.

## Fix

Await the virtual display initialization:

```js
vdDisplay = await localVirtualDisplay.get();
```

## Testing

Tested locally on Linux with `@askjo/camofox-browser 1.11.2`.

Before the change, browser launch failed with:

```text
Error: cannot open display: [object Promise]
```

After the change, the server was able to create browser tabs successfully.
