### PR TITLE
fix: await VirtualDisplay.get() and null viewport for Camoufox 135 compat

### DIFF
--- a/server.js
+++ b/server.js
@@ -707,7 +707,7 @@ async function probeGoogleSearch(candidateBrowser) {
   let context = null;
   try {
     context = await candidateBrowser.newContext({
-      viewport: { width: 1280, height: 720 },
+      viewport: null,
       permissions: ['geolocation'],
     });
     const page = await context.newPage();
@@ -952,7 +952,7 @@ async function launchBrowserInstance() {
     try {
       if (os.platform() === 'linux') {
         localVirtualDisplay = pluginCtx.createVirtualDisplay();
-        vdDisplay = localVirtualDisplay.get();
+        vdDisplay = await localVirtualDisplay.get();
         log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
       }
     } catch (err) {
@@ -1177,7 +1177,7 @@ async function getSession(userId, { trace = false } = {}) {
       }
       const b = await ensureBrowser();
       const contextOptions = {
-        viewport: { width: 1280, height: 720 },
+        viewport: null,
         permissions: ['geolocation'],
       };
       // When geoip is active (proxy configured), camoufox auto-configures


### PR DESCRIPTION
## Summary

Two bugs prevent Camoufox 135.0.1-beta.24 from launching inside Docker (Xvfb headless mode).

### Bug 1: Missing await on VirtualDisplay.get() (line 955)

VirtualDisplay.get() is async but was called without await. vdDisplay resolved to a Promise instead of the display string.

Symptom: Logs show display:{} and Camoufox fails with 'cannot open display: [object Promise]'.

Fix: vdDisplay = await localVirtualDisplay.get();

### Bug 2: viewport isMobile incompatible with Juggler protocol (lines 709, 1180)

Playwright sends isMobile:false in Browser.setDefaultViewport but Camoufox 135 Juggler does not recognize this property.

Fix: Set viewport:null in both newContext calls.

## Test Plan

- [x] Docker image built with DOCKER_BUILDKIT=1 make up ARCH=x86_64
- [x] Browser pre-warms: camoufox launched, virtualDisplay:true
- [x] Tab creation works: POST /tabs returns tabId
- [x] Navigation works: example.com loads, snapshot returns accessibility tree
- [x] Health: browserConnected true, browserRunning true