### PR TITLE
Await async VirtualDisplay.get() so DISPLAY isn't a stringified Promise

### DIFF
--- a/server.js
+++ b/server.js
@@ -952,7 +952,7 @@ async function launchBrowserInstance() {
     try {
       if (os.platform() === 'linux') {
         localVirtualDisplay = pluginCtx.createVirtualDisplay();
-        vdDisplay = localVirtualDisplay.get();
+        vdDisplay = await localVirtualDisplay.get();
         log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
       }
     } catch (err) {


### PR DESCRIPTION
## Problem

On Linux (including the Docker image), the browser never launches — every `POST /tabs` returns 500, and the browser logs show:

```
[pid=NN][err] Error: cannot open display: [object Promise]
```

`camoufox-js`'s `VirtualDisplay.get()` is **async** (it spawns Xvfb with `-displayfd 3` and awaits the display number it reports back). But `launchBrowserInstance()` in `server.js` calls it without `await`:

```js
localVirtualDisplay = pluginCtx.createVirtualDisplay();
vdDisplay = localVirtualDisplay.get();   // <-- a Promise, not ":99"
```

So `vdDisplay` is a `Promise`. It's passed as `virtual_display: vdDisplay` into `launchOptions()` and ultimately becomes the browser's `DISPLAY`, where it stringifies to `[object Promise]` → "cannot open display" → launch fails on every attempt. The structured log line gives it away too: `"display": {}` (a Promise serialized by `JSON.stringify`).

## Fix

`await` the call. This is safe whether `.get()` is sync or async — `await` on a non-Promise just returns the value — so it works across `camoufox-js` versions.

```diff
-        vdDisplay = localVirtualDisplay.get();
+        vdDisplay = await localVirtualDisplay.get();
```

## Environment / repro
- Docker image via `make build` / `make up` on **aarch64**, Camoufox **135.0.1-beta.24**, `camoufox-js` **0.11.1**, Node 22.
- **Before:** every `POST /tabs` 500s with the display error above.
- **After:** browser launches; `/snapshot`, `@google_search` macro, and `/evaluate` all return real results (verified `navigator.webdriver === false`, no CAPTCHA on Google).

## Unrelated heads-up (not in this PR)
With `"playwright-core": "^1.58.0"`, a fresh `npm install` today resolves to **1.61.0**, whose `Browser.setDefaultViewport` sends `viewport.isMobile`, which the Camoufox 135 Juggler protocol rejects:

```
property "<root>.viewport.isMobile" - false which is not described in this scheme
```

The committed `package-lock.json` already pins **1.59.1** (which works), but the `Dockerfile` runs `npm install` (not `npm ci`), so it ignores the lock. Might be worth switching the Docker build to `npm ci` or tightening the range. Happy to send a separate PR if useful.
