### PR TITLE
fix: re-attach x11vnc after it dies on browser restart

### DIFF
--- a/plugins/vnc/vnc-watcher.sh
+++ b/plugins/vnc/vnc-watcher.sh
@@ -52,7 +52,8 @@ while true; do
     }
   ' | head -1)
 
-  if [ -n "$FOUND" ] && [ "$FOUND" != "$CURRENT_DISPLAY" ]; then
+  if [ -n "$FOUND" ] && { [ "$FOUND" != "$CURRENT_DISPLAY" ] || ! pgrep -x x11vnc >/dev/null; }; then
+    CURRENT_DISPLAY=""
     # New or changed display -- (re)attach x11vnc
     if [ -n "$X11VNC_PID" ] && kill -0 "$X11VNC_PID" 2>/dev/null; then
       log "Camoufox display changed ($CURRENT_DISPLAY -> $FOUND), restarting x11vnc"


### PR DESCRIPTION
When the browser restarts, x11vnc dies and is never re-attached, so noVNC loses
its backend, clients get a blank screen and don't reconnect until the container
is restarted.

The watcher only re-attaches when the display *number* changes:

```sh
if [ -n "$FOUND" ] && [ "$FOUND" != "$CURRENT_DISPLAY" ]; then
```

But on a browser restart, Camoufox recreates its Xvfb as the same display (`:0`).
x11vnc dies with `caught XIO error`, yet `FOUND` still equals `CURRENT_DISPLAY`,
so the watcher never notices.

This fix also re-attaches when x11vnc isn't running, regardless of the display
number:

```sh
if [ -n "$FOUND" ] && { [ "$FOUND" != "$CURRENT_DISPLAY" ] || ! pgrep -x x11vnc >/dev/null; }; then
    CURRENT_DISPLAY=""
```

(The `CURRENT_DISPLAY=""` reset lets the existing re-attach block run when the
display number is unchanged.)

x11vnc now self-heals across browser restarts. Validated on Linux Docker x86_64
with `camofox-browser:135.0.1-x86_64` by forcing a restart (`pkill -f camoufox-bin`)
and confirming x11vnc re-attaches and port 5900 comes back.