### PR TITLE
fix: Xvfb display init and viewport compat on ARM64 Linux

### DIFF
--- a/server.js
+++ b/server.js
@@ -707,7 +707,7 @@ async function probeGoogleSearch(candidateBrowser) {
   let context = null;
   try {
     context = await candidateBrowser.newContext({
-      viewport: { width: 1280, height: 720 },
+      viewport: null,
       permissions: ['geolocation'],
     });
     const page = await context.newPage();
@@ -952,7 +952,7 @@ async function launchBrowserInstance() {
     try {
       if (os.platform() === 'linux') {
         localVirtualDisplay = pluginCtx.createVirtualDisplay();
-        vdDisplay = localVirtualDisplay.get();
+        vdDisplay = await localVirtualDisplay.get();
         log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
       }
     } catch (err) {
@@ -1177,7 +1177,7 @@ async function getSession(userId, { trace = false } = {}) {
       }
       const b = await ensureBrowser();
       const contextOptions = {
-        viewport: { width: 1280, height: 720 },
+        viewport: null,
         permissions: ['geolocation'],
       };
       // When geoip is active (proxy configured), camoufox auto-configures
@@ -5965,7 +5965,7 @@ setInterval(async () => {
   
   let testContext;
   try {
-    testContext = await browser.newContext();
+    testContext = await browser.newContext({ viewport: null });
     const page = await testContext.newPage();
     await page.goto('about:blank', { timeout: 5000 });
     await page.close();


### PR DESCRIPTION
## What broke

Two separate issues made Camofox unusable on ARM64 Linux servers running headless (no physical display):

### 1. Xvfb display never passed to browser

`VirtualDisplay.get()` is async — it spawns Xvfb and reads the display number from fd 3. But `launchBrowserInstance` called it without `await`, so the Promise object got passed as `virtual_display` instead of the string `:0`. The browser launched in headed mode with no display, and Xvfb sat there unused.

Log showed `"display":{}` instead of `"display":":0"`. That empty object is `JSON.stringify(Promise)`.

**Fix:** one word — `await`.

### 2. `viewport.isMobile` rejected by Camoufox v135 Juggler protocol

Playwright >=1.58 includes `isMobile: false` in `Browser.setDefaultViewport` CDP calls. Camoufox v135 (latest ARM64 binary) doesn't recognize that field in its Juggler schema, so context creation fails with:

```
Found property "<root>.viewport.isMobile" - false which is not described in this scheme
```

Passing `viewport: null` in `newContext()` options skips the `setDefaultViewport` call entirely. The existing `page.setViewportSize()` calls (already in the codebase) handle viewport sizing per-page, so nothing is lost.

## Testing

Both fixes tested on Oracle Cloud Ampere A1 (ARM64, Ubuntu, Docker), Camoufox v135.0.1-beta.24:

- Tabs create and return accessibility snapshots
- Navigation works (example.com → icanhazip.com)
- Health check returns `browserConnected: true`
- No viewport regression

## Related

Closes #5916
