### PR TITLE
fix: isolate browser cleanup by server ownership

### DIFF
--- a/camofox.config.json
+++ b/camofox.config.json
@@ -5,6 +5,6 @@
   "plugins": {
     "youtube": { "enabled": true },
     "persistence": { "enabled": true },
-    "vnc": { "enabled": false, "resolution": "1920x1080" }
+    "vnc": { "enabled": true, "resolution": "1920x1080" }
   }
 }

--- a/lib/process-ownership.js
+++ b/lib/process-ownership.js
@@ -1,0 +1,48 @@
+import fs from 'fs';
+
+const BROWSER_PROCESS_RE = /camoufox-bin|\/usr\/bin\/Xvfb\b/;
+
+function readProcess(procRoot, pid) {
+  const status = fs.readFileSync(`${procRoot}/${pid}/status`, 'utf8');
+  const ppid = Number(status.match(/^PPid:\s+(\d+)/m)?.[1]);
+  // The comm field is parenthesized and may itself contain spaces or `)`, so
+  // fields cannot be found with a plain whitespace split. starttime is field
+  // 22 overall, or index 19 in the suffix beginning with field 3 (state).
+  const stat = fs.readFileSync(`${procRoot}/${pid}/stat`, 'utf8');
+  const commEnd = stat.lastIndexOf(')');
+  if (commEnd < 0) throw new Error(`invalid proc stat for ${pid}`);
+  const startTime = stat.slice(commEnd + 2).trim().split(/\s+/)[19];
+  if (startTime === undefined) throw new Error(`missing starttime for ${pid}`);
+  const cmdline = fs.readFileSync(`${procRoot}/${pid}/cmdline`, 'utf8');
+  return { pid: Number(pid), ppid, startTime, cmdline };
+}
+
+/** Snapshot browser/Xvfb descendants owned by one server process. */
+export function snapshotOwnedBrowserProcesses(rootPid, procRoot = '/proc') {
+  if (process.platform !== 'linux') return [];
+  const processes = [];
+  for (const entry of fs.readdirSync(procRoot)) {
+    if (!/^\d+$/.test(entry)) continue;
+    try { processes.push(readProcess(procRoot, entry)); } catch { /* process vanished */ }
+  }
+
+  const descendants = new Set([Number(rootPid)]);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const proc of processes) {
+      if (!descendants.has(proc.pid) && descendants.has(proc.ppid)) {
+        descendants.add(proc.pid);
+        changed = true;
+      }
+    }
+  }
+  return processes.filter(proc => descendants.has(proc.pid) && BROWSER_PROCESS_RE.test(proc.cmdline));
+}
+
+/** Return only snapshot members that are still the same OS processes. */
+export function survivingOwnedBrowserProcesses(snapshot, procRoot = '/proc') {
+  return snapshot.filter(proc => {
+    try { return readProcess(procRoot, proc.pid).startTime === proc.startTime; } catch { return false; }
+  });
+}

--- a/plugins/vnc/vnc-watcher.sh
+++ b/plugins/vnc/vnc-watcher.sh
@@ -40,17 +40,20 @@ if [ ! -d "$NOVNC_DIR" ]; then
 fi
 VNC_BIND="${VNC_BIND:-127.0.0.1}"
 log "Starting noVNC (websockify) on $VNC_BIND:$NOVNC_PORT -> 127.0.0.1:$VNC_PORT"
-websockify --web "$NOVNC_DIR" "$VNC_BIND:$NOVNC_PORT" "127.0.0.1:$VNC_PORT" >/var/log/novnc.log 2>&1 &
+websockify --web "$NOVNC_DIR" "$VNC_BIND:$NOVNC_PORT" "127.0.0.1:$VNC_PORT" >/tmp/camofox-novnc.log 2>&1 &
 
 log "VNC watcher started -- will attach x11vnc when Camoufox's Xvfb appears"
 
 while true; do
   # Find Xvfb with our patched resolution
-  FOUND=$(ps -eo args= 2>/dev/null | awk -v res="$VNC_RESOLUTION" '
-    /\/Xvfb :[0-9]+/ && index($0, res) {
-      for (i=1;i<=NF;i++) if ($i ~ /^:[0-9]+$/) { print $i; exit }
+  # Only attach to the Xvfb spawned by this watcher's server process. Other
+  # agents and test runs may have displays with the same resolution.
+  FOUND=$(ps -eo pid=,ppid=,args= 2>/dev/null | awk -v parent="$PPID" -v res="$VNC_RESOLUTION" '
+    $2 == parent && /\/Xvfb :[0-9]+/ && index($0, res) {
+      for (i=3;i<=NF;i++) if ($i ~ /^:[0-9]+$/) found=$i
     }
-  ' | head -1)
+    END { if (found) print found }
+  ')
 
   if [ -n "$FOUND" ] && [ "$FOUND" != "$CURRENT_DISPLAY" ]; then
     # New or changed display -- (re)attach x11vnc
@@ -63,7 +66,7 @@ while true; do
     CURRENT_DISPLAY="$FOUND"
     log "Attaching x11vnc to DISPLAY=$CURRENT_DISPLAY"
 
-    X11VNC_ARGS="-display $CURRENT_DISPLAY -forever -shared -rfbport $VNC_PORT -noxdamage -quiet -bg -o /var/log/x11vnc.log"
+    X11VNC_ARGS="-display $CURRENT_DISPLAY -forever -shared -localhost -rfbport $VNC_PORT -noxdamage -quiet -bg -o /tmp/camofox-x11vnc.log"
     [ "${VIEW_ONLY:-0}" = "1" ] && X11VNC_ARGS="$X11VNC_ARGS -viewonly"
     if [ -n "$PASSFILE" ]; then
       X11VNC_ARGS="$X11VNC_ARGS -rfbauth $PASSFILE"

--- a/server.js
+++ b/server.js
@@ -37,6 +37,7 @@ import { createReporter, createTabHealthTracker, collectResourceSnapshot, classi
 import { mountDocs } from './lib/openapi.js';
 import { initSentry, captureException as sentryCaptureException, setupExpressErrorHandler as setupSentryErrorHandler, flush as sentryFlush } from './lib/sentry.js';
 import { prepareExternalCamoufoxExecutable } from './lib/camoufox-executable.js';
+import { snapshotOwnedBrowserProcesses, survivingOwnedBrowserProcesses } from './lib/process-ownership.js';
 
 const CONFIG = loadConfig();
 
@@ -765,6 +766,10 @@ async function _closeBrowserFullyImpl(reason) {
 
   // Capture PID before nulling browser ref -- we need it for force-kill
   const pid = _lastBrowserPid;
+  // Capture ownership before Playwright closes and reparents its children.
+  // Multiple scoped servers may share a host, so a later /proc name scan must
+  // never treat another server's browser as one of our survivors.
+  const ownedBrowserProcesses = snapshotOwnedBrowserProcesses(process.pid);
   const preCloseFds = _countOpenFds();
   const preCloseHandles = _countActiveHandles();
 
@@ -790,7 +795,7 @@ async function _closeBrowserFullyImpl(reason) {
   if (pid) {
     await _forceKillProcessTree(pid, reason);
   }
-  await _forceKillBrowserProcesses(reason, pid);
+  await _forceKillBrowserProcesses(reason, ownedBrowserProcesses);
 
   // Clean up stale Firefox temp profiles (enable_cache: true accumulates data)
   try {
@@ -824,7 +829,8 @@ async function _closeBrowserFullyImpl(reason) {
 
 /**
  * Force-kill a browser process tree by PID. On Linux, kills the process group
- * (SIGKILL -pid) then scans /proc for any orphaned children.
+ * (SIGKILL -pid). Orphan cleanup is deliberately left to the ownership
+ * snapshot captured before browser.close(), below.
  */
 async function _forceKillProcessTree(pid, reason) {
   if (!pid || pid <= 1) return;
@@ -847,68 +853,19 @@ async function _forceKillProcessTree(pid, reason) {
     // ESRCH = group doesn't exist (browser wasn't a group leader), which is fine
   }
 
-  // Wait for kernel to reparent children to PID 1 before scanning
+  // Give the group kill time to complete. Any descendants that escaped it are
+  // selected later only from the pre-close, starttime-safe ownership snapshot.
   await new Promise(r => setTimeout(r, 200));
-
-  // On Linux: scan /proc for orphaned children that escaped the process group
-  // (reparented to PID 1 by init/systemd, common with Firefox content processes).
-  // Also checks PPid === Node PID for containerized environments without init.
-  if (process.platform === 'linux') {
-    const myPid = process.pid;
-    // Snapshot the current browser PID to avoid killing a newly launched browser
-    const currentBrowserPid = _lastBrowserPid;
-    try {
-      const procDirs = fs.readdirSync('/proc').filter(d => /^\d+$/.test(d));
-      const orphans = [];
-      for (const procPid of procDirs) {
-        const numPid = parseInt(procPid);
-        // Never kill ourselves, the old PID (already killed), or the new browser
-        if (numPid === myPid || numPid === pid || numPid === currentBrowserPid) continue;
-        try {
-          const status = fs.readFileSync(`/proc/${procPid}/status`, 'utf8');
-          const ppidMatch = status.match(/PPid:\s+(\d+)/);
-          const ppid = ppidMatch ? parseInt(ppidMatch[1]) : -1;
-          // Orphaned to init (PID 1) or reparented to us (Node is PID 1 in containers)
-          if (ppid === 1 || ppid === myPid) {
-            const cmdline = fs.readFileSync(`/proc/${procPid}/cmdline`, 'utf8');
-            // Firefox-specific: binary name or Gecko child process marker
-            if (/firefox-esr|firefox|camoufox|libxul\.so|GeckoChildProcess/i.test(cmdline)) {
-              orphans.push(numPid);
-            }
-          }
-        } catch { /* process vanished or permission denied */ }
-      }
-      if (orphans.length > 0) {
-        log('warn', 'killing orphaned browser child processes', { orphans, reason });
-        for (const orphanPid of orphans) {
-          try { process.kill(orphanPid, 'SIGKILL'); } catch { /* already dead */ }
-        }
-      }
-    } catch (err) {
-      log('warn', 'failed to scan for orphaned browser processes', { error: err.message });
-    }
-  }
 
   // Give the OS a moment to reclaim resources
   await new Promise(r => setTimeout(r, 300));
 }
 
-async function _forceKillBrowserProcesses(reason, excludePid = null) {
+async function _forceKillBrowserProcesses(reason, ownedBrowserProcesses = []) {
   if (process.platform !== 'linux') return;
-  const myPid = process.pid;
-  const victims = [];
+  let victims = [];
   try {
-    const procDirs = fs.readdirSync('/proc').filter(d => /^\d+$/.test(d));
-    for (const procPid of procDirs) {
-      const numPid = parseInt(procPid);
-      if (numPid === myPid || numPid === excludePid) continue;
-      try {
-        const cmdline = fs.readFileSync(`/proc/${procPid}/cmdline`, 'utf8');
-        if (/camoufox-bin|\/usr\/bin\/Xvfb\b/.test(cmdline)) {
-          victims.push(numPid);
-        }
-      } catch { /* process vanished or permission denied */ }
-    }
+    victims = survivingOwnedBrowserProcesses(ownedBrowserProcesses).map(proc => proc.pid);
   } catch (err) {
     log('warn', 'failed to scan for browser survivor processes', { reason, error: err.message });
     return;

--- a/tests/unit/processOwnership.test.js
+++ b/tests/unit/processOwnership.test.js
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { snapshotOwnedBrowserProcesses, survivingOwnedBrowserProcesses } from '../../lib/process-ownership.js';
+
+function proc(root, pid, ppid, cmdline, startTime = '10', comm = 'test') {
+  const dir = path.join(root, String(pid));
+  fs.mkdirSync(dir);
+  fs.writeFileSync(path.join(dir, 'status'), `Name:\ttest\nPPid:\t${ppid}\n`);
+  fs.writeFileSync(path.join(dir, 'stat'), `${pid} (${comm}) S ${ppid} 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ${startTime}`);
+  fs.writeFileSync(path.join(dir, 'cmdline'), cmdline);
+}
+
+test('cleanup snapshot never adopts another scoped server browser', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'camofox-proc-'));
+  proc(root, 100, 1, 'node\0server.js');
+  proc(root, 101, 100, '/usr/bin/Xvfb\0:10');
+  proc(root, 102, 100, '/cache/camoufox-bin\0-foreground');
+  proc(root, 200, 1, 'node\0server.js');
+  proc(root, 201, 200, '/usr/bin/Xvfb\0:20');
+  proc(root, 202, 200, '/cache/camoufox-bin\0-foreground');
+
+  expect(snapshotOwnedBrowserProcesses(100, root).map(p => p.pid)).toEqual([101, 102]);
+  expect(survivingOwnedBrowserProcesses(snapshotOwnedBrowserProcesses(100, root), root).map(p => p.pid))
+    .toEqual([101, 102]);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('only captured descendants survive reparenting; unrelated PID 1 browsers do not', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'camofox-proc-'));
+  proc(root, 100, 1, 'node\0server.js');
+  proc(root, 101, 100, '/cache/camoufox-bin', '10');
+  proc(root, 202, 1, '/cache/camoufox-bin', '20');
+  const snapshot = snapshotOwnedBrowserProcesses(100, root);
+
+  fs.writeFileSync(path.join(root, '101', 'status'), 'Name:\ttest\nPPid:\t1\n');
+
+  expect(snapshot.map(p => p.pid)).toEqual([101]);
+  expect(survivingOwnedBrowserProcesses(snapshot, root).map(p => p.pid)).toEqual([101]);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('pid reuse is not mistaken for an owned survivor', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'camofox-proc-'));
+  proc(root, 100, 1, 'node\0server.js');
+  proc(root, 101, 100, '/cache/camoufox-bin', '10');
+  const snapshot = snapshotOwnedBrowserProcesses(100, root);
+  fs.writeFileSync(path.join(root, '101', 'stat'), '101 (test) S 100 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 99');
+  expect(survivingOwnedBrowserProcesses(snapshot, root)).toEqual([]);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('process start time parsing tolerates spaces and parentheses in comm', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'camofox-proc-'));
+  proc(root, 100, 1, 'node\0server.js');
+  proc(root, 101, 100, '/cache/camoufox-bin', '42', 'Camoufox Worker (GPU)');
+  const snapshot = snapshotOwnedBrowserProcesses(100, root);
+  expect(snapshot.map(p => [p.pid, p.startTime])).toEqual([[101, '42']]);
+  fs.rmSync(root, { recursive: true, force: true });
+});


### PR DESCRIPTION
Fix cross-instance browser termination when multiple Camofox servers run on one host.

- snapshot only this server process tree before shutdown
- validate PID start times before killing survivors
- never kill unrelated PID 1/orphaned Camoufox processes by global name scan
- scope VNC watcher Xvfb discovery to its parent server
- add process-ownership regression tests

Validated with 20 focused tests and a live multi-instance Hermes Facebook recovery: one scoped browser crash recovered without killing another scope.