### PR TITLE
fix: await VirtualDisplay.get() and drop unsupported viewport isMobile on Linux launch

### DIFF
--- a/server.js
+++ b/server.js
@@ -685,6 +685,21 @@ function getTotalTabCount() {
 // Virtual display for WebGL support and anti-detection.
 // Xvfb gives Firefox a real X display with GLX, enabling software-rendered WebGL
 // via Mesa llvmpipe. Without this, WebGL returns "no context" -- a massive bot signal.
+const DEFAULT_VIRTUAL_DISPLAY_RESOLUTION = '1280x720x24';
+
+class DefaultVirtualDisplay extends VirtualDisplay {
+  get xvfb_args() {
+    const args = super.xvfb_args;
+    const idx = args.indexOf('0');
+    if (idx > 0 && args[idx - 1] === '-screen') {
+      const patched = [...args];
+      patched[idx + 1] = DEFAULT_VIRTUAL_DISPLAY_RESOLUTION;
+      return patched;
+    }
+    return args;
+  }
+}
+
 let virtualDisplay = null;
 let browserLaunchProxy = null;
 let externalCamoufoxLaunch = null;
@@ -6055,7 +6070,7 @@ const pluginCtx = {
   metricsRegistry: getRegister,
   createMetric,
   /** Factory for Xvfb virtual display. Plugins can replace this to customise resolution/args. */
-  createVirtualDisplay: () => new VirtualDisplay(),
+  createVirtualDisplay: () => new DefaultVirtualDisplay(),
   /** The upstream VirtualDisplay class -- plugins can subclass it. */
   VirtualDisplay,
 };

--- a/server.js
+++ b/server.js
@@ -707,7 +707,7 @@ async function probeGoogleSearch(candidateBrowser) {
   let context = null;
   try {
     context = await candidateBrowser.newContext({
-      viewport: { width: 1280, height: 720 },
+      viewport: null,
       permissions: ['geolocation'],
     });
     const page = await context.newPage();
@@ -952,7 +952,7 @@ async function launchBrowserInstance() {
     try {
       if (os.platform() === 'linux') {
         localVirtualDisplay = pluginCtx.createVirtualDisplay();
-        vdDisplay = localVirtualDisplay.get();
+        vdDisplay = await localVirtualDisplay.get();
         log('info', 'xvfb virtual display started', { display: vdDisplay, attempt });
       }
     } catch (err) {
@@ -1177,7 +1177,7 @@ async function getSession(userId, { trace = false } = {}) {
       }
       const b = await ensureBrowser();
       const contextOptions = {
-        viewport: { width: 1280, height: 720 },
+        viewport: null,
         permissions: ['geolocation'],
       };
       // When geoip is active (proxy configured), camoufox auto-configures

--- a/tests/unit/launchCompat.test.js
+++ b/tests/unit/launchCompat.test.js
@@ -1,10 +1,7 @@
-import { describe, test, expect } from '@jest/globals';
-import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+const { readFileSync } = process.getBuiltinModule('fs');
+const { join } = process.getBuiltinModule('path');
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const serverSource = readFileSync(join(__dirname, '../../server.js'), 'utf-8');
+const serverSource = readFileSync(join(process.cwd(), 'server.js'), 'utf-8');
 
 function sourceBetween(startMarker, endMarker) {
   const start = serverSource.indexOf(startMarker);

--- a/tests/unit/launchCompat.test.js
+++ b/tests/unit/launchCompat.test.js
@@ -18,6 +18,22 @@ describe('launch compatibility source contract', () => {
     expect(serverSource).not.toMatch(/vdDisplay\s*=\s*localVirtualDisplay\.get\(\)/);
   });
 
+  test('sizes the default virtual display used with null context viewports', () => {
+    const defaultVirtualDisplay = sourceBetween(
+      'const DEFAULT_VIRTUAL_DISPLAY_RESOLUTION',
+      'let virtualDisplay = null;'
+    );
+    const pluginContext = sourceBetween(
+      'const pluginCtx = {',
+      'const loadedPlugins = await loadPlugins'
+    );
+
+    expect(defaultVirtualDisplay).toContain("DEFAULT_VIRTUAL_DISPLAY_RESOLUTION = '1280x720x24'");
+    expect(defaultVirtualDisplay).toContain('class DefaultVirtualDisplay extends VirtualDisplay');
+    expect(defaultVirtualDisplay).toContain('patched[idx + 1] = DEFAULT_VIRTUAL_DISPLAY_RESOLUTION');
+    expect(pluginContext).toContain('createVirtualDisplay: () => new DefaultVirtualDisplay()');
+  });
+
   test('does not configure a fixed default browser context viewport', () => {
     const googleProbeOptions = sourceBetween(
       'context = await candidateBrowser.newContext({',

--- a/tests/unit/launchCompat.test.js
+++ b/tests/unit/launchCompat.test.js
@@ -1,0 +1,38 @@
+import { describe, test, expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverSource = readFileSync(join(__dirname, '../../server.js'), 'utf-8');
+
+function sourceBetween(startMarker, endMarker) {
+  const start = serverSource.indexOf(startMarker);
+  const end = serverSource.indexOf(endMarker, start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return serverSource.slice(start, end);
+}
+
+describe('launch compatibility source contract', () => {
+
+  test('awaits virtual display display string before launch', () => {
+    expect(serverSource).toMatch(/vdDisplay\s*=\s*await\s+localVirtualDisplay\.get\(\)/);
+    expect(serverSource).not.toMatch(/vdDisplay\s*=\s*localVirtualDisplay\.get\(\)/);
+  });
+
+  test('does not configure a fixed default browser context viewport', () => {
+    const googleProbeOptions = sourceBetween(
+      'context = await candidateBrowser.newContext({',
+      'const page = await context.newPage();'
+    );
+    const sessionContextOptions = sourceBetween(
+      'const contextOptions = {',
+      '// When geoip is active'
+    );
+
+    expect(googleProbeOptions).toContain('viewport: null');
+    expect(sessionContextOptions).toContain('viewport: null');
+    expect(`${googleProbeOptions}\n${sessionContextOptions}`).not.toMatch(/viewport\s*:\s*\{\s*width\s*:/);
+  });
+});


### PR DESCRIPTION
## Summary
`npx @askjo/camofox-browser` on Linux fails to launch a browser for two independent reasons: the Xvfb display string is a pending Promise, and Playwright 1.61 sends a `viewport.isMobile` field the Camoufox juggler rejects. This PR awaits `VirtualDisplay.get()` (async since camoufox-js 0.10) and stops passing a fixed context viewport, sizing the default virtual display at 1280x720 so non-VNC launches keep a usable display instead of Camoufox's 1x1 default.

## Why this matters
The reporter hit this on a fresh install (Ubuntu 24.04, Node 24):

> Error: cannot open display: [object Promise]

`server.js` called `localVirtualDisplay.get()` without `await`. camoufox-js 0.11.1 made `get()` async (the repo pins `>=0.10.0`), so the value stringified into the launch env as `[object Promise]`. Past that, no tab could be created: `newContext({viewport: {width: 1280, height: 720}})` makes playwright-core 1.61 emit `Browser.setDefaultViewport` with an `isMobile` property the juggler schema rejects (`Found property "<root>.viewport.isMobile" ... not described in this scheme`). A second user confirmed the same failure in the issue thread.

`await` on the older sync `get()` (0.8.x) is a no-op, so the change is compatible across the declared camoufox-js range, and the `/tabs/{tabId}/viewport` endpoint keeps working since it uses `page.setViewportSize` rather than context defaults.

## Testing
- New `tests/unit/launchCompat.test.js` (same source-contract idiom as `tests/unit/noSecrets.test.js`) locks the awaited `get()`, the removal of fixed context viewports, and the 1280x720 non-VNC display sizing.
- `NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit/launchCompat.test.js` passes; the unit suite shows no new failures vs master (the 4 suites failing on this branch fail identically on clean master).

Fixes #6807

AI was used for assistance.
