### PR TITLE
fix: Firefox CDP compatibility - display init and viewport isMobile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ COPY camofox.config.json ./
 COPY lib/ ./lib/
 COPY plugins/ ./plugins/
 COPY scripts/ ./scripts/
+COPY patch-firefox-cdp.sh ./
 
 # Install default plugin dependencies (apt packages + post-install hooks)
 RUN sh scripts/install-plugin-deps.sh
@@ -75,7 +76,7 @@ ENV CAMOFOX_PORT=9377
 
 EXPOSE 9377
 
-CMD ["sh", "-c", "node --max-old-space-size=${MAX_OLD_SPACE_SIZE:-128} server.js"]
+CMD ["sh", "-c", "sh patch-firefox-cdp.sh && node --max-old-space-size=${MAX_OLD_SPACE_SIZE:-128} server.js"]
 
 # Optional: rebuild plugin deps after adding third-party plugins
 # Usage: docker build --target with-plugins -t camofox-browser .

--- a/patch-firefox-cdp.sh
+++ b/patch-firefox-cdp.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Patch playwright-core's Firefox CDP viewport call to strip isMobile
+# Firefox CDP rejects isMobile in Browser.setDefaultViewport, causing tab creation to fail.
+PBUNDLE="node_modules/playwright-core/lib/coreBundle.js"
+if [ -f "$PBUNDLE" ]; then
+  # Remove the "isMobile: !!this._options.isMobile" line from the viewport object
+  sed -i '/isMobile: !!this._options.isMobile/d' "$PBUNDLE"
+fi
+exec "$@"

--- a/server.js
+++ b/server.js
@@ -952,7 +952,7 @@ async function launchBrowserInstance() {
     try {
       if (os.platform() === 'linux') {
         localVirtualDisplay = pluginCtx.createVirtualDisplay();
-        vdDisplay = localVirtualDisplay.get();
+        vdDisplay = await localVirtualDisplay.get();
         log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
       }
     } catch (err) {


### PR DESCRIPTION
Fixes were required to successfully deploy camofox-browser in a docker container with functional noVNC.html.
   
I'm using camofox-browser deployed as a container alongside hermes agent, both within a docker sbx shell on a LAN Linux server and me accessing the noVNC webpage from my macbook os tahoe chrome browser.  

Hermes driven by qwen3.6-27B-FP8 found and implemented the necessary fix, guided, reviewed, and tested by me.

To clear my own confusion, firefox support is being patched here as camofox is based on firefox.

----------------- ----------------- ----------------- ----------------- ----------------- -----------------

  The fix was two part:     
   
   Fix 1: server.js line 955 — Add await to localVirtualDisplay.get()

    Problem: The VirtualDisplay.get() method is async. Without await, it returns a Promise object. That Promise gets assigned to the DISPLAY environment variable, so Firefox starts with DISPLAY=[object Promise] instead of DISPLAY=:0, which crashes with cannot open display: [object Promise].
    
    Fix: vdDisplay = await localVirtualDisplay.get();
    
    Affects: All browsers (Firefox, Chrome, etc.) — this is a pure server.js bug.
    
    ----------------- ----------------- ----------------- ----------------- ----------------- -----------------
    
    Fix 2: patch-firefox-cdp.sh + Dockerfile — Strip isMobile from Firefox CDP viewport call
    
    Problem: Playwright-core's bundled code (coreBundle.js) builds a viewport object that includes isMobile: !!this._options.isMobile and sends it to Firefox via the Browser.setDefaultViewport CDP command. Firefox's Juggler CDP implementation rejects unknown properties and throws: Found property isMobile - false which is not described in this scheme. This causes every tab creation to fail with "Internal server error".
    
    Chrome/Chromium accepts isMobile fine — this is Firefox-only.
    
    Fix: A startup shell script that runs sed to delete the isMobile line from coreBundle.js before the server starts. The Dockerfile CMD was updated to run this script first: sh patch-firefox-cdp.sh && node server.js.
    
    Why a script instead of editing coreBundle.js directly? Because coreBundle.js lives inside node_modules/playwright-core and is installed at Docker build time from npm. It's not committed to the repo, so we can't patch it in git. The script patches it at container startup, which is idempotent and survives rebuilds.
    
    Please note: the patch-firefox-cdp.sh approach is a runtime workaround since coreBundle.js lives in node_modules. A more permanent fix would be upstream in playwright-core or a monkey-patch in server.js, but this is the least-invasive approach for now.
    
    
    Files changed (3):
    
    | File                 | Change                                                        |
    |----------------------|---------------------------------------------------------------|
    | server.js            | Added await to localVirtualDisplay.get()                      |
    | patch-firefox-cdp.sh | New script that strips isMobile from coreBundle.js at startup |
    | Dockerfile           | COPY the script + run it before node server.js in CMD         |

