### PR TITLE
fix: await VirtualDisplay.get() — missing await crashes browser in Docker

### DIFF
--- a/server.js
+++ b/server.js
@@ -952,7 +952,7 @@ async function launchBrowserInstance() {
     try {
       if (os.platform() === 'linux') {
         localVirtualDisplay = pluginCtx.createVirtualDisplay();
-        vdDisplay = localVirtualDisplay.get();
+        vdDisplay = await localVirtualDisplay.get();
         log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
       }
     } catch (err) {


### PR DESCRIPTION
`VirtualDisplay.get()` is async and returns a Promise, but the call on line 955 was missing `await`. The unresolved Promise was passed to camoufox as the display argument:

```
Error: cannot open display: [object Promise]
```

Browser launch fails and retries indefinitely in Docker/headless Linux.

Fixed by adding `await` so `vdDisplay` resolves to the actual display number (e.g. `:0`) before it reaches `launchOptions`.