### PR TITLE
feat(persistence): opt-in periodic storage-state checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ By default, camofox persists each user's cookies and localStorage to `~/.camofox
 
 Override the directory with `CAMOFOX_PROFILE_DIR` or set `"profileDir"` in the persistence plugin config. To disable persistence, set `"persistence": { "enabled": false }` in `camofox.config.json`.
 
+Opt-in periodic checkpointing (default-off):
+
+- `checkpointIntervalMs` / `CAMOFOX_CHECKPOINT_INTERVAL_MS` -- periodically checkpoint all active sessions on this interval, in addition to the existing checkpoint-on-close/shutdown, so an ungraceful crash (OOM/SIGKILL) only loses state since the last periodic checkpoint.
+
 ### Session Tracing
 
 Capture a Playwright trace of every action in a session: page screenshots, DOM snapshots, network requests, and console output. Output is a single `.zip` file you can open in Playwright's built-in Trace Viewer.
@@ -617,6 +621,7 @@ Reddit macros return JSON directly (no HTML parsing needed):
 | `CAMOFOX_EXECUTABLE_PATH` | Compatibility alias for `CAMOUFOX_EXECUTABLE` | - |
 | `CAMOFOX_COOKIES_DIR` | Directory for cookie files | `~/.camofox/cookies` |
 | `CAMOFOX_PROFILE_DIR` | Directory for persisted session profiles | `~/.camofox/profiles` |
+| `CAMOFOX_CHECKPOINT_INTERVAL_MS` | Periodic storage-state checkpoint interval, in ms (0/unset = off) | `0` |
 | `CAMOFOX_TRACES_DIR` | Directory for session trace zips | `~/.camofox/traces` |
 | `CAMOFOX_TRACES_MAX_BYTES` | Max size per trace, removed on next startup if exceeded | `52428800` (50MB) |
 | `CAMOFOX_TRACES_TTL_HOURS` | Traces older than this are swept on startup | `24` |

--- a/plugins/persistence/AGENTS.md
+++ b/plugins/persistence/AGENTS.md
@@ -7,8 +7,9 @@ Saves and restores per-user browser storage state (cookies + localStorage) acros
 - `session:creating` hook → loads saved `storage_state.json` into `contextOptions.storageState`
 - `session:created` hook → imports bootstrap cookies if no persisted state exists
 - `session:cookies:import` / `session:destroyed` / `server:shutdown` → checkpoints state to disk
+- Optional `checkpointIntervalMs` timer → periodically checkpoints all active sessions, bounding data loss on an ungraceful crash
 
-All hooks are async and awaited via `emitAsync()` — storage state is guaranteed loaded before the context is created.
+All hooks are async and awaited via `emitAsync()` — storage state is guaranteed loaded before the context is created. Checkpoints are guarded against overlap per-userId (`checkpointsInFlight`), so the periodic timer and an event-driven checkpoint never race each other.
 
 ## Key Files
 
@@ -27,6 +28,10 @@ All hooks are async and awaited via `emitAsync()` — storage state is guarantee
 ## Configuration
 
 Enabled by default. Override profile directory with `CAMOFOX_PROFILE_DIR` env var or `"profileDir"` in plugin config. To disable: `"persistence": { "enabled": false }` in `camofox.config.json`.
+
+Opt-in periodic checkpointing, default-off (zero behavior change when unset):
+
+- `checkpointIntervalMs` / `CAMOFOX_CHECKPOINT_INTERVAL_MS` — periodic checkpoint interval in ms.
 
 ## Original Contributors
 

--- a/plugins/persistence/README.md
+++ b/plugins/persistence/README.md
@@ -13,23 +13,28 @@ In `camofox.config.json`:
   "plugins": {
     "persistence": {
       "enabled": true,
-      "profileDir": "/data/profiles"
+      "profileDir": "/data/profiles",
+      "checkpointIntervalMs": 60000
     }
   }
 }
 ```
 
-Or override via environment variable:
+Or override via environment variables:
 
 ```
 CAMOFOX_PROFILE_DIR=/data/profiles
+CAMOFOX_CHECKPOINT_INTERVAL_MS=60000
 ```
+
+- `checkpointIntervalMs` (default: off) — when set to a positive number, all active sessions are additionally checkpointed on a timer, bounding data loss on an ungraceful crash (OOM/SIGKILL) to the checkpoint interval instead of everything since the last teardown.
 
 ## How it works
 
 - **Session create**: If a persisted `storageState` exists for the `userId`, it's restored into the new Playwright context.
 - **First run**: If no persisted state exists, bootstrap cookies from `CAMOFOX_COOKIES_DIR/cookies.txt` are imported (if present).
 - **Cookie import / session close / shutdown**: Storage state is checkpointed to disk via atomic tmp-write + rename.
+- **Periodic (opt-in)**: If `checkpointIntervalMs` is set, all active sessions are also checkpointed on that interval.
 - **User isolation**: Each `userId` maps to a deterministic SHA256-hashed subdirectory under `profileDir`, so arbitrary userIds are path-safe.
 
 ## Docker

--- a/plugins/persistence/index.js
+++ b/plugins/persistence/index.js
@@ -9,18 +9,25 @@
  *     "plugins": {
  *       "persistence": {
  *         "enabled": true,
- *         "profileDir": "/data/profiles"
+ *         "profileDir": "/data/profiles",
+ *         "checkpointIntervalMs": 60000
  *       }
  *     }
  *   }
  *
  * Or via environment variables (overrides config file):
  *   CAMOFOX_PROFILE_DIR=/data/profiles
+ *   CAMOFOX_CHECKPOINT_INTERVAL_MS=60000
  *
  * Each userId gets a deterministic SHA256-hashed subdirectory under profileDir.
  * Storage state is checkpointed on cookie import, session close, and shutdown.
  * On session creation, saved state is restored into the new Playwright context
  * via the session:creating hook (mutates contextOptions.storageState).
+ *
+ * checkpointIntervalMs (default: 0/off): when > 0, all active sessions are
+ * additionally checkpointed on a timer, so an ungraceful crash (OOM/SIGKILL)
+ * only loses state since the last periodic checkpoint instead of everything
+ * since the last teardown.
  */
 
 import {
@@ -40,25 +47,40 @@ export async function register(app, ctx, pluginConfig = {}) {
     return;
   }
 
+  // Resolve checkpointIntervalMs: env var > plugin config > off (0)
+  const checkpointIntervalMs =
+    parseInt(process.env.CAMOFOX_CHECKPOINT_INTERVAL_MS, 10) ||
+    parseInt(pluginConfig.checkpointIntervalMs, 10) ||
+    0;
+
   const logger = {
     warn: (msg, fields = {}) => log('warn', msg, fields),
   };
 
-  log('info', 'persistence plugin enabled', { profileDir });
+  log('info', 'persistence plugin enabled', { profileDir, checkpointIntervalMs });
 
   // Track active sessions for checkpoint on close
   const activeSessions = new Map(); // userId -> context
+  // Guard against overlapping checkpoints (periodic timer racing an
+  // event-driven checkpoint) for the same userId.
+  const checkpointsInFlight = new Set();
 
   /**
    * Checkpoint storage state to disk for a userId.
    */
   async function checkpoint(userId, context, reason) {
     if (!context) return;
-    const result = await persistStorageState({ profileDir, userId, context, logger });
-    if (result.persisted) {
-      log('info', 'storage state persisted', { userId, reason, path: result.storageStatePath });
+    if (checkpointsInFlight.has(userId)) return;
+    checkpointsInFlight.add(userId);
+    try {
+      const result = await persistStorageState({ profileDir, userId, context, logger });
+      if (result.persisted) {
+        log('info', 'storage state persisted', { userId, reason, path: result.storageStatePath });
+      }
+      return result;
+    } finally {
+      checkpointsInFlight.delete(userId);
     }
-    return result;
   }
 
   // --- Lifecycle hooks ---
@@ -114,8 +136,25 @@ export async function register(app, ctx, pluginConfig = {}) {
     activeSessions.delete(userId);
   });
 
+  // Periodic checkpoint: bounds data loss on ungraceful crashes (OOM/SIGKILL)
+  // to the checkpoint interval instead of "since the last teardown".
+  let checkpointTimer;
+  if (checkpointIntervalMs > 0) {
+    checkpointTimer = setInterval(async () => {
+      for (const [userId, context] of activeSessions) {
+        await checkpoint(userId, context, 'periodic').catch(() => {});
+      }
+    }, checkpointIntervalMs);
+    checkpointTimer.unref?.();
+    log('info', 'persistence periodic checkpoint enabled', { checkpointIntervalMs });
+  }
+
   // On shutdown: checkpoint all remaining sessions
   events.on('server:shutdown', async () => {
+    if (checkpointTimer) {
+      clearInterval(checkpointTimer);
+      checkpointTimer = undefined;
+    }
     for (const [userId, context] of activeSessions) {
       await checkpoint(userId, context, 'shutdown').catch(() => {});
     }

--- a/plugins/persistence/plugin.test.js
+++ b/plugins/persistence/plugin.test.js
@@ -89,10 +89,48 @@ describe('persistence plugin', () => {
     process.env.CAMOFOX_PROFILE_DIR = envDir;
     try {
       await register(mockApp, ctx, { profileDir: '/should/not/use' });
-      expect(ctx.log).toHaveBeenCalledWith('info', 'persistence plugin enabled', { profileDir: envDir });
+      expect(ctx.log).toHaveBeenCalledWith(
+        'info',
+        'persistence plugin enabled',
+        expect.objectContaining({ profileDir: envDir })
+      );
     } finally {
       if (orig === undefined) delete process.env.CAMOFOX_PROFILE_DIR;
       else process.env.CAMOFOX_PROFILE_DIR = orig;
     }
   });
+
+  test('periodic checkpointIntervalMs is off by default (no timer set)', async () => {
+    await register(mockApp, ctx, { profileDir: tmpDir });
+    expect(ctx.log).toHaveBeenCalledWith(
+      'info',
+      'persistence plugin enabled',
+      expect.objectContaining({ checkpointIntervalMs: 0 })
+    );
+    expect(ctx.log).not.toHaveBeenCalledWith(
+      'info',
+      'persistence periodic checkpoint enabled',
+      expect.anything()
+    );
+  });
+
+  test('checkpointIntervalMs > 0 periodically checkpoints active sessions', async () => {
+    await register(mockApp, ctx, { profileDir: tmpDir, checkpointIntervalMs: 20 });
+
+    const mockContext = {
+      storageState: jest.fn(async ({ path: p }) => {
+        await fs.writeFile(p, JSON.stringify({ cookies: [], origins: [] }));
+      }),
+    };
+    await events.emitAsync('session:created', { userId: 'user-periodic', context: mockContext });
+    mockContext.storageState.mockClear();
+
+    // Wait for at least one real periodic tick.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(mockContext.storageState.mock.calls.length).toBeGreaterThanOrEqual(1);
+
+    await events.emitAsync('server:shutdown');
+  });
+
 });


### PR DESCRIPTION
## Motivation

The persistence plugin currently checkpoints storage state only on cookie import, session teardown (`session:destroying`), and process shutdown (`server:shutdown`). An ungraceful crash (OOM, SIGKILL) between those points loses everything accumulated since the last checkpoint — including a login that happened seconds before the crash.

## What's added

An opt-in flag on the persistence plugin, **default-off, preserving current behavior exactly when unset**:

- `checkpointIntervalMs` / `CAMOFOX_CHECKPOINT_INTERVAL_MS` — when set to a positive number, all active sessions are additionally checkpointed on a timer via the existing `checkpoint(userId, context, 'periodic')` path, bounding crash data loss to the checkpoint interval instead of "since the last teardown". The timer is `unref()`'d and cleared on `server:shutdown`.

The flag follows the existing env-var-overrides-config pattern used for `profileDir`/`CAMOFOX_PROFILE_DIR`.

Periodic checkpoints are guarded against racing an event-driven checkpoint for the same `userId` (a `checkpointsInFlight` set), since `checkpoint()` is now called from two triggers instead of one.

This builds on the `session:destroying` event's stated purpose — its v1.7.2 release notes describe it as being introduced explicitly "for persistence checkpoints" — by adding a second checkpoint trigger to the same code path rather than a new mechanism.

Note: companion PR adding IndexedDB storage-state support touches adjacent lines in the same files (option resolution block, "persistence plugin enabled" log fields, docs); whichever lands second will need a trivial rebase.

## Testing

- Extended `plugins/persistence/plugin.test.js`: periodic checkpoint off by default, and periodic checkpoint firing for active sessions on the configured interval. Also loosened one pre-existing assertion (`toHaveBeenCalledWith`) to `expect.objectContaining` since the "plugin enabled" log now carries the new field.
- `npm test` (full suite, excluding `tests/e2e` and `tests/live` which need a real browser/network): 45 suites, 695 tests, all passing.
- No lint script/config exists in this repo, so none was run.