### PR TITLE
Fix OpenClaw factory tool registration names

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -134,7 +134,7 @@ export default function register(api) {
             });
             return toToolResult(result);
         },
-    }));
+    }), { name: "camofox_create_tab" });
     api.registerTool((ctx) => ({
         name: "camofox_snapshot",
         description: "Get accessibility snapshot of a Camoufox page with element refs (e1, e2, etc.) for interaction, plus a visual screenshot. " +
@@ -162,7 +162,7 @@ export default function register(api) {
             }
             return { content };
         },
-    }));
+    }), { name: "camofox_snapshot" });
     api.registerTool((ctx) => ({
         name: "camofox_click",
         description: "Click an element in a Camoufox tab by ref (e.g., e1) or CSS selector.",
@@ -184,7 +184,7 @@ export default function register(api) {
             });
             return toToolResult(result);
         },
-    }));
+    }), { name: "camofox_click" });
     api.registerTool((ctx) => ({
         name: "camofox_type",
         description: "Type text into an element in a Camoufox tab.",
@@ -208,7 +208,7 @@ export default function register(api) {
             });
             return toToolResult(result);
         },
-    }));
+    }), { name: "camofox_type" });
     api.registerTool((ctx) => ({
         name: "camofox_navigate",
         description: "Navigate a Camoufox tab to a URL or use a search macro (@google_search, @youtube_search, etc.). Preferred over Chrome for sites with bot detection.",
@@ -249,7 +249,7 @@ export default function register(api) {
             });
             return toToolResult(result);
         },
-    }));
+    }), { name: "camofox_navigate" });
     api.registerTool((ctx) => ({
         name: "camofox_scroll",
         description: "Scroll a Camoufox page.",
@@ -271,7 +271,7 @@ export default function register(api) {
             });
             return toToolResult(result);
         },
-    }));
+    }), { name: "camofox_scroll" });
     api.registerTool((ctx) => ({
         name: "camofox_screenshot",
         description: "Take a screenshot of a Camoufox page.",
@@ -310,7 +310,7 @@ export default function register(api) {
                 ],
             };
         },
-    }));
+    }), { name: "camofox_screenshot" });
     api.registerTool((ctx) => ({
         name: "camofox_close_tab",
         description: "Close a Camoufox browser tab.",
@@ -329,7 +329,7 @@ export default function register(api) {
             });
             return toToolResult(result);
         },
-    }));
+    }), { name: "camofox_close_tab" });
     api.registerTool((ctx) => ({
         name: "camofox_evaluate",
         description: "Execute JavaScript in a Camoufox tab's page context. Returns the result of the expression. Use for injecting scripts, reading page state, or calling web app APIs.",
@@ -350,7 +350,7 @@ export default function register(api) {
             });
             return toToolResult(result);
         },
-    }));
+    }), { name: "camofox_evaluate" });
     api.registerTool((ctx) => ({
         name: "camofox_list_tabs",
         description: "List all open Camoufox tabs for a user.",
@@ -364,7 +364,7 @@ export default function register(api) {
             const result = await fetchApi(baseUrl, `/tabs?userId=${userId}`);
             return toToolResult(result);
         },
-    }));
+    }), { name: "camofox_list_tabs" });
     api.registerTool((ctx) => ({
         name: "camofox_import_cookies",
         description: "Import cookies into the current Camoufox user session (Netscape cookie file). Use to authenticate to sites like LinkedIn without interactive login.",
@@ -401,7 +401,7 @@ export default function register(api) {
             });
             return toToolResult({ imported: pwCookies.length, userId, result });
         },
-    }));
+    }), { name: "camofox_import_cookies" });
     api.registerCommand({
         name: "camofox",
         description: "Camoufox browser server control (status, start, stop)",

--- a/plugin.ts
+++ b/plugin.ts
@@ -82,7 +82,7 @@ type ToolFactory = (ctx: ToolContext) => ToolDefinition | ToolDefinition[] | nul
 interface PluginApi {
   registerTool: (
     tool: ToolDefinition | ToolFactory,
-    options?: { optional?: boolean }
+    options?: { name?: string; names?: string[]; optional?: boolean }
   ) => void;
   registerCommand: (cmd: {
     name: string;
@@ -234,7 +234,7 @@ export default function register(api: PluginApi) {
       });
       return toToolResult(result);
     },
-  }));
+  }), { name: "camofox_create_tab" });
 
   api.registerTool((ctx: ToolContext) => ({
     name: "camofox_snapshot",
@@ -264,7 +264,7 @@ export default function register(api: PluginApi) {
       }
       return { content };
     },
-  }));
+  }), { name: "camofox_snapshot" });
 
   api.registerTool((ctx: ToolContext) => ({
     name: "camofox_click",
@@ -287,7 +287,7 @@ export default function register(api: PluginApi) {
       });
       return toToolResult(result);
     },
-  }));
+  }), { name: "camofox_click" });
 
   api.registerTool((ctx: ToolContext) => ({
     name: "camofox_type",
@@ -312,7 +312,7 @@ export default function register(api: PluginApi) {
       });
       return toToolResult(result);
     },
-  }));
+  }), { name: "camofox_type" });
 
   api.registerTool((ctx: ToolContext) => ({
     name: "camofox_navigate",
@@ -355,7 +355,7 @@ export default function register(api: PluginApi) {
       });
       return toToolResult(result);
     },
-  }));
+  }), { name: "camofox_navigate" });
 
   api.registerTool((ctx: ToolContext) => ({
     name: "camofox_scroll",
@@ -378,7 +378,7 @@ export default function register(api: PluginApi) {
       });
       return toToolResult(result);
     },
-  }));
+  }), { name: "camofox_scroll" });
 
   api.registerTool((ctx: ToolContext) => ({
     name: "camofox_screenshot",
@@ -418,7 +418,7 @@ export default function register(api: PluginApi) {
         ],
       };
     },
-  }));
+  }), { name: "camofox_screenshot" });
 
   api.registerTool((ctx: ToolContext) => ({
     name: "camofox_close_tab",
@@ -438,7 +438,7 @@ export default function register(api: PluginApi) {
       });
       return toToolResult(result);
     },
-  }));
+  }), { name: "camofox_close_tab" });
 
   api.registerTool((ctx: ToolContext) => ({
     name: "camofox_evaluate",
@@ -461,7 +461,7 @@ export default function register(api: PluginApi) {
       });
       return toToolResult(result);
     },
-  }));
+  }), { name: "camofox_evaluate" });
 
   api.registerTool((ctx: ToolContext) => ({
     name: "camofox_list_tabs",
@@ -476,7 +476,7 @@ export default function register(api: PluginApi) {
       const result = await fetchApi(baseUrl, `/tabs?userId=${userId}`);
       return toToolResult(result);
     },
-  }));
+  }), { name: "camofox_list_tabs" });
 
   api.registerTool((ctx: ToolContext) => ({
     name: "camofox_import_cookies",
@@ -526,7 +526,7 @@ export default function register(api: PluginApi) {
 
       return toToolResult({ imported: pwCookies.length, userId, result });
     },
-  }));
+  }), { name: "camofox_import_cookies" });
 
   api.registerCommand({
     name: "camofox",


### PR DESCRIPTION
Fixes #5437

This updates both:

- `plugin.ts`, the source plugin file
- `plugin.js`, the generated/runtime plugin file loaded by OpenClaw

Both changes add explicit factory tool registration names so OpenClaw 2026.6.x exposes the `camofox_*` tools correctly.

Without this, `openclaw plugins inspect camofox-browser --runtime --json` shows:

- `status: "loaded"`
- `imported: true`
- `toolNames: []`
- `tools[*].names: []`

After this change, the same install shows all `camofox_*` tools under `toolNames`, and the tools are callable by agents when allowed by tool policy.

Tested locally with:

- OpenClaw `2026.6.11` (`e085fa1`)
- `@askjo/camofox-browser@1.11.2`
- remote Camofox server at `http://redacted:9377`

Smoke test passed:

- `camofox_create_tab` opened `https://example.com`
- `camofox_snapshot` returned the Example Domain page content

Note: users with `tools.profile: "coding"` still need to allow plugin tools separately, for example via `tools.alsoAllow`. That is separate from this registration fix.