### PR TITLE
fix: await VirtualDisplay.get() for camoufox-js 0.11.1+

### DIFF
--- a/server.js
+++ b/server.js
@@ -952,7 +952,7 @@ async function launchBrowserInstance() {
     try {
       if (os.platform() === 'linux') {
         localVirtualDisplay = pluginCtx.createVirtualDisplay();
-        vdDisplay = localVirtualDisplay.get();
+        vdDisplay = await localVirtualDisplay.get();
         log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
       }
     } catch (err) {


### PR DESCRIPTION
## Problem

VirtualDisplay.get() changed from sync to async in camoufox-js 0.11.1. Without await, vdDisplay becomes a Promise object, causing browser launch to fail with `'cannot open display: [object Promise]'`

## Fix

Add `await` to `localVirtualDisplay.get()` call in server.js line 955.

## Reproduction

1. Use camoufox-js 0.11.1+ (e.g. in Docker image camofox-browser:135.0.1-x86_64)
2. Try to create a tab: `POST /tabs`
3. Error: `cannot open display: [object Promise]`

## Verification

After this fix, browser launches successfully on display :0 and tabs can be created normally.