### PR TITLE
feat(persistence): add DELETE /sessions/:userId/cookies to reset login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,7 +310,7 @@ export function register(app, ctx) {
 | `auth` | `function` | `auth()` returns Express middleware enforcing API key / loopback |
 | `ensureBrowser` | `async function` | Launch browser if not running, return browser instance |
 | `getSession` | `async function` | `getSession(userId)` -- get or create a session |
-| `destroySession` | `function` | `destroySession(userId)` -- tear down a session |
+| `destroySession` | `async function` | `destroySession(userId, { reason })` -- tear down and await a session close |
 | `withUserLimit` | `async function` | `withUserLimit(userId, fn)` -- run `fn` within per-user concurrency limit |
 | `safePageClose` | `async function` | `safePageClose(page)` -- close a page with timeout guard |
 | `normalizeUserId` | `function` | `normalizeUserId(id)` -- coerce to string for map keys |

--- a/README.md
+++ b/README.md
@@ -595,7 +595,8 @@ Uses [yt-dlp](https://github.com/yt-dlp/yt-dlp) when available (fast, no browser
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `POST` | `/sessions/:userId/cookies` | Add cookies to a user session (Playwright cookie objects) |
-| `GET` | `/sessions/:userId/storage_state` | Export cookies + localStorage ([VNC plugin](plugins/vnc/)) |
+| `GET` | `/sessions/:userId/storage_state` | Export persisted browser storage ([VNC plugin](plugins/vnc/)) |
+| `DELETE` | `/sessions/:userId/storage_state` | Reset the live session and delete its persisted browser storage ([persistence plugin](plugins/persistence/)) |
 
 ## Search Macros
 

--- a/plugins/persistence/AGENTS.md
+++ b/plugins/persistence/AGENTS.md
@@ -7,6 +7,7 @@ Saves and restores per-user browser storage state (cookies + localStorage, with 
 - `session:creating` hook → loads saved `storage_state.json` into `contextOptions.storageState`
 - `session:created` hook → imports bootstrap cookies if no persisted state exists
 - `session:cookies:import` / `session:destroyed` / `server:shutdown` → checkpoints state to disk
+- `DELETE /sessions/:userId/storage_state` → closes the live context without checkpointing and removes persisted state
 
 All hooks are async and awaited via `emitAsync()` — storage state is guaranteed loaded before the context is created.
 

--- a/plugins/persistence/README.md
+++ b/plugins/persistence/README.md
@@ -33,6 +33,7 @@ CAMOFOX_PROFILE_DIR=/data/profiles
 - **Session create**: If a persisted `storageState` exists for the `userId`, it's restored into the new Playwright context.
 - **First run**: If no persisted state exists, bootstrap cookies from `CAMOFOX_COOKIES_DIR/cookies.txt` are imported (if present).
 - **Cookie import / session close / shutdown**: Storage state is checkpointed to disk via atomic tmp-write + rename.
+- **Session reset**: `DELETE /sessions/:userId/storage_state` closes the live context without checkpointing it, waits for in-flight writes, and deletes persisted state so the next session starts fresh.
 - **User isolation**: Each `userId` maps to a deterministic SHA256-hashed subdirectory under `profileDir`, so arbitrary userIds are path-safe.
 
 ## Docker

--- a/plugins/persistence/index.js
+++ b/plugins/persistence/index.js
@@ -67,32 +67,47 @@ export async function register(app, ctx, pluginConfig = {}) {
 
   log('info', 'persistence plugin enabled', { profileDir, indexedDB });
 
-  // Track active sessions for checkpoint on close
+  // Track active sessions and serialize checkpoints per user. Resetting users
+  // skip new checkpoints until their live context and saved state are gone.
   const activeSessions = new Map(); // userId -> context
+  const checkpointPromises = new Map(); // userId -> latest queued checkpoint
+  const resettingUsers = new Set();
 
   /**
    * Checkpoint storage state to disk for a userId.
    */
   async function checkpoint(userId, context, reason, storageState) {
-    if (!context && !storageState) return;
-    const result = await persistStorageState({
-      profileDir,
-      userId,
-      context,
-      storageState,
-      logger,
-      indexedDB,
+    if ((!context && !storageState) || resettingUsers.has(userId)) return;
+
+    const previous = checkpointPromises.get(userId) || Promise.resolve();
+    const current = previous.catch(() => {}).then(async () => {
+      if (resettingUsers.has(userId)) return;
+      const result = await persistStorageState({
+        profileDir,
+        userId,
+        context,
+        storageState,
+        logger,
+        indexedDB,
+      });
+      if (result.persisted) {
+        log('info', 'storage state persisted', { userId, reason, path: result.storageStatePath });
+      }
+      return result;
     });
-    if (result.persisted) {
-      log('info', 'storage state persisted', { userId, reason, path: result.storageStatePath });
+    checkpointPromises.set(userId, current);
+    try {
+      return await current;
+    } finally {
+      if (checkpointPromises.get(userId) === current) checkpointPromises.delete(userId);
     }
-    return result;
   }
 
   // --- Lifecycle hooks ---
 
   // Before session context is created: inject storageState if we have one saved
   events.on('session:creating', async ({ userId, contextOptions }) => {
+    if (resettingUsers.has(userId)) return;
     const storageStatePath = await loadPersistedStorageState(profileDir, userId, logger);
     if (storageStatePath) {
       contextOptions.storageState = storageStatePath;
@@ -140,7 +155,9 @@ export async function register(app, ctx, pluginConfig = {}) {
   events.on('session:destroying', async ({ userId, reason }) => {
     const context = activeSessions.get(userId);
     if (context) {
-      await checkpoint(userId, context, reason).catch(() => {});
+      if (reason !== 'storage_reset') {
+        await checkpoint(userId, context, reason).catch(() => {});
+      }
       activeSessions.delete(userId);
     }
   });
@@ -158,24 +175,35 @@ export async function register(app, ctx, pluginConfig = {}) {
     activeSessions.clear();
   });
 
-  app.delete('/sessions/:userId/cookies', ctx.auth(), async (req, res) => {
+  app.delete('/sessions/:userId/storage_state', ctx.auth(), async (req, res) => {
     const userId = ctx.normalizeUserId(req.params.userId);
+    if (resettingUsers.has(userId)) {
+      return res.status(409).json({ error: 'storage state reset already in progress' });
+    }
+
+    resettingUsers.add(userId);
     try {
-      const context = activeSessions.get(userId);
-      const clearedLive = Boolean(context);
-      if (context) await context.clearCookies();
+      const clearedLive = await ctx.destroySession(userId, { reason: 'storage_reset' });
+      await checkpointPromises.get(userId)?.catch(() => {});
 
       const { storageStatePath, metaPath } = getUserPersistencePaths(profileDir, userId);
       const removedPersisted = await removeIfExists(storageStatePath);
       await removeIfExists(metaPath);
 
-      log('info', 'session cookies cleared', { reqId: req.reqId, userId, clearedLive, removedPersisted });
+      log('info', 'session storage state reset', {
+        reqId: req.reqId,
+        userId,
+        clearedLive,
+        removedPersisted,
+      });
       res.json({ ok: true, userId, clearedLive, removedPersisted });
     } catch (err) {
-      log('error', 'clear cookies failed', { reqId: req.reqId, userId, error: err.message });
+      log('error', 'storage state reset failed', { reqId: req.reqId, userId, error: err.message });
       res.status(500).json({ error: ctx.safeError(err) });
+    } finally {
+      resettingUsers.delete(userId);
     }
   });
 
-  log('info', 'persistence plugin: registered DELETE /sessions/:userId/cookies');
+  log('info', 'persistence plugin: registered DELETE /sessions/:userId/storage_state');
 }

--- a/plugins/persistence/index.js
+++ b/plugins/persistence/index.js
@@ -23,12 +23,23 @@
  * via the session:creating hook (mutates contextOptions.storageState).
  */
 
+import fs from 'node:fs/promises';
 import {
   getUserPersistencePaths,
   loadPersistedStorageState,
   persistStorageState,
 } from '../../lib/persistence.js';
 import { importBootstrapCookies } from '../../lib/cookies.js';
+
+async function removeIfExists(p) {
+  try {
+    await fs.unlink(p);
+    return true;
+  } catch (err) {
+    if (err?.code === 'ENOENT') return false;
+    throw err;
+  }
+}
 
 export async function register(app, ctx, pluginConfig = {}) {
   const { events, config, log } = ctx;
@@ -121,4 +132,25 @@ export async function register(app, ctx, pluginConfig = {}) {
     }
     activeSessions.clear();
   });
+
+  app.delete('/sessions/:userId/cookies', ctx.auth(), async (req, res) => {
+    const userId = ctx.normalizeUserId(req.params.userId);
+    try {
+      const context = activeSessions.get(userId);
+      const clearedLive = Boolean(context);
+      if (context) await context.clearCookies();
+
+      const { storageStatePath, metaPath } = getUserPersistencePaths(profileDir, userId);
+      const removedPersisted = await removeIfExists(storageStatePath);
+      await removeIfExists(metaPath);
+
+      log('info', 'session cookies cleared', { reqId: req.reqId, userId, clearedLive, removedPersisted });
+      res.json({ ok: true, userId, clearedLive, removedPersisted });
+    } catch (err) {
+      log('error', 'clear cookies failed', { reqId: req.reqId, userId, error: err.message });
+      res.status(500).json({ error: ctx.safeError(err) });
+    }
+  });
+
+  log('info', 'persistence plugin: registered DELETE /sessions/:userId/cookies');
 }

--- a/plugins/persistence/plugin.test.js
+++ b/plugins/persistence/plugin.test.js
@@ -11,11 +11,14 @@ describe('persistence plugin', () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'camofox-persist-plugin-'));
     events = createPluginEvents();
-    mockApp = {};
+    mockApp = { delete: jest.fn() };
     ctx = {
       events,
       config: { cookiesDir: path.join(tmpDir, 'cookies') },
       log: jest.fn(),
+      auth: () => (req, res, next) => next(),
+      normalizeUserId: (u) => String(u),
+      safeError: (err) => err.message,
     };
   });
 
@@ -81,6 +84,48 @@ describe('persistence plugin', () => {
     await events.emitAsync('session:destroying', { userId: 'user-3', reason: 'test' });
 
     expect(mockContext.storageState).toHaveBeenCalled();
+  });
+
+  test('DELETE /sessions/:userId/cookies clears live cookies and removes persisted state', async () => {
+    await register(mockApp, ctx, { profileDir: tmpDir });
+
+    const call = mockApp.delete.mock.calls.find(c => c[0] === '/sessions/:userId/cookies');
+    expect(call).toBeTruthy();
+    const handler = call[call.length - 1];
+
+    const { getUserPersistencePaths } = await import('../../lib/persistence.js');
+    const { userDir, storageStatePath, metaPath } = getUserPersistencePaths(tmpDir, 'user-4');
+    await fs.mkdir(userDir, { recursive: true });
+    await fs.writeFile(storageStatePath, JSON.stringify({
+      cookies: [{ name: 'sid', value: 'a', domain: '.x.com', path: '/' }],
+      origins: [],
+    }));
+    await fs.writeFile(metaPath, JSON.stringify({ userId: 'user-4' }));
+
+    const mockContext = { clearCookies: jest.fn(async () => {}) };
+    await events.emitAsync('session:created', { userId: 'user-4', context: mockContext });
+
+    const res = { json: jest.fn(), status: jest.fn(function () { return this; }) };
+    await handler({ params: { userId: 'user-4' } }, res);
+
+    expect(mockContext.clearCookies).toHaveBeenCalled();
+    await expect(fs.access(storageStatePath)).rejects.toBeTruthy();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: true, clearedLive: true, removedPersisted: true })
+    );
+  });
+
+  test('DELETE cookies route is a no-op without a live session or persisted file', async () => {
+    await register(mockApp, ctx, { profileDir: tmpDir });
+    const call = mockApp.delete.mock.calls.find(c => c[0] === '/sessions/:userId/cookies');
+    const handler = call[call.length - 1];
+
+    const res = { json: jest.fn(), status: jest.fn(function () { return this; }) };
+    await handler({ params: { userId: 'nobody' } }, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: true, clearedLive: false, removedPersisted: false })
+    );
   });
 
   test('env var CAMOFOX_PROFILE_DIR overrides pluginConfig', async () => {

--- a/plugins/persistence/plugin.test.js
+++ b/plugins/persistence/plugin.test.js
@@ -19,6 +19,11 @@ describe('persistence plugin', () => {
       auth: () => (req, res, next) => next(),
       normalizeUserId: (u) => String(u),
       safeError: (err) => err.message,
+      destroySession: jest.fn(async (userId, { reason } = {}) => {
+        await events.emitAsync('session:destroying', { userId: String(userId), reason });
+        await events.emitAsync('session:destroyed', { userId: String(userId), reason });
+        return true;
+      }),
     };
   });
 
@@ -104,46 +109,93 @@ describe('persistence plugin', () => {
     expect(mockContext.storageState).toHaveBeenCalled();
   });
 
-  test('DELETE /sessions/:userId/cookies clears live cookies and removes persisted state', async () => {
+  test('DELETE storage_state destroys the live session without checkpointing and removes persisted state', async () => {
     await register(mockApp, ctx, { profileDir: tmpDir });
 
-    const call = mockApp.delete.mock.calls.find(c => c[0] === '/sessions/:userId/cookies');
+    const call = mockApp.delete.mock.calls.find(c => c[0] === '/sessions/:userId/storage_state');
     expect(call).toBeTruthy();
-    const handler = call[call.length - 1];
+    const handler = call.at(-1);
 
     const { getUserPersistencePaths } = await import('../../lib/persistence.js');
     const { userDir, storageStatePath, metaPath } = getUserPersistencePaths(tmpDir, 'user-4');
     await fs.mkdir(userDir, { recursive: true });
     await fs.writeFile(storageStatePath, JSON.stringify({
       cookies: [{ name: 'sid', value: 'a', domain: '.x.com', path: '/' }],
-      origins: [],
+      origins: [{
+        origin: 'https://x.com',
+        localStorage: [{ name: 'token', value: 'secret' }],
+        indexedDB: [{ name: 'auth', version: 1, stores: [] }],
+      }],
     }));
     await fs.writeFile(metaPath, JSON.stringify({ userId: 'user-4' }));
 
-    const mockContext = { clearCookies: jest.fn(async () => {}) };
+    const mockContext = { storageState: jest.fn() };
     await events.emitAsync('session:created', { userId: 'user-4', context: mockContext });
 
     const res = { json: jest.fn(), status: jest.fn(function () { return this; }) };
     await handler({ params: { userId: 'user-4' } }, res);
 
-    expect(mockContext.clearCookies).toHaveBeenCalled();
-    await expect(fs.access(storageStatePath)).rejects.toBeTruthy();
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ ok: true, clearedLive: true, removedPersisted: true })
-    );
+    expect(ctx.destroySession).toHaveBeenCalledWith('user-4', { reason: 'storage_reset' });
+    expect(mockContext.storageState).not.toHaveBeenCalled();
+    await expect(fs.access(storageStatePath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.access(metaPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(res.json).toHaveBeenCalledWith({
+      ok: true,
+      userId: 'user-4',
+      clearedLive: true,
+      removedPersisted: true,
+    });
   });
 
-  test('DELETE cookies route is a no-op without a live session or persisted file', async () => {
+  test('DELETE storage_state waits for an in-flight checkpoint before deleting', async () => {
     await register(mockApp, ctx, { profileDir: tmpDir });
-    const call = mockApp.delete.mock.calls.find(c => c[0] === '/sessions/:userId/cookies');
-    const handler = call[call.length - 1];
+    const handler = mockApp.delete.mock.calls
+      .find(c => c[0] === '/sessions/:userId/storage_state')
+      .at(-1);
+
+    let finishCheckpoint;
+    let markCheckpointStarted;
+    const checkpointBlocked = new Promise(resolve => { finishCheckpoint = resolve; });
+    const checkpointStarted = new Promise(resolve => { markCheckpointStarted = resolve; });
+    const mockContext = {
+      storageState: jest.fn(async ({ path: targetPath }) => {
+        markCheckpointStarted();
+        await checkpointBlocked;
+        await fs.writeFile(targetPath, JSON.stringify({ cookies: [], origins: [] }));
+      }),
+    };
+    await events.emitAsync('session:created', { userId: 'user-race', context: mockContext });
+    const checkpoint = events.emitAsync('session:cookies:import', { userId: 'user-race' });
+    await checkpointStarted;
+
+    const res = { json: jest.fn(), status: jest.fn(function () { return this; }) };
+    const reset = handler({ params: { userId: 'user-race' } }, res);
+    await Promise.resolve();
+    expect(res.json).not.toHaveBeenCalled();
+
+    finishCheckpoint();
+    await Promise.all([checkpoint, reset]);
+
+    const { getUserPersistencePaths } = await import('../../lib/persistence.js');
+    const { storageStatePath } = getUserPersistencePaths(tmpDir, 'user-race');
+    await expect(fs.access(storageStatePath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  test('DELETE storage_state is idempotent without a live session or persisted file', async () => {
+    ctx.destroySession.mockResolvedValueOnce(false);
+    await register(mockApp, ctx, { profileDir: tmpDir });
+    const call = mockApp.delete.mock.calls.find(c => c[0] === '/sessions/:userId/storage_state');
+    const handler = call.at(-1);
 
     const res = { json: jest.fn(), status: jest.fn(function () { return this; }) };
     await handler({ params: { userId: 'nobody' } }, res);
 
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ ok: true, clearedLive: false, removedPersisted: false })
-    );
+    expect(res.json).toHaveBeenCalledWith({
+      ok: true,
+      userId: 'nobody',
+      clearedLive: false,
+      removedPersisted: false,
+    });
   });
 
   test('env var CAMOFOX_PROFILE_DIR overrides pluginConfig', async () => {

--- a/server.js
+++ b/server.js
@@ -1369,7 +1369,7 @@ function handleRouteError(err, req, res, extraFields = {}) {
     return res.status(410).json({ error: 'Page crashed. Open a new tab.', code: 'page_crashed', retryable: true, recovery: 'create_new_tab', ...extraFields });
   }
   if (userId && isDeadContextError(err)) {
-    destroySession(userId);
+    destroySession(userId).catch(() => {});
   }
   // Proxy errors mean the session is dead -- rotate at context level.
   // Destroy the user's session so the next request gets a fresh context with a new proxy.
@@ -1378,7 +1378,7 @@ function handleRouteError(err, req, res, extraFields = {}) {
       action, userId, error: err.message,
     });
     browserRestartsTotal.labels('proxy_error').inc();
-    destroySession(userId);
+    destroySession(userId).catch(() => {});
   }
   // Navigation-related timeouts can poison the proxy session (e.g., Cloudflare holding
   // the connection open for 30s). The browser context shares a single proxy session, so
@@ -1390,7 +1390,7 @@ function handleRouteError(err, req, res, extraFields = {}) {
       action, userId, error: err.message,
     });
     browserRestartsTotal.labels('navigation_timeout').inc();
-    destroySession(userId);
+    destroySession(userId).catch(() => {});
   }
   // Track consecutive timeouts per tab and auto-destroy stuck tabs
   // (for non-navigation timeouts like type, scroll that don't poison the proxy)
@@ -1523,13 +1523,14 @@ async function recycleOldestTab(session, reqId, userId) {
   return { recycledTabId: oldestTabId, recycledFromGroup: oldestGroupKey };
 }
 
-function destroySession(userId) {
+async function destroySession(userId, { reason = 'destroy_session' } = {}) {
   const key = normalizeUserId(userId);
   const session = sessions.get(key);
-  if (!session) return;
-  log('warn', 'destroying dead session', { userId: key });
+  if (!session) return false;
+  log('warn', 'destroying session', { userId: key, reason });
   sessions.delete(key);
-  closeSession(key, session, { reason: 'destroy_session', clearDownloads: true, clearLocks: true }).catch(() => {});
+  await closeSession(key, session, { reason, clearDownloads: true, clearLocks: true });
+  return true;
 }
 
 function findTab(session, tabId) {


### PR DESCRIPTION
## What
Adds `DELETE /sessions/:userId/cookies`, registered by the persistence plugin.
It forgets a user's persisted auth by deleting the persisted storage-state file
and clearing the live context's cookies when a session is active, so the next
session for that userId starts logged out.

## Why
There is no supported way to reset a persisted session to a logged-out state.
`POST /sessions/:userId/cookies` only imports (adds) cookies, and
`DELETE /sessions/:userId` tears the session down but the persistence plugin
checkpoints storage state on `session:destroying`, so cookies get re-persisted
and restored on the next createTab. Agents needing a forced fresh login
(expired session, account switch) had no primitive for it.

## Implementation
The route lives in the persistence plugin because that plugin already owns
profileDir resolution and the storage-state file layout, so it deletes exactly
the file the restore path reads. When a live context exists it also calls
context.clearCookies() so a later checkpoint cannot re-persist the stale login.
Auth reuses ctx.auth() like the other session endpoints. Unit tests cover the
live-session, no-session, and missing-file cases.

## Response
{ ok, userId, clearedLive, removedPersisted }
