### PR TITLE
feat(persistence): include IndexedDB in persisted storage state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,7 +378,7 @@ export function register(app, ctx) {
 | Event | Payload |
 |-------|---------|
 | `session:cookies:import` | `{ userId, count }` |
-| `session:storage:export` | `{ userId }` |
+| `session:storage:export` | `{ userId, storageState }` |
 
 #### Server
 | Event | Payload |

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ By default, camofox persists each user's cookies and localStorage to `~/.camofox
 
 Override the directory with `CAMOFOX_PROFILE_DIR` or set `"profileDir"` in the persistence plugin config. To disable persistence, set `"persistence": { "enabled": false }` in `camofox.config.json`.
 
-Storage state includes IndexedDB by default, so logins on sites that keep auth in IndexedDB (e.g. Firebase Auth) survive restarts. Set `CAMOFOX_PERSIST_INDEXEDDB=false` (or `"indexedDB": false` in the plugin config) to restore the previous cookies+localStorage-only behavior.
+By default, storage state contains cookies and localStorage only. To also persist IndexedDB, set `"indexedDB": true` in the persistence plugin config. This captures all serializable IndexedDB records—not only authentication data—and may make snapshots significantly larger and checkpoints slower.
 
 ### Session Tracing
 
@@ -619,7 +619,6 @@ Reddit macros return JSON directly (no HTML parsing needed):
 | `CAMOFOX_EXECUTABLE_PATH` | Compatibility alias for `CAMOUFOX_EXECUTABLE` | - |
 | `CAMOFOX_COOKIES_DIR` | Directory for cookie files | `~/.camofox/cookies` |
 | `CAMOFOX_PROFILE_DIR` | Directory for persisted session profiles | `~/.camofox/profiles` |
-| `CAMOFOX_PERSIST_INDEXEDDB` | Include IndexedDB in persisted storage state (`false` to disable) | `true` |
 | `CAMOFOX_TRACES_DIR` | Directory for session trace zips | `~/.camofox/traces` |
 | `CAMOFOX_TRACES_MAX_BYTES` | Max size per trace, removed on next startup if exceeded | `52428800` (50MB) |
 | `CAMOFOX_TRACES_TTL_HOURS` | Traces older than this are swept on startup | `24` |

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ By default, camofox persists each user's cookies and localStorage to `~/.camofox
 
 Override the directory with `CAMOFOX_PROFILE_DIR` or set `"profileDir"` in the persistence plugin config. To disable persistence, set `"persistence": { "enabled": false }` in `camofox.config.json`.
 
+Storage state includes IndexedDB by default, so logins on sites that keep auth in IndexedDB (e.g. Firebase Auth) survive restarts. Set `CAMOFOX_PERSIST_INDEXEDDB=false` (or `"indexedDB": false` in the plugin config) to restore the previous cookies+localStorage-only behavior.
+
 ### Session Tracing
 
 Capture a Playwright trace of every action in a session: page screenshots, DOM snapshots, network requests, and console output. Output is a single `.zip` file you can open in Playwright's built-in Trace Viewer.
@@ -617,6 +619,7 @@ Reddit macros return JSON directly (no HTML parsing needed):
 | `CAMOFOX_EXECUTABLE_PATH` | Compatibility alias for `CAMOUFOX_EXECUTABLE` | - |
 | `CAMOFOX_COOKIES_DIR` | Directory for cookie files | `~/.camofox/cookies` |
 | `CAMOFOX_PROFILE_DIR` | Directory for persisted session profiles | `~/.camofox/profiles` |
+| `CAMOFOX_PERSIST_INDEXEDDB` | Include IndexedDB in persisted storage state (`false` to disable) | `true` |
 | `CAMOFOX_TRACES_DIR` | Directory for session trace zips | `~/.camofox/traces` |
 | `CAMOFOX_TRACES_MAX_BYTES` | Max size per trace, removed on next startup if exceeded | `52428800` (50MB) |
 | `CAMOFOX_TRACES_TTL_HOURS` | Traces older than this are swept on startup | `24` |

--- a/lib/persistence-config.js
+++ b/lib/persistence-config.js
@@ -1,5 +1,0 @@
-function resolvePersistenceIndexedDB(pluginConfig = {}) {
-  return pluginConfig.indexedDB === true;
-}
-
-export { resolvePersistenceIndexedDB };

--- a/lib/persistence-config.js
+++ b/lib/persistence-config.js
@@ -1,0 +1,5 @@
+function resolvePersistenceIndexedDB(pluginConfig = {}) {
+  return pluginConfig.indexedDB === true;
+}
+
+export { resolvePersistenceIndexedDB };

--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -47,7 +47,7 @@ async function persistStorageState({
   userId,
   context,
   logger = console,
-  indexedDB = true,
+  indexedDB = false,
 }) {
   if (!profileDir || !context) {
     return { persisted: false, reason: 'disabled' };

--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -46,10 +46,11 @@ async function persistStorageState({
   profileDir,
   userId,
   context,
+  storageState,
   logger = console,
   indexedDB = false,
 }) {
-  if (!profileDir || !context) {
+  if (!profileDir || (!context && !storageState)) {
     return { persisted: false, reason: 'disabled' };
   }
 
@@ -60,7 +61,11 @@ async function persistStorageState({
 
   try {
     await fs.mkdir(userDir, { recursive: true });
-    await context.storageState(indexedDB ? { path: tmpStoragePath, indexedDB: true } : { path: tmpStoragePath });
+    if (storageState) {
+      await fs.writeFile(tmpStoragePath, JSON.stringify(storageState, null, 2));
+    } else {
+      await context.storageState(indexedDB ? { path: tmpStoragePath, indexedDB: true } : { path: tmpStoragePath });
+    }
     await fs.rename(tmpStoragePath, storageStatePath);
     await fs.writeFile(
       tmpMetaPath,

--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -42,7 +42,13 @@ async function loadPersistedStorageState(profileDir, userId, logger = console) {
   }
 }
 
-async function persistStorageState({ profileDir, userId, context, logger = console }) {
+async function persistStorageState({
+  profileDir,
+  userId,
+  context,
+  logger = console,
+  indexedDB = true,
+}) {
   if (!profileDir || !context) {
     return { persisted: false, reason: 'disabled' };
   }
@@ -54,7 +60,7 @@ async function persistStorageState({ profileDir, userId, context, logger = conso
 
   try {
     await fs.mkdir(userDir, { recursive: true });
-    await context.storageState({ path: tmpStoragePath });
+    await context.storageState(indexedDB ? { path: tmpStoragePath, indexedDB: true } : { path: tmpStoragePath });
     await fs.rename(tmpStoragePath, storageStatePath);
     await fs.writeFile(
       tmpMetaPath,

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -46,7 +46,7 @@
  *
  *   COOKIES / AUTH
  *     session:cookies:import  { userId, count }
- *     session:storage:export  { userId }
+ *     session:storage:export  { userId, storageState }
  *
  *   SERVER
  *     server:starting         { port }
@@ -156,6 +156,9 @@ export async function loadPlugins(app, ctx, options = {}) {
   }
 
   const { list: allowList, configs: pluginConfigs } = readPluginConfig(configPath);
+  // Expose resolved per-plugin configuration so plugins that share an API
+  // contract (for example persistence and VNC storage export) stay consistent.
+  ctx.pluginConfigs = pluginConfigs;
   const entries = fs.readdirSync(pluginsDir, { withFileTypes: true });
 
   for (const entry of entries) {

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -156,9 +156,6 @@ export async function loadPlugins(app, ctx, options = {}) {
   }
 
   const { list: allowList, configs: pluginConfigs } = readPluginConfig(configPath);
-  // Expose resolved per-plugin configuration so plugins that share an API
-  // contract (for example persistence and VNC storage export) stay consistent.
-  ctx.pluginConfigs = pluginConfigs;
   const entries = fs.readdirSync(pluginsDir, { withFileTypes: true });
 
   for (const entry of entries) {

--- a/plugins/persistence/AGENTS.md
+++ b/plugins/persistence/AGENTS.md
@@ -1,6 +1,6 @@
 # Persistence Plugin — Agent Guide
 
-Saves and restores per-user browser storage state (cookies + localStorage + IndexedDB) across session restarts using Playwright's `storageState` API. Enabled by default — profiles persist to `~/.camofox/profiles/`.
+Saves and restores per-user browser storage state (cookies + localStorage, with optional IndexedDB) across session restarts using Playwright's `storageState` API. Enabled by default — profiles persist to `~/.camofox/profiles/`.
 
 ## How It Works
 
@@ -28,7 +28,7 @@ All hooks are async and awaited via `emitAsync()` — storage state is guarantee
 
 Enabled by default. Override profile directory with `CAMOFOX_PROFILE_DIR` env var or `"profileDir"` in plugin config. To disable: `"persistence": { "enabled": false }` in `camofox.config.json`.
 
-IndexedDB is included in persisted storage state by default (`indexedDB` / `CAMOFOX_PERSIST_INDEXEDDB`, default `true`) so IndexedDB-backed logins survive restarts; set to `false` to restore cookies+localStorage-only snapshots.
+IndexedDB persistence is opt-in (`"indexedDB": true` in the persistence plugin config). It captures all serializable IndexedDB records, not only authentication data, and may make snapshots significantly larger and checkpoints slower.
 
 ## Original Contributors
 

--- a/plugins/persistence/AGENTS.md
+++ b/plugins/persistence/AGENTS.md
@@ -1,6 +1,6 @@
 # Persistence Plugin — Agent Guide
 
-Saves and restores per-user browser storage state (cookies + localStorage) across session restarts using Playwright's `storageState` API. Enabled by default — profiles persist to `~/.camofox/profiles/`.
+Saves and restores per-user browser storage state (cookies + localStorage + IndexedDB) across session restarts using Playwright's `storageState` API. Enabled by default — profiles persist to `~/.camofox/profiles/`.
 
 ## How It Works
 
@@ -27,6 +27,8 @@ All hooks are async and awaited via `emitAsync()` — storage state is guarantee
 ## Configuration
 
 Enabled by default. Override profile directory with `CAMOFOX_PROFILE_DIR` env var or `"profileDir"` in plugin config. To disable: `"persistence": { "enabled": false }` in `camofox.config.json`.
+
+IndexedDB is included in persisted storage state by default (`indexedDB` / `CAMOFOX_PERSIST_INDEXEDDB`, default `true`) so IndexedDB-backed logins survive restarts; set to `false` to restore cookies+localStorage-only snapshots.
 
 ## Original Contributors
 

--- a/plugins/persistence/README.md
+++ b/plugins/persistence/README.md
@@ -2,7 +2,7 @@
 
 Optional per-user browser storage state persistence for camofox-browser.
 
-Saves and restores cookies + localStorage across session restarts, container deploys, and idle timeouts using Playwright's `storageState` API.
+Saves and restores cookies + localStorage + IndexedDB across session restarts, container deploys, and idle timeouts using Playwright's `storageState` API.
 
 ## Configuration
 
@@ -13,17 +13,21 @@ In `camofox.config.json`:
   "plugins": {
     "persistence": {
       "enabled": true,
-      "profileDir": "/data/profiles"
+      "profileDir": "/data/profiles",
+      "indexedDB": true
     }
   }
 }
 ```
 
-Or override via environment variable:
+Or override via environment variables:
 
 ```
 CAMOFOX_PROFILE_DIR=/data/profiles
+CAMOFOX_PERSIST_INDEXEDDB=false
 ```
+
+- `indexedDB` (default: `true`) — `storageState()` also captures IndexedDB-backed data, so logins stored there (e.g. Firebase Auth and other SSO flows) survive restarts. Set to `false` to restore cookies+localStorage-only snapshots.
 
 ## How it works
 

--- a/plugins/persistence/README.md
+++ b/plugins/persistence/README.md
@@ -2,7 +2,7 @@
 
 Optional per-user browser storage state persistence for camofox-browser.
 
-Saves and restores cookies + localStorage + IndexedDB across session restarts, container deploys, and idle timeouts using Playwright's `storageState` API.
+Saves and restores cookies and localStorage across session restarts, container deploys, and idle timeouts using Playwright's `storageState` API. IndexedDB persistence is available as an opt-in.
 
 ## Configuration
 
@@ -20,14 +20,13 @@ In `camofox.config.json`:
 }
 ```
 
-Or override via environment variables:
+The profile directory can also be set via environment variable:
 
 ```
 CAMOFOX_PROFILE_DIR=/data/profiles
-CAMOFOX_PERSIST_INDEXEDDB=false
 ```
 
-- `indexedDB` (default: `true`) — `storageState()` also captures IndexedDB-backed data, so logins stored there (e.g. Firebase Auth and other SSO flows) survive restarts. Set to `false` to restore cookies+localStorage-only snapshots.
+- `indexedDB` (default: `false`) — set to `true` to capture IndexedDB through `storageState()`. This can preserve logins stored there, including Firebase Auth and other SSO flows. It captures all serializable IndexedDB records—not only authentication data—and may make snapshots significantly larger and checkpoints slower.
 
 ## How it works
 

--- a/plugins/persistence/index.js
+++ b/plugins/persistence/index.js
@@ -15,20 +15,17 @@
  *     }
  *   }
  *
- * Or via environment variables (overrides config file):
+ * The profile directory can also be set via environment variable:
  *   CAMOFOX_PROFILE_DIR=/data/profiles
- *   CAMOFOX_PERSIST_INDEXEDDB=false
  *
  * Each userId gets a deterministic SHA256-hashed subdirectory under profileDir.
  * Storage state is checkpointed on cookie import, session close, and shutdown.
  * On session creation, saved state is restored into the new Playwright context
  * via the session:creating hook (mutates contextOptions.storageState).
  *
- * indexedDB (default: true): storageState() also captures IndexedDB-backed
- * data, so logins stored there (e.g. Firebase Auth and other SSO flows)
- * survive restarts too. Set "indexedDB": false (or
- * CAMOFOX_PERSIST_INDEXEDDB=false) to restore the previous
- * cookies+localStorage-only snapshots.
+ * indexedDB (default: false): opt in to capturing all serializable IndexedDB
+ * records in storageState(). This can preserve IndexedDB-backed logins, but
+ * may make snapshots significantly larger and checkpoints slower.
  */
 
 import {
@@ -48,12 +45,9 @@ export async function register(app, ctx, pluginConfig = {}) {
     return;
   }
 
-  // Resolve indexedDB: env var > plugin config > on (true)
-  const envIndexedDB = process.env.CAMOFOX_PERSIST_INDEXEDDB;
-  const indexedDB =
-    envIndexedDB !== undefined
-      ? !['false', '0', 'no'].includes(envIndexedDB.toLowerCase())
-      : pluginConfig.indexedDB !== false;
+  // IndexedDB capture is opt-in because it may persist large amounts of
+  // application data and make checkpoints significantly slower.
+  const indexedDB = pluginConfig.indexedDB === true;
 
   const logger = {
     warn: (msg, fields = {}) => log('warn', msg, fields),

--- a/plugins/persistence/index.js
+++ b/plugins/persistence/index.js
@@ -1,26 +1,34 @@
 /**
  * Persistence plugin for camofox-browser.
  *
- * Saves and restores per-user browser storage state (cookies + localStorage)
- * across session restarts using Playwright's storageState API.
+ * Saves and restores per-user browser storage state (cookies + localStorage
+ * + IndexedDB) across session restarts using Playwright's storageState API.
  *
  * Configuration (camofox.config.json):
  *   {
  *     "plugins": {
  *       "persistence": {
  *         "enabled": true,
- *         "profileDir": "/data/profiles"
+ *         "profileDir": "/data/profiles",
+ *         "indexedDB": true
  *       }
  *     }
  *   }
  *
  * Or via environment variables (overrides config file):
  *   CAMOFOX_PROFILE_DIR=/data/profiles
+ *   CAMOFOX_PERSIST_INDEXEDDB=false
  *
  * Each userId gets a deterministic SHA256-hashed subdirectory under profileDir.
  * Storage state is checkpointed on cookie import, session close, and shutdown.
  * On session creation, saved state is restored into the new Playwright context
  * via the session:creating hook (mutates contextOptions.storageState).
+ *
+ * indexedDB (default: true): storageState() also captures IndexedDB-backed
+ * data, so logins stored there (e.g. Firebase Auth and other SSO flows)
+ * survive restarts too. Set "indexedDB": false (or
+ * CAMOFOX_PERSIST_INDEXEDDB=false) to restore the previous
+ * cookies+localStorage-only snapshots.
  */
 
 import {
@@ -40,11 +48,18 @@ export async function register(app, ctx, pluginConfig = {}) {
     return;
   }
 
+  // Resolve indexedDB: env var > plugin config > on (true)
+  const envIndexedDB = process.env.CAMOFOX_PERSIST_INDEXEDDB;
+  const indexedDB =
+    envIndexedDB !== undefined
+      ? !['false', '0', 'no'].includes(envIndexedDB.toLowerCase())
+      : pluginConfig.indexedDB !== false;
+
   const logger = {
     warn: (msg, fields = {}) => log('warn', msg, fields),
   };
 
-  log('info', 'persistence plugin enabled', { profileDir });
+  log('info', 'persistence plugin enabled', { profileDir, indexedDB });
 
   // Track active sessions for checkpoint on close
   const activeSessions = new Map(); // userId -> context
@@ -54,7 +69,7 @@ export async function register(app, ctx, pluginConfig = {}) {
    */
   async function checkpoint(userId, context, reason) {
     if (!context) return;
-    const result = await persistStorageState({ profileDir, userId, context, logger });
+    const result = await persistStorageState({ profileDir, userId, context, logger, indexedDB });
     if (result.persisted) {
       log('info', 'storage state persisted', { userId, reason, path: result.storageStatePath });
     }

--- a/plugins/persistence/index.js
+++ b/plugins/persistence/index.js
@@ -34,6 +34,7 @@ import {
   persistStorageState,
 } from '../../lib/persistence.js';
 import { importBootstrapCookies } from '../../lib/cookies.js';
+import { resolvePersistenceIndexedDB } from '../../lib/persistence-config.js';
 
 export async function register(app, ctx, pluginConfig = {}) {
   const { events, config, log } = ctx;
@@ -47,7 +48,7 @@ export async function register(app, ctx, pluginConfig = {}) {
 
   // IndexedDB capture is opt-in because it may persist large amounts of
   // application data and make checkpoints significantly slower.
-  const indexedDB = pluginConfig.indexedDB === true;
+  const indexedDB = resolvePersistenceIndexedDB(pluginConfig);
 
   const logger = {
     warn: (msg, fields = {}) => log('warn', msg, fields),
@@ -61,9 +62,16 @@ export async function register(app, ctx, pluginConfig = {}) {
   /**
    * Checkpoint storage state to disk for a userId.
    */
-  async function checkpoint(userId, context, reason) {
-    if (!context) return;
-    const result = await persistStorageState({ profileDir, userId, context, logger, indexedDB });
+  async function checkpoint(userId, context, reason, storageState) {
+    if (!context && !storageState) return;
+    const result = await persistStorageState({
+      profileDir,
+      userId,
+      context,
+      storageState,
+      logger,
+      indexedDB,
+    });
     if (result.persisted) {
       log('info', 'storage state persisted', { userId, reason, path: result.storageStatePath });
     }
@@ -106,6 +114,14 @@ export async function register(app, ctx, pluginConfig = {}) {
     const context = activeSessions.get(userId);
     if (context) {
       await checkpoint(userId, context, 'cookie_import');
+    }
+  });
+
+  // When another plugin exports storage state, persist that exact snapshot so
+  // the browser is serialized only once and the exported/checkpointed data match.
+  events.on('session:storage:export', async ({ userId, storageState }) => {
+    if (storageState) {
+      await checkpoint(userId, undefined, 'storage_export', storageState);
     }
   });
 

--- a/plugins/persistence/index.js
+++ b/plugins/persistence/index.js
@@ -34,7 +34,6 @@ import {
   persistStorageState,
 } from '../../lib/persistence.js';
 import { importBootstrapCookies } from '../../lib/cookies.js';
-import { resolvePersistenceIndexedDB } from '../../lib/persistence-config.js';
 
 export async function register(app, ctx, pluginConfig = {}) {
   const { events, config, log } = ctx;
@@ -48,7 +47,8 @@ export async function register(app, ctx, pluginConfig = {}) {
 
   // IndexedDB capture is opt-in because it may persist large amounts of
   // application data and make checkpoints significantly slower.
-  const indexedDB = resolvePersistenceIndexedDB(pluginConfig);
+  const indexedDB = pluginConfig.indexedDB === true;
+  ctx.persistenceStorageStateOptions = indexedDB ? { indexedDB: true } : undefined;
 
   const logger = {
     warn: (msg, fields = {}) => log('warn', msg, fields),

--- a/plugins/persistence/plugin.test.js
+++ b/plugins/persistence/plugin.test.js
@@ -100,24 +100,8 @@ describe('persistence plugin', () => {
     }
   });
 
-  test('persists IndexedDB in storage state by default', async () => {
+  test('does not persist IndexedDB by default', async () => {
     await register(mockApp, ctx, { profileDir: tmpDir });
-
-    const mockContext = {
-      storageState: jest.fn(async ({ path: p }) => {
-        await fs.writeFile(p, JSON.stringify({ cookies: [], origins: [] }));
-      }),
-    };
-    await events.emitAsync('session:created', { userId: 'user-idb', context: mockContext });
-    await events.emitAsync('session:destroying', { userId: 'user-idb', reason: 'test' });
-
-    expect(mockContext.storageState).toHaveBeenCalledWith(
-      expect.objectContaining({ indexedDB: true })
-    );
-  });
-
-  test('indexedDB: false opts out of IndexedDB persistence', async () => {
-    await register(mockApp, ctx, { profileDir: tmpDir, indexedDB: false });
 
     const mockContext = {
       storageState: jest.fn(async ({ path: p }) => {
@@ -127,25 +111,35 @@ describe('persistence plugin', () => {
     await events.emitAsync('session:created', { userId: 'user-no-idb', context: mockContext });
     await events.emitAsync('session:destroying', { userId: 'user-no-idb', reason: 'test' });
 
+    expect(ctx.log).toHaveBeenCalledWith(
+      'info',
+      'persistence plugin enabled',
+      expect.objectContaining({ indexedDB: false })
+    );
     expect(mockContext.storageState).toHaveBeenCalled();
     for (const [arg] of mockContext.storageState.mock.calls) {
       expect(arg.indexedDB).toBeUndefined();
     }
   });
 
-  test('CAMOFOX_PERSIST_INDEXEDDB=false overrides plugin config', async () => {
-    const orig = process.env.CAMOFOX_PERSIST_INDEXEDDB;
-    process.env.CAMOFOX_PERSIST_INDEXEDDB = 'false';
-    try {
-      await register(mockApp, ctx, { profileDir: tmpDir, indexedDB: true });
-      expect(ctx.log).toHaveBeenCalledWith(
-        'info',
-        'persistence plugin enabled',
-        expect.objectContaining({ indexedDB: false })
-      );
-    } finally {
-      if (orig === undefined) delete process.env.CAMOFOX_PERSIST_INDEXEDDB;
-      else process.env.CAMOFOX_PERSIST_INDEXEDDB = orig;
-    }
+  test('indexedDB: true opts in to IndexedDB persistence', async () => {
+    await register(mockApp, ctx, { profileDir: tmpDir, indexedDB: true });
+
+    const mockContext = {
+      storageState: jest.fn(async ({ path: p }) => {
+        await fs.writeFile(p, JSON.stringify({ cookies: [], origins: [] }));
+      }),
+    };
+    await events.emitAsync('session:created', { userId: 'user-idb', context: mockContext });
+    await events.emitAsync('session:destroying', { userId: 'user-idb', reason: 'test' });
+
+    expect(ctx.log).toHaveBeenCalledWith(
+      'info',
+      'persistence plugin enabled',
+      expect.objectContaining({ indexedDB: true })
+    );
+    expect(mockContext.storageState).toHaveBeenCalledWith(
+      expect.objectContaining({ indexedDB: true })
+    );
   });
 });

--- a/plugins/persistence/plugin.test.js
+++ b/plugins/persistence/plugin.test.js
@@ -89,10 +89,63 @@ describe('persistence plugin', () => {
     process.env.CAMOFOX_PROFILE_DIR = envDir;
     try {
       await register(mockApp, ctx, { profileDir: '/should/not/use' });
-      expect(ctx.log).toHaveBeenCalledWith('info', 'persistence plugin enabled', { profileDir: envDir });
+      expect(ctx.log).toHaveBeenCalledWith(
+        'info',
+        'persistence plugin enabled',
+        expect.objectContaining({ profileDir: envDir })
+      );
     } finally {
       if (orig === undefined) delete process.env.CAMOFOX_PROFILE_DIR;
       else process.env.CAMOFOX_PROFILE_DIR = orig;
+    }
+  });
+
+  test('persists IndexedDB in storage state by default', async () => {
+    await register(mockApp, ctx, { profileDir: tmpDir });
+
+    const mockContext = {
+      storageState: jest.fn(async ({ path: p }) => {
+        await fs.writeFile(p, JSON.stringify({ cookies: [], origins: [] }));
+      }),
+    };
+    await events.emitAsync('session:created', { userId: 'user-idb', context: mockContext });
+    await events.emitAsync('session:destroying', { userId: 'user-idb', reason: 'test' });
+
+    expect(mockContext.storageState).toHaveBeenCalledWith(
+      expect.objectContaining({ indexedDB: true })
+    );
+  });
+
+  test('indexedDB: false opts out of IndexedDB persistence', async () => {
+    await register(mockApp, ctx, { profileDir: tmpDir, indexedDB: false });
+
+    const mockContext = {
+      storageState: jest.fn(async ({ path: p }) => {
+        await fs.writeFile(p, JSON.stringify({ cookies: [], origins: [] }));
+      }),
+    };
+    await events.emitAsync('session:created', { userId: 'user-no-idb', context: mockContext });
+    await events.emitAsync('session:destroying', { userId: 'user-no-idb', reason: 'test' });
+
+    expect(mockContext.storageState).toHaveBeenCalled();
+    for (const [arg] of mockContext.storageState.mock.calls) {
+      expect(arg.indexedDB).toBeUndefined();
+    }
+  });
+
+  test('CAMOFOX_PERSIST_INDEXEDDB=false overrides plugin config', async () => {
+    const orig = process.env.CAMOFOX_PERSIST_INDEXEDDB;
+    process.env.CAMOFOX_PERSIST_INDEXEDDB = 'false';
+    try {
+      await register(mockApp, ctx, { profileDir: tmpDir, indexedDB: true });
+      expect(ctx.log).toHaveBeenCalledWith(
+        'info',
+        'persistence plugin enabled',
+        expect.objectContaining({ indexedDB: false })
+      );
+    } finally {
+      if (orig === undefined) delete process.env.CAMOFOX_PERSIST_INDEXEDDB;
+      else process.env.CAMOFOX_PERSIST_INDEXEDDB = orig;
     }
   });
 });

--- a/plugins/persistence/plugin.test.js
+++ b/plugins/persistence/plugin.test.js
@@ -68,6 +68,24 @@ describe('persistence plugin', () => {
     expect(saved.cookies[0].name).toBe('x');
   });
 
+  test('persists the exact state supplied by session:storage:export', async () => {
+    await register(mockApp, ctx, { profileDir: tmpDir, indexedDB: true });
+
+    const storageState = {
+      cookies: [],
+      origins: [{
+        origin: 'https://example.test',
+        localStorage: [],
+        indexedDB: [{ name: 'auth', version: 1, stores: [] }],
+      }],
+    };
+    await events.emitAsync('session:storage:export', { userId: 'user-export', storageState });
+
+    const { getUserPersistencePaths } = await import('../../lib/persistence.js');
+    const { storageStatePath } = getUserPersistencePaths(tmpDir, 'user-export');
+    expect(JSON.parse(await fs.readFile(storageStatePath, 'utf8'))).toEqual(storageState);
+  });
+
   test('checkpoints on session:destroying', async () => {
     await register(mockApp, ctx, { profileDir: tmpDir });
 

--- a/plugins/vnc/README.md
+++ b/plugins/vnc/README.md
@@ -162,4 +162,4 @@ The plugin declares its apt dependencies in `apt.txt` — these are installed au
 | `vnc:watcher:started` | `{ pid }` | Watcher process spawned |
 | `vnc:watcher:stopped` | `{ code, signal }` | Watcher exited |
 | `vnc:storage:exported` | `{ userId, cookies, origins }` | Storage state exported via API |
-| `session:storage:export` | `{ userId }` | Emitted after export (persistence plugin listens) |
+| `session:storage:export` | `{ userId, storageState }` | Awaited after export; the persistence plugin writes the same snapshot to disk without serializing the browser again |

--- a/plugins/vnc/index.js
+++ b/plugins/vnc/index.js
@@ -45,12 +45,15 @@
 
 import { resolveVncConfig, startWatcher } from './vnc-launcher.js';
 import { requireAuth } from '../../lib/auth.js';
+import { resolvePersistenceIndexedDB } from '../../lib/persistence-config.js';
 
 export async function register(app, ctx, pluginConfig = {}) {
   const { events, config, log, sessions, VirtualDisplay, safeError } = ctx;
 
   // Resolve all config (env vars + pluginConfig) via the launcher module
   const vncConfig = resolveVncConfig(pluginConfig);
+  const persistenceConfig = ctx.pluginConfigs?.get('persistence') || {};
+  const persistIndexedDB = resolvePersistenceIndexedDB(persistenceConfig);
 
   if (!vncConfig.enabled) {
     log('info', 'vnc plugin: disabled (set ENABLE_VNC=1 or plugins.vnc.enabled=true)');
@@ -114,7 +117,9 @@ export async function register(app, ctx, pluginConfig = {}) {
         return res.status(404).json({ error: `No active session for userId="${userId}"` });
       }
 
-      const state = await session.context.storageState();
+      const state = await session.context.storageState(
+        persistIndexedDB ? { indexedDB: true } : undefined
+      );
 
       log('info', 'storage_state exported', {
         reqId: req.reqId,
@@ -129,7 +134,10 @@ export async function register(app, ctx, pluginConfig = {}) {
         origins: state.origins?.length || 0,
       });
 
-      events.emit('session:storage:export', { userId: String(userId) });
+      await events.emitAsync('session:storage:export', {
+        userId: String(userId),
+        storageState: state,
+      });
 
       res.json(state);
     } catch (err) {

--- a/plugins/vnc/index.js
+++ b/plugins/vnc/index.js
@@ -45,15 +45,12 @@
 
 import { resolveVncConfig, startWatcher } from './vnc-launcher.js';
 import { requireAuth } from '../../lib/auth.js';
-import { resolvePersistenceIndexedDB } from '../../lib/persistence-config.js';
 
 export async function register(app, ctx, pluginConfig = {}) {
   const { events, config, log, sessions, VirtualDisplay, safeError } = ctx;
 
   // Resolve all config (env vars + pluginConfig) via the launcher module
   const vncConfig = resolveVncConfig(pluginConfig);
-  const persistenceConfig = ctx.pluginConfigs?.get('persistence') || {};
-  const persistIndexedDB = resolvePersistenceIndexedDB(persistenceConfig);
 
   if (!vncConfig.enabled) {
     log('info', 'vnc plugin: disabled (set ENABLE_VNC=1 or plugins.vnc.enabled=true)');
@@ -117,9 +114,7 @@ export async function register(app, ctx, pluginConfig = {}) {
         return res.status(404).json({ error: `No active session for userId="${userId}"` });
       }
 
-      const state = await session.context.storageState(
-        persistIndexedDB ? { indexedDB: true } : undefined
-      );
+      const state = await session.context.storageState(ctx.persistenceStorageStateOptions);
 
       log('info', 'storage_state exported', {
         reqId: req.reqId,

--- a/plugins/vnc/vnc.test.js
+++ b/plugins/vnc/vnc.test.js
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { jest } from '@jest/globals';
+import { createPluginEvents } from '../../lib/plugins.js';
 
 // Mock the launcher module -- index.js no longer imports child_process directly
 const mockWatcher = () => {
@@ -44,8 +45,7 @@ describe('vnc plugin', () => {
   let events, ctx, mockApp, routes;
 
   beforeEach(() => {
-    events = new EventEmitter();
-    events.setMaxListeners(50);
+    events = createPluginEvents();
     routes = {};
     mockApp = {
       get: jest.fn((path, ...handlers) => { routes[`GET ${path}`] = handlers; }),
@@ -53,6 +53,7 @@ describe('vnc plugin', () => {
     ctx = {
       events,
       config: {},
+      pluginConfigs: new Map(),
       log: jest.fn(),
       sessions: new Map(),
       safeError: (err) => typeof err === 'string' ? err : (err?.message || 'Internal error'),
@@ -153,7 +154,24 @@ describe('vnc plugin', () => {
     const res = { json: jest.fn() };
 
     await handler(req, res);
+    expect(ctx.sessions.get('user-1').context.storageState).toHaveBeenCalledWith(undefined);
     expect(res.json).toHaveBeenCalledWith(mockState);
+  });
+
+  test('storage_state endpoint includes IndexedDB when persistence opts in', async () => {
+    ctx.pluginConfigs.set('persistence', { indexedDB: true });
+    await register(mockApp, ctx, { enabled: true });
+
+    const storageState = jest.fn(async () => ({ cookies: [], origins: [] }));
+    ctx.sessions.set('user-1', { context: { storageState } });
+
+    const handler = routes['GET /sessions/:userId/storage_state'].at(-1);
+    await handler(
+      { params: { userId: 'user-1' }, reqId: 'test' },
+      { json: jest.fn() },
+    );
+
+    expect(storageState).toHaveBeenCalledWith({ indexedDB: true });
   });
 
   test('storage_state endpoint uses safeError on failure', async () => {
@@ -192,6 +210,10 @@ describe('vnc plugin', () => {
 
     expect(exported).toHaveLength(2);
     expect(exported[0]).toMatchObject({ userId: 'user-1' });
+    expect(exported[1]).toMatchObject({
+      userId: 'user-1',
+      storageState: { cookies: [], origins: [] },
+    });
   });
 
   test('watcher is killed on server:shutdown', async () => {

--- a/plugins/vnc/vnc.test.js
+++ b/plugins/vnc/vnc.test.js
@@ -53,7 +53,6 @@ describe('vnc plugin', () => {
     ctx = {
       events,
       config: {},
-      pluginConfigs: new Map(),
       log: jest.fn(),
       sessions: new Map(),
       safeError: (err) => typeof err === 'string' ? err : (err?.message || 'Internal error'),
@@ -159,7 +158,7 @@ describe('vnc plugin', () => {
   });
 
   test('storage_state endpoint includes IndexedDB when persistence opts in', async () => {
-    ctx.pluginConfigs.set('persistence', { indexedDB: true });
+    ctx.persistenceStorageStateOptions = { indexedDB: true };
     await register(mockApp, ctx, { enabled: true });
 
     const storageState = jest.fn(async () => ({ cookies: [], origins: [] }));


### PR DESCRIPTION
## Motivation

The persistence plugin calls `context.storageState()` without `indexedDB: true`, which defaults to cookies+localStorage only. Sites that keep auth state in IndexedDB (e.g. Firebase Auth and other SSO flows) therefore never have their logins persisted — sessions on those sites silently do not survive restarts even with the plugin enabled.

## What's changed

Persisted storage state now includes IndexedDB **by default**: `{ indexedDB: true }` is threaded through `persistStorageState()` into `context.storageState()`.

Opt out with `"indexedDB": false` in the plugin config or `CAMOFOX_PERSIST_INDEXEDDB=false` (env overrides config, matching the existing `profileDir`/`CAMOFOX_PROFILE_DIR` pattern) to restore the previous cookies+localStorage-only behavior.

Playwright's `storageState({ indexedDB })` option exists since v1.51; `playwright-core` in this repo is `^1.58.0`, so no dependency bump is needed. Restore is unchanged — a persisted snapshot containing IndexedDB data is loaded through the same `contextOptions.storageState` path.

Note: companion PR #7223 (opt-in periodic checkpointing) touches adjacent lines in the same files (option resolution, "persistence plugin enabled" log fields, docs); whichever lands second will need a trivial rebase.

## Testing

- Extended `plugins/persistence/plugin.test.js`: IndexedDB included by default, `indexedDB: false` opt-out, and `CAMOFOX_PERSIST_INDEXEDDB=false` overriding plugin config. Also loosened one pre-existing assertion (`toHaveBeenCalledWith`) to `expect.objectContaining` since the "plugin enabled" log now carries the new field.
- `npm test` (full suite, excluding `tests/e2e` and `tests/live` which need a real browser/network): 45 suites, 696 tests, all passing.
- No lint script/config exists in this repo, so none was run.