### PR TITLE
fix: await virtual display before launch

### DIFF
--- a/server.js
+++ b/server.js
@@ -952,7 +952,7 @@ async function launchBrowserInstance() {
     try {
       if (os.platform() === 'linux') {
         localVirtualDisplay = pluginCtx.createVirtualDisplay();
-        vdDisplay = localVirtualDisplay.get();
+        vdDisplay = await localVirtualDisplay.get();
         log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
       }
     } catch (err) {


### PR DESCRIPTION
This fixes a Linux Docker startup issue where Camoufox failed to launch after Xvfb started.

The failure looked like this:

```text
xvfb virtual display started display:{}
Error: cannot open display: [object Promise]
browser pre-warm failed
```

`localVirtualDisplay.get()` returns a Promise, so `vdDisplay` was getting passed through before it resolved. Awaiting it gives the expected display value before launch.

After the change:

```text
xvfb virtual display started display:":0"
camoufox launched
browser pre-warmed
```

Validated on Linux Docker x86_64 with `camofox-browser:135.0.1-x86_64`.

No environment handling was changed.