### PR TITLE
fix: selective dependency maintenance + Juggler viewport patch for playwright-core 1.61.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "camofox-browser": "bin/camofox-browser.js"
       },
       "devDependencies": {
-        "@types/node": "^22.0.0",
+        "@types/node": "^22.20.0",
         "jest": "^29.7.0",
         "pngjs": "^7.0.0",
         "typescript": "^5.7.0"
@@ -1202,9 +1202,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
-      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "express": "^4.22.2",
         "playwright-core": "^1.61.1",
         "prom-client": "^15.1.3",
-        "swagger-jsdoc": "^6.2.8"
+        "swagger-jsdoc": "^6.3.0"
       },
       "bin": {
         "camofox-browser": "bin/camofox-browser.js"
@@ -30,15 +30,19 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
-      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
       "license": "MIT",
       "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
+        "@types/json-schema": "^7.0.15",
         "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
@@ -48,9 +52,19 @@
       "license": "Python-2.0"
     },
     "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -75,17 +89,17 @@
       "license": "MIT"
     },
     "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.1.0.tgz",
+      "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
+        "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^5.0.1"
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
       },
       "peerDependencies": {
         "openapi-types": ">=7"
@@ -637,6 +651,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1059,12 +1082,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-      "license": "MIT"
-    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -1255,6 +1272,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -1894,6 +1941,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
@@ -1965,7 +2013,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2394,12 +2441,34 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -2476,6 +2545,34 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2504,6 +2601,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -2963,6 +3061,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -3088,7 +3187,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -3198,6 +3296,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jest": {
@@ -3943,6 +4056,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -4013,13 +4132,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
-      "license": "MIT"
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -4476,6 +4588,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -4518,6 +4636,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4527,7 +4646,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4864,6 +4982,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -5019,7 +5146,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5032,7 +5158,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5338,39 +5463,23 @@
       }
     },
     "node_modules/swagger-jsdoc": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
-      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.3.0.tgz",
+      "integrity": "sha512-I+iQjVGV3t28pOkQUJv2MncthvOtkEactOn8R76SvSYhxgtIn7FoqfDHwQaN+GBnQdXQLrhgDXseKitmJcHMsA==",
       "license": "MIT",
       "dependencies": {
+        "@apidevtools/swagger-parser": "^12.1.0",
         "commander": "6.2.0",
         "doctrine": "3.0.0",
-        "glob": "7.1.6",
+        "glob": "11.1.0",
         "lodash.mergewith": "^4.6.2",
-        "swagger-parser": "^10.0.3",
         "yaml": "2.0.0-1"
       },
       "bin": {
         "swagger-jsdoc": "bin/swagger-jsdoc.js"
       },
       "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/swagger-jsdoc/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/swagger-jsdoc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/swagger-jsdoc/node_modules/commander": {
@@ -5383,48 +5492,27 @@
       }
     },
     "node_modules/swagger-jsdoc/node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": "*"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/swagger-jsdoc/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/swagger-parser": "10.0.3"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/tar-fs": {
@@ -5774,15 +5862,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/validator": {
-      "version": "13.15.35",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
-      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -5806,7 +5885,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -5944,36 +6022,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/z-schema": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
-      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^13.7.0"
-      },
-      "bin": {
-        "z-schema": "bin/z-schema"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "commander": "^9.4.1"
-      }
-    },
-    "node_modules/z-schema/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "camoufox-js": ">=0.10.0",
-        "express": "^4.18.2",
+        "express": "^4.22.2",
         "playwright-core": "^1.61.1",
         "prom-client": "^15.1.3",
         "swagger-jsdoc": "^6.2.8"
@@ -1549,21 +1549,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
@@ -2236,9 +2221,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2364,14 +2349,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -2390,7 +2375,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -4785,12 +4770,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -5053,14 +5039,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "camoufox-js": ">=0.10.0",
         "express": "^4.18.2",
-        "playwright-core": "^1.58.0",
+        "playwright-core": "^1.61.1",
         "prom-client": "^15.1.3",
         "swagger-jsdoc": "^6.2.8"
       },
@@ -4629,9 +4629,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "swagger-jsdoc": "^6.2.8"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^22.20.0",
     "jest": "^29.7.0",
     "pngjs": "^7.0.0",
     "typescript": "^5.7.0"

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "express": "^4.22.2",
     "playwright-core": "^1.61.1",
     "prom-client": "^15.1.3",
-    "swagger-jsdoc": "^6.2.8"
+    "swagger-jsdoc": "^6.3.0"
   },
   "devDependencies": {
     "@types/node": "^22.20.0",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
   "dependencies": {
     "camoufox-js": ">=0.10.0",
     "express": "^4.18.2",
-    "playwright-core": "^1.58.0",
+    "playwright-core": "^1.61.1",
     "prom-client": "^15.1.3",
     "swagger-jsdoc": "^6.2.8"
   },

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
   },
   "dependencies": {
     "camoufox-js": ">=0.10.0",
-    "express": "^4.18.2",
+    "express": "^4.22.2",
     "playwright-core": "^1.61.1",
     "prom-client": "^15.1.3",
     "swagger-jsdoc": "^6.2.8"

--- a/plugin.js
+++ b/plugin.js
@@ -483,7 +483,7 @@ export default function register(api) {
     if (api.registerRpc) {
         api.registerRpc("camofox.health", async () => {
             try {
-                const health = await fetchApi(baseUrl, "/health");
+                const health = (await fetchApi(baseUrl, "/health"));
                 return { status: "ok", ...health };
             }
             catch (err) {

--- a/plugin.ts
+++ b/plugin.ts
@@ -46,16 +46,16 @@ interface HealthCheckResult {
   details?: Record<string, unknown>;
 }
 
+type CliCommand = {
+  description: (desc: string) => CliCommand;
+  option: (flags: string, desc: string, defaultValue?: string) => CliCommand;
+  argument: (name: string, desc: string) => CliCommand;
+  action: (handler: (...args: unknown[]) => void | Promise<void>) => CliCommand;
+  command: (name: string) => CliCommand;
+};
+
 interface CliContext {
-  program: {
-    command: (name: string) => {
-      description: (desc: string) => CliContext["program"];
-      option: (flags: string, desc: string, defaultValue?: string) => CliContext["program"];
-      argument: (name: string, desc: string) => CliContext["program"];
-      action: (handler: (...args: unknown[]) => void | Promise<void>) => CliContext["program"];
-      command: (name: string) => CliContext["program"];
-    };
-  };
+  program: CliCommand;
   config: PluginConfig;
   logger: {
     info: (msg: string) => void;
@@ -611,7 +611,7 @@ export default function register(api: PluginApi) {
   if (api.registerRpc) {
     api.registerRpc("camofox.health", async () => {
       try {
-        const health = await fetchApi(baseUrl, "/health");
+        const health = (await fetchApi(baseUrl, "/health")) as Record<string, unknown>;
         return { status: "ok", ...health };
       } catch (err) {
         return { status: "error", error: (err as Error).message };

--- a/scripts/patch-juggler-viewport.js
+++ b/scripts/patch-juggler-viewport.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+// Patch the Camoufox Juggler protocol schema to accept isMobile and screenSize
+// fields that playwright-core >=1.61 sends in Browser.setDefaultViewport and
+// Page.setViewportSize. Without this patch, Playwright 1.61+ fails every
+// context creation and viewport resize with a protocol schema validation error.
+//
+// See: https://github.com/daijro/camoufox/issues/653
+//
+// This script patches chrome/juggler/content/protocol/Protocol.js inside
+// the Camoufox omni.ja archive. The Juggler handlers already ignore the
+// extra fields — only the schema validator (checkScheme in PrimitiveTypes.js)
+// rejects them.
+//
+// Usage:
+//   node scripts/patch-juggler-viewport.js
+//
+// Exit codes:
+//   0 — patch applied (or already applied)
+//   1 — Camoufox not found or patch failed
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir, platform } from 'node:os';
+import { execSync } from 'node:child_process';
+
+function camoufoxCacheDir() {
+  const home = homedir();
+  const plat = platform();
+  if (plat === 'darwin') return join(home, 'Library', 'Caches', 'camoufox');
+  if (plat === 'win32') {
+    const base = process.env.LOCALAPPDATA || join(home, 'AppData', 'Local');
+    return join(base, 'camoufox', 'camoufox', 'Cache');
+  }
+  return join(process.env.XDG_CACHE_HOME || join(home, '.cache'), 'camoufox');
+}
+
+const PROTOCOL_PATH = 'chrome/juggler/content/protocol/Protocol.js';
+
+// Patches to apply:
+const PATCHES = [
+  {
+    name: 'pageTypes.Viewport',
+    find: `pageTypes.Viewport = {
+  viewportSize: pageTypes.Size,
+  deviceScaleFactor: t.Optional(t.Number),
+};`,
+    replace: `pageTypes.Viewport = {
+  viewportSize: pageTypes.Size,
+  screenSize: t.Optional(pageTypes.Size),
+  deviceScaleFactor: t.Optional(t.Number),
+  isMobile: t.Optional(t.Boolean),
+};`,
+  },
+  {
+    name: 'Page.setViewportSize params',
+    find: `    'setViewportSize': {
+      params: {
+        viewportSize: t.Nullable(pageTypes.Size),
+      },
+    },`,
+    replace: `    'setViewportSize': {
+      params: {
+        viewportSize: t.Nullable(pageTypes.Size),
+        screenSize: t.Optional(pageTypes.Size),
+        isMobile: t.Optional(t.Boolean),
+      },
+    },`,
+  },
+];
+
+function main() {
+  const cacheDir = camoufoxCacheDir();
+  const omniJa = join(cacheDir, 'omni.ja');
+
+  if (!existsSync(omniJa)) {
+    process.stderr.write(`[patch-juggler] omni.ja not found at ${omniJa}\n`);
+    process.stderr.write('[patch-juggler] Run `npx camoufox-js fetch` first.\n');
+    process.exit(1);
+  }
+
+  // Extract Protocol.js from omni.ja
+  const tmpDir = join(cacheDir, '.juggler-patch-tmp');
+  rmSync(tmpDir, { recursive: true, force: true });
+  mkdirSync(tmpDir, { recursive: true });
+
+  try {
+    execSync(`unzip -o "${omniJa}" "${PROTOCOL_PATH}" -d "${tmpDir}"`, { stdio: 'pipe' });
+  } catch {
+    process.stderr.write(`[patch-juggler] Failed to extract ${PROTOCOL_PATH} from omni.ja\n`);
+    process.exit(1);
+  }
+
+  const protocolFile = join(tmpDir, PROTOCOL_PATH);
+  if (!existsSync(protocolFile)) {
+    process.stderr.write(`[patch-juggler] ${PROTOCOL_PATH} not found in omni.ja\n`);
+    process.exit(1);
+  }
+
+  let content = readFileSync(protocolFile, 'utf8');
+  let patched = 0;
+
+  for (const patch of PATCHES) {
+    if (content.includes(patch.replace)) {
+      // Already patched
+      process.stdout.write(`[patch-juggler] ${patch.name}: already patched\n`);
+      patched++;
+      continue;
+    }
+    if (!content.includes(patch.find)) {
+      process.stderr.write(`[patch-juggler] ${patch.name}: pattern not found — schema may have changed\n`);
+      continue;
+    }
+    content = content.replace(patch.find, patch.replace);
+    process.stdout.write(`[patch-juggler] ${patch.name}: patched\n`);
+    patched++;
+  }
+
+  if (patched === 0) {
+    process.stderr.write('[patch-juggler] No patches applied — aborting\n');
+    process.exit(1);
+  }
+
+  // Check if all patches were already applied
+  if (patched === PATCHES.length && !PATCHES.some(p => content.includes(p.find))) {
+    process.stdout.write('[patch-juggler] All patches already in place — omni.ja unchanged\n');
+    rmSync(tmpDir, { recursive: true, force: true });
+    process.exit(0);
+  }
+
+  // Write patched Protocol.js back
+  writeFileSync(protocolFile, content, 'utf8');
+
+  // Repack omni.ja with patched Protocol.js using Python zipfile
+  const pythonScript = `
+import zipfile, shutil, os, sys
+src = '${omniJa}'
+tmp = src + '.tmp'
+patched_file = '${protocolFile}'
+target = '${PROTOCOL_PATH}'
+
+with zipfile.ZipFile(src, 'r') as zin:
+    with zipfile.ZipFile(tmp, 'w', zipfile.ZIP_DEFLATED) as zout:
+        for item in zin.infolist():
+            if item.filename == target:
+                zout.writestr(item, open(patched_file, 'rb').read())
+            else:
+                zout.writestr(item, zin.read(item.filename))
+
+shutil.move(tmp, src)
+print('[patch-juggler] omni.ja repacked successfully')
+`;
+
+  try {
+    execSync(`python3 -c '${pythonScript.replace(/'/g, "'\\''")}'`, { stdio: 'inherit' });
+  } catch {
+    process.stderr.write('[patch-juggler] Failed to repack omni.ja\n');
+    process.exit(1);
+  }
+
+  // Cleanup
+  rmSync(tmpDir, { recursive: true, force: true });
+  process.stdout.write('[patch-juggler] Done. Camoufox Juggler protocol patched for playwright-core >=1.61.\n');
+}
+
+main();

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -190,6 +190,19 @@ export async function main() {
     warn('    - PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD re-exported by a wrapping process');
     warn('  Manual fix:  npx camoufox-js fetch');
   }
+
+  // Patch the Juggler protocol schema for playwright-core >=1.61 compatibility.
+  // This is idempotent and safe to run on every install.
+  try {
+    const { spawnSync: run } = await import('node:child_process');
+    const patchScript = join(dirname(new URL('.', import.meta.url).pathname), 'patch-juggler-viewport.js');
+    if (existsSync(patchScript)) {
+      const r = run(process.execPath, [patchScript], { stdio: 'inherit' });
+      if (r.status !== 0) warn('Juggler viewport patch failed — see output above');
+    }
+  } catch (e) {
+    warn(`Juggler viewport patch error: ${e.message}`);
+  }
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/server.js
+++ b/server.js
@@ -710,7 +710,7 @@ async function probeGoogleSearch(candidateBrowser) {
       viewport: { width: 1280, height: 720 },
       permissions: ['geolocation'],
     });
-    const page = await context.newPage();
+    const page = await newPageWithViewport(context);
     await page.goto('https://www.google.com/', { waitUntil: 'domcontentloaded', timeout: 30000 });
     await page.waitForTimeout(1200);
     await page.goto('https://www.google.com/search?q=weather%20today', { waitUntil: 'domcontentloaded', timeout: 30000 });
@@ -1469,6 +1469,14 @@ function tabNotFoundResponse(res, tabId) {
   return res.status(404).json({ error: 'Tab not found' });
 }
 
+// Helper: create a new page and set the default viewport size.
+// Works with both playwright-core <1.61 and >=1.61 (with patched Juggler schema).
+const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
+async function newPageWithViewport(context) {
+  const page = await context.newPage();
+  await page.setViewportSize(DEFAULT_VIEWPORT);
+  return page;
+}
 function createTabState(page) {
   const healthTracker = createTabHealthTracker(page);
   return {
@@ -1686,7 +1694,7 @@ async function rotateGoogleTab(userId, sessionKey, tabId, previousTabState, reas
   }
   const session = await getSession(userId);
   const group = getTabGroup(session, sessionKey);
-  const page = await session.context.newPage();
+  const page = await newPageWithViewport(session.context);
   const tabState = createTabState(page);
   tabState.googleRetryCount = (previousTabState.googleRetryCount || 0) + 1;
   tabState.lastRequestedUrl = previousTabState.lastRequestedUrl;
@@ -2613,7 +2621,7 @@ app.post('/tabs', async (req, res) => {
       
       const group = getTabGroup(session, resolvedSessionKey);
       
-      const page = await session.context.newPage();
+      const page = await newPageWithViewport(session.context);
       const tabId = fly.makeTabId();
       let tabState = createTabState(page);
       attachDownloadListener(tabState, tabId, log, pluginEvents, userId);
@@ -2640,7 +2648,7 @@ app.post('/tabs', async (req, res) => {
             }
             session = await getSession(userId, { trace: !!trace });
             const retryGroup = getTabGroup(session, resolvedSessionKey);
-            const retryPage = await session.context.newPage();
+            const retryPage = await newPageWithViewport(session.context);
             tabState = createTabState(retryPage);
             tabState.lastRequestedUrl = url;
             attachDownloadListener(tabState, tabId, log, pluginEvents, userId);
@@ -2811,7 +2819,7 @@ app.post('/tabs/:tabId/navigate', async (req, res) => {
           }
           session = await getSession(userId);
           const group = getTabGroup(session, currentSessionKey);
-          const page = await session.context.newPage();
+          const page = await newPageWithViewport(session.context);
           tabState = createTabState(page);
           tabState.googleRetryCount = previousRetryCount + 1;
           attachDownloadListener(tabState, tabId, log, pluginEvents, userId);
@@ -5311,7 +5319,7 @@ app.post('/tabs/open', async (req, res) => {
     
     let group = getTabGroup(session, listItemId);
     
-    let page = await session.context.newPage();
+    let page = await newPageWithViewport(session.context);
     const tabId = fly.makeTabId();
     let tabState = createTabState(page);
     attachDownloadListener(tabState, tabId, log, pluginEvents, userId);
@@ -5334,7 +5342,7 @@ app.post('/tabs/open', async (req, res) => {
         }
         session = await getSession(userId);
         group = getTabGroup(session, listItemId);
-        page = await session.context.newPage();
+        page = await newPageWithViewport(session.context);
         tabState = createTabState(page);
         attachDownloadListener(tabState, tabId, log, pluginEvents, userId);
         group.set(tabId, tabState);
@@ -5966,7 +5974,7 @@ setInterval(async () => {
   let testContext;
   try {
     testContext = await browser.newContext();
-    const page = await testContext.newPage();
+    const page = await newPageWithViewport(testContext);
     await page.goto('about:blank', { timeout: 5000 });
     await page.close();
     await testContext.close();


### PR DESCRIPTION
## Summary

Selective dependency maintenance slice updating 4 direct dependencies and patching the Camoufox Juggler protocol for playwright-core 1.61.1 compatibility.

## Commits

1. **`bbb7b44` — `chore(deps): update @types/node to 22.20.0`**
   Type-surface compatibility fixes in `plugin.ts`/`plugin.js` (`CliCommand` type extraction, `Record<string, unknown>` cast).

2. **`3b77176` — `fix: patch Juggler protocol for playwright-core 1.61.1 compatibility`**
   Playwright 1.61 sends `isMobile` and `screenSize` in `Browser.setDefaultViewport` and `Page.setViewportSize`, but the Camoufox Juggler schema rejects both fields ([daijro/camoufox#653](https://github.com/daijro/camoufox/issues/653)). The Juggler handlers already ignore these fields — only the schema validator blocks them.
   
   **Fix:** Patch `Protocol.js` inside the Camoufox `omni.ja` archive to accept the new fields:
   - `pageTypes.Viewport`: add `screenSize` (Optional) and `isMobile` (Optional)
   - `Page.setViewportSize` params: add `screenSize` (Optional) and `isMobile` (Optional)
   
   **Automation:** `scripts/patch-juggler-viewport.js` is a new idempotent patcher, called from `scripts/postinstall.js` after the Camoufox binary download. Safe to run on every install.
   
   **server.js:** Add `newPageWithViewport()` helper that wraps `newPage()` + `setViewportSize()`. Replace all 8 `newPage()` call sites. Viewport stays 1280×720.

3. **`4370c9e` — `fix(deps): update express to 4.22.2 to fix qs vulnerability`**
   express 4.22.1 depends on qs 6.14.2 (vulnerable, GHSA-q8mj-m7cp-5q26). Updating to 4.22.2 pulls qs 6.15.3 (patched). Reduces audit from 5→3 vulnerabilities.

4. **`6ea9000` — `chore(deps): update swagger-jsdoc to 6.3.0`**
   Upgrades `@apidevtools/swagger-parser` to 12.1.0 and `js-yaml` to 4.3.0 (patched, fixes GHSA-h67p-54hq-rp68). This update was previously rolled back because 6.3.0 downgraded express — with express now at 4.22.2, 6.3.0 introduces no new vulnerabilities. OpenAPI regeneration produces identical output (no drift).

## Validation

All gates pass:
- `npx tsc -p .`: exit 0
- OpenAPI unit test: 16/16 pass
- `npm run generate-openapi`: success (no diff)
- Postinstall unit test: 3/3 pass
- E2E smoke (`tabLifecycle`, `navigation`, `snapshotScreenshot`): 22/22 pass
- `npm audit`: 3 vulnerabilities (down from 5; remaining 3 are unfixable transitive devDeps: `@babel/core` + `js-yaml` via Jest 29, `ua-parser-js` via camoufox-js)

## Deferred migrations (require separate specs)

- `camoufox-js` 0.10.2 → 0.11.1 (pre-1.0 runtime coupling)
- `jest` 29 → 30 (test-runner migration)
- `typescript` 5 → 6 (compiler migration)
- `express` 4 → 5 (framework migration)

## Specs & Plans

- `specs/2026-07-04-selective-dependency-maintenance-spec.md`
- `specs/2026-07-06-playwright-core-1.61.1-viewport-compat-spec.md`
- `plans/2026-07-04-selective-dependency-maintenance-implementation-plan.md`
- `plans/2026-07-06-playwright-core-1.61.1-viewport-compat-plan.md`

## Known limitation

The `/tabs/:tabId/viewport` API route uses `page.setViewportSize()` which now works with the patched Juggler. However, if a user runs this code with an unpatched Camoufox binary (e.g. pre-1.61 Playwright), the patch script will need to be re-run. The postinstall hook handles this automatically.