### PR TITLE
fix(buildRefs): skip PerimeterX/captcha iframes to prevent 30s hang + spurious 500 on authenticated clicks

### DIFF
--- a/server.js
+++ b/server.js
@@ -175,6 +175,14 @@ const IFRAME_SKIP_PATTERNS = [
   /web-pixel/i, /analytics/i, /tracking/i, /gtm/i, /facebook/i,
   /doubleclick/i, /google.*tag/i, /hotjar/i, /segment/i, /sentry/i,
   /recaptcha/i, /gstatic/i, /app-bridge/i, /extensions\.shopifycdn/i,
+  // Bot-detection / anti-automation frames. These are short-lived and frequently
+  // DETACH mid-ariaSnapshot, which hangs buildRefs until the handler timeout (30s)
+  // and surfaces as a spurious 500 on the click/snapshot that triggered the rebuild.
+  // e.g. LinkedIn injects PerimeterX (px-iframe-*/px-captcha) on authenticated
+  // actions such as the connection-invite modal, so skipping these is required for
+  // those write flows to work.
+  /px-iframe/i, /px-captcha/i, /perimeterx/i, /\bcaptcha\b/i, /hcaptcha/i,
+  /arkose/i, /funcaptcha/i, /datadome/i,
 ];
 const MAX_IFRAMES_TO_PROCESS = 8;
 const IFRAME_SNAPSHOT_TIMEOUT_MS = 3000;


### PR DESCRIPTION
## Problem

`buildRefs()` traverses child frames and calls `frame.locator('body').ariaSnapshot()` on each frame **not** matched by `IFRAME_SKIP_PATTERNS`. Some sites inject a short-lived bot-detection iframe that **detaches mid-`ariaSnapshot`**. When that happens the `ariaSnapshot` promise hangs until the handler timeout (**30s**), and the `/click` (or `/snapshot`, `/evaluate`) call that triggered the post-action ref rebuild returns a **spurious `500 Internal server error`** — even though the underlying click actually succeeded.

Container logs show the tell:

```
buildRefs: iframe snapshot failed  frameName=px-iframe-<digits>  error=locator.ariaSnapshot: Frame was detached
click timeout, trying mouse sequence
action timed out after 30000ms
```

### Concrete repro (LinkedIn)

LinkedIn injects a **PerimeterX** iframe (`px-iframe-*` / `px-captcha`) on authenticated actions such as the connection-invite **"Add a note to your invitation?"** modal. Every click that pops such a modal hits the px-iframe during the ref rebuild, hangs 30s, and 500s — so the automated write flow silently fails (the click landed, but the response is an error and no follow-up state is observable).

## Fix

Add the common bot-detection / anti-automation frames to `IFRAME_SKIP_PATTERNS` so `buildRefs` skips them entirely (the same treatment `recaptcha` already gets):

```
/px-iframe/i, /px-captcha/i, /perimeterx/i, /\bcaptcha\b/i, /hcaptcha/i,
/arkose/i, /funcaptcha/i, /datadome/i,
```

These frames never contain app-interactive elements worth snapshotting, and they're the ones most prone to detaching mid-snapshot. Both iframe loops in `server.js` reference this single constant, so the one edit covers ref building and the snapshot YAML path.

## Testing

- `node --check server.js` passes.
- Built a derived image and ran an automated LinkedIn connection-invite flow that **previously 500'd** on profiles showing the intermediate "Add a note" step. After the change the flow completes and the invite verifies as **Pending**. The `px-iframe ... Frame was detached -> 30s timeout -> 500` sequence no longer appears in logs.

## Scope

One file, 8 lines added (plus a comment). No behavior change for sites without these iframes.
