### PR TITLE
fix: include docs/ directory in Docker image for Swagger UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ COPY camofox.config.json ./
 COPY lib/ ./lib/
 COPY plugins/ ./plugins/
 COPY scripts/ ./scripts/
+COPY docs/ ./docs/
 
 # Install default plugin dependencies (apt packages + post-install hooks)
 RUN sh scripts/install-plugin-deps.sh


### PR DESCRIPTION
The Dockerfile is missing `COPY docs/ ./docs/`, so the Swagger UI at `/docs` returns 404.

**Root cause:** `mountDocs()` in `lib/openapi.js` serves static assets from `docs/` via `express.static`, but the Dockerfile never copies that directory into the container.

**Fix:** Add `COPY docs/ ./docs/` after the existing COPY instructions.

**Verification:** After rebuild, `/docs` serves the swagger-stripey UI (api.html + fox.png) correctly.

**Files in docs/:**
- `api.html` — swagger-stripey: Stripe-style 3-panel OpenAPI renderer
- `fox.png` — logo
- `openapi.json` — static copy (runtime version at /openapi.json is generated from JSDoc)