### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
 git clone https://github.com/jo-inc/camofox-browser && cd camofox-browser
 npm install && npm start
 # -> http://localhost:9377
+
+[![Listed on TakoAPI](https://img.shields.io/badge/Listed%20on-TakoAPI-7c3aed)](https://takoapi.com/agents/jo-inc-camofox-browser)
+
 ```
 
 ---


### PR DESCRIPTION
Hi! 👋 **camofox-browser** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/jo-inc-camofox-browser

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building camofox-browser! 🙏