### PR TITLE
fix(reporter): expose native memory reset when disabled

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -661,6 +661,7 @@ export function createReporter(config) {
       startWatchdog: () => {},
       trackRoute: () => {},
       stop: () => {},
+      resetNativeMemBaseline: () => {},
       _anonymize: anonymize,
       _stackSignature: stackSignature,
     };

--- a/tests/unit/reporter.test.js
+++ b/tests/unit/reporter.test.js
@@ -395,6 +395,8 @@ describe('createReporter', () => {
     await reporter.reportStuckLoop(60000);
     reporter.startWatchdog();
     reporter.trackRoute('GET /test');
+    expect(typeof reporter.resetNativeMemBaseline).toBe('function');
+    reporter.resetNativeMemBaseline();
     reporter.stop();
   });
 


### PR DESCRIPTION
## Summary
- add resetNativeMemBaseline to the disabled/no-op reporter surface
- cover the disabled reporter contract in reporter lifecycle tests

## Test Plan
- npm test -- tests/unit/reporter.test.js
- npm test -- tests/unit/config.test.js plugins/vnc/vnc-launcher.test.js
- runtime Camofox smoke via camofox-smoke.mjs against http://127.0.0.1:9377
