### PR TITLE
fix(reporter): add resetNativeMemBaseline no-op when crash reporting disabled

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -661,6 +661,7 @@ export function createReporter(config) {
       startWatchdog: () => {},
       trackRoute: () => {},
       stop: () => {},
+      resetNativeMemBaseline: () => {},
       _anonymize: anonymize,
       _stackSignature: stackSignature,
     };


### PR DESCRIPTION
## Bug

When crash/hang reporting is disabled with `CAMOFOX_CRASH_REPORT_ENABLED=false`, browser close / idle cleanup throws:

```
TypeError: reporter.resetNativeMemBaseline is not a function
```

## Root cause

`server.js` calls `reporter.resetNativeMemBaseline()` unconditionally on browser close, but the no-op reporter (returned when `enabled === false`) only stubs `reportCrash`, `reportHang`, `reportStuckLoop`, `startWatchdog`, `trackRoute`, and `stop` — it was missing `resetNativeMemBaseline`.

## Fix

Add `resetNativeMemBaseline: () => {}` to the no-op reporter return object in `lib/reporter.js:665`. This keeps the reporter interface stable without changing any reporting behavior.

## Validation

- `node --check lib/re` passes
- `node --check server.js` passes
- One-line change, no new deps

Fixes #5434