### PR TITLE
fix(click): bound boundingBox() in mouse-sequence fallback to prevent 30s timeout 500s

### DIFF
--- a/server.js
+++ b/server.js
@@ -3248,7 +3248,23 @@ app.post('/tabs/:tabId/click', async (req, res) => {
       // Full mouse event sequence for stubborn JS click handlers (mirrors Swift WebView.swift)
       // Dispatches: mouseover -> mouseenter -> mousedown -> mouseup -> click
       const dispatchMouseSequence = async (locator) => {
-        const box = await locator.boundingBox();
+        // boundingBox() with no timeout inherits Playwright's 30s default, which
+        // silently eats the entire handler budget when the element detached after
+        // the failed click attempt (the page changed under us). Bound it to the
+        // remaining budget (capped at 3s) so the route fails fast with an
+        // actionable 422 instead of blowing HANDLER_TIMEOUT_MS into a 500.
+        // NOTE: the message deliberately avoids the 'timed out after' phrase so
+        // isTimeoutError() doesn't classify a detached element as a navigation
+        // timeout and destroy the whole session in handleRouteError().
+        const bboxTimeout = Math.max(500, Math.min(3000, remainingBudget()));
+        let box;
+        try {
+          box = await locator.boundingBox({ timeout: bboxTimeout });
+        } catch (e) {
+          const detachedErr = new Error(`Element not actionable: no bounding box within ${bboxTimeout}ms (element likely detached after page change). Call snapshot to refresh refs and retry.`);
+          detachedErr.statusCode = 422;
+          throw detachedErr;
+        }
         if (!box) throw new Error('Element not visible (no bounding box)');
         
         const x = box.x + box.width / 2;

--- a/tests/unit/clickBoundingBoxTimeout.test.js
+++ b/tests/unit/clickBoundingBoxTimeout.test.js
@@ -1,0 +1,91 @@
+/**
+ * Tests for the bounded boundingBox() call in the /click mouse-sequence fallback.
+ *
+ * Regression: when a click attempt failed (element detached after the page
+ * changed under us, e.g. a SPA re-render between snapshot and click), the
+ * mouse-sequence fallback called locator.boundingBox() with NO timeout.
+ * Playwright then waited its default 30s for the element to become resolvable,
+ * which blew the entire HANDLER_TIMEOUT_MS budget and surfaced as:
+ *
+ *   {"level":"error","msg":"click failed","error":"action timed out after 30000ms"}
+ *   {"level":"error","msg":"internal error","error":"action timed out after 30000ms"}
+ *   -> 500 to the client
+ *
+ * The fix bounds boundingBox() to min(3s, remaining budget) and throws a
+ * 422 "Element not actionable" error that:
+ *   1. fails fast (~3s instead of ~30s),
+ *   2. is NOT classified as a timeout error (so handleRouteError does not
+ *      destroy the whole user session over a detached element),
+ *   3. tells the caller to snapshot + retry.
+ */
+import { describe, test, expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverSrc = readFileSync(join(__dirname, '../../server.js'), 'utf8');
+
+// Mirror of isTimeoutError from server.js (kept in sync; see navigationTimeout.test.js)
+function isTimeoutError(err) {
+  if (!err) return false;
+  const msg = err.message || '';
+  return msg.includes('timed out after') || (msg.includes('Timeout') && msg.includes('exceeded'));
+}
+
+// Mirror of the bboxTimeout computation in the /click handler
+function computeBboxTimeout(remainingBudgetMs) {
+  return Math.max(500, Math.min(3000, remainingBudgetMs));
+}
+
+describe('/click mouse-sequence boundingBox bounding', () => {
+  describe('server.js source contract', () => {
+    test('boundingBox in the mouse-sequence fallback is called with an explicit timeout', () => {
+      // Any bare `locator.boundingBox()` (no options) inside server.js would
+      // reintroduce the 30s default-timeout hang.
+      const bare = serverSrc.match(/\.boundingBox\(\s*\)/g) || [];
+      expect(bare).toHaveLength(0);
+      expect(serverSrc).toMatch(/\.boundingBox\(\{\s*timeout:\s*bboxTimeout\s*\}\)/);
+    });
+
+    test('detached-element error carries statusCode 422', () => {
+      const idx = serverSrc.indexOf('Element not actionable: no bounding box within');
+      expect(idx).toBeGreaterThan(-1);
+      const surrounding = serverSrc.slice(idx, idx + 400);
+      expect(surrounding).toMatch(/statusCode = 422/);
+    });
+  });
+
+  describe('bboxTimeout budget math', () => {
+    test('caps at 3s even with a full budget', () => {
+      expect(computeBboxTimeout(28000)).toBe(3000);
+    });
+
+    test('uses remaining budget when below the cap', () => {
+      expect(computeBboxTimeout(1800)).toBe(1800);
+    });
+
+    test('floors at 500ms when the budget is exhausted', () => {
+      expect(computeBboxTimeout(0)).toBe(500);
+      expect(computeBboxTimeout(-100)).toBe(500);
+    });
+  });
+
+  describe('error classification (session must survive a detached element)', () => {
+    test('detached-element error is NOT classified as a timeout error', () => {
+      const err = new Error(
+        'Element not actionable: no bounding box within 3000ms (element likely detached after page change). Call snapshot to refresh refs and retry.'
+      );
+      // If this were classified as a timeout, handleRouteError would destroy
+      // the entire user session ('navigation timeout — destroying session for
+      // fresh proxy') over a stale ref. It must not be.
+      expect(isTimeoutError(err)).toBe(false);
+    });
+
+    test('the old unbounded behavior WAS classified as a session-destroying timeout', () => {
+      // Documents the bug being fixed: the generic withTimeout wrapper error.
+      const err = new Error('action timed out after 30000ms');
+      expect(isTimeoutError(err)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

When a `/tabs/:tabId/click` request hits the mouse-sequence fallback and the target element has **detached** (page changed between snapshot and click — common on SPAs like LinkedIn search results), `locator.boundingBox()` is called with **no timeout**. Playwright waits its default **30s** for the element to resolve, which blows the entire handler budget:

```
{"level":"warn","msg":"click timeout, trying mouse sequence"}
... 27s of silence ...
{"level":"error","msg":"click failed","error":"action timed out after 30000ms"}
{"level":"error","msg":"internal error","error":"action timed out after 30000ms","stack":"Error: action timed out after 30000ms\n    at Timeout._onTimeout (file:///app/server.js:485:31)"}
{"level":"info","msg":"res","status":500,"ms":30938}
```

Two compounding issues:

1. The client waits the full 30s and gets an opaque **500**.
2. The generic `action timed out after 30000ms` message is matched by `isTimeoutError()`, and since `click` is in `NAVIGATION_TIMEOUT_ACTIONS`, `handleRouteError()` **destroys the whole user session** (fresh BrowserContext + proxy) — losing every other live tab — over what is really just a stale ref.

Observed in production logs (v1.11.2) during a LinkedIn people-search batch: two such 500s in one run, each costing ~31s and killing the session of a concurrently-used tab.

## Fix

In `dispatchMouseSequence`:

- `boundingBox()` is now bounded to `min(3000ms, remaining handler budget)`, floored at 500ms.
- On timeout it throws a **422 `Element not actionable`** error that (a) returns in ~3s instead of 30s, (b) deliberately avoids the `timed out after` phrase so `isTimeoutError()` doesn't nuke the session, and (c) tells the caller to `snapshot` + retry — which is exactly what the existing post-timeout refresh path recommends.

## Tests

New `tests/unit/clickBoundingBoxTimeout.test.js` (7 tests):
- source contract: no bare `boundingBox()` calls remain in server.js; the call site uses `bboxTimeout`; the error carries `statusCode = 422`
- budget math: cap at 3s, pass-through under cap, 500ms floor
- error classification: new error is NOT a session-destroying timeout; documents that the old behavior WAS

`node --check server.js` passes; full unit suite: 661 passed, with the only failures (`security.test.js`, `cookies.test.js`) failing identically on clean `master` in my environment (real-browser spawn tests), i.e. pre-existing/environment-dependent.