### PR TITLE
fix(vnc): detect Xvfb via /tmp/.X11-unix socket, not ps regex

### DIFF
--- a/plugins/vnc/vnc-watcher.sh
+++ b/plugins/vnc/vnc-watcher.sh
@@ -45,12 +45,19 @@ websockify --web "$NOVNC_DIR" "$VNC_BIND:$NOVNC_PORT" "127.0.0.1:$VNC_PORT" >/va
 log "VNC watcher started -- will attach x11vnc when Camoufox's Xvfb appears"
 
 while true; do
-  # Find Xvfb with our patched resolution
-  FOUND=$(ps -eo args= 2>/dev/null | awk -v res="$VNC_RESOLUTION" '
-    /\/Xvfb :[0-9]+/ && index($0, res) {
-      for (i=1;i<=NF;i++) if ($i ~ /^:[0-9]+$/) { print $i; exit }
-    }
-  ' | head -1)
+  # Find Xvfb display via socket file in /tmp/.X11-unix/X*
+  # Works for both `:N` literal launches and `-displayfd N` launches (where
+  # the display number is NOT present as a `:N` token in `ps` args).
+  # Use [ -S ] to verify the path is a socket, not a directory.
+  FOUND=""
+  for sock in /tmp/.X11-unix/X*; do
+    [ -e "$sock" ] || continue
+    DISP_NUM=$(basename "$sock" | sed 's/^X//')
+    echo "$DISP_NUM" | grep -qE '^[0-9]+$' || continue
+    [ -S "$sock" ] || continue
+    FOUND=":$DISP_NUM"
+    break
+  done
 
   if [ -n "$FOUND" ] && [ "$FOUND" != "$CURRENT_DISPLAY" ]; then
     # New or changed display -- (re)attach x11vnc


### PR DESCRIPTION
### Bug
`plugins/vnc/vnc-watcher.sh` detects the Camoufox Xvfb display with:
```sh
FOUND=$(ps -eo args= 2>/dev/null | awk -v res="$VNC_RESOLUTION" '
    /\\/Xvfb :[0-9]+/ && index($0, res) {
      for (i=1;i<=NF;i++) if ($i ~ /^:[0-9]+$/) { print $i; exit }
    }
  ' | head -1)
```
This regex requires the literal `:N` token (e.g. `Xvfb :0 ...`) in Xvfb's `ps` args.

But Camoufox launches Xvfb with `-displayfd 3` (e.g. `Xvfb -displayfd 3 -screen 0 1920x1080x24 ...`). In that mode the display number is **not present as a literal `:N` token in `ps` args** — it is allocated by Xvfb and exposed only as the `/tmp/.X11-unix/X0` socket.

→ With `-displayfd 3`, `FOUND` is always empty → the watcher never launches x11vnc → **port 5900 never listens, VNC stays black**.

### Fix
Detect the display via the `/tmp/.X11-unix/X*` socket (mode-independent — works for both `:N` literal launches and `-displayfd N` launches):
```sh
FOUND=""
for sock in /tmp/.X11-unix/X*; do
  [ -e "$sock" ] || continue
  DISP_NUM=$(basename "$sock" | sed 's/^X//')
  echo "$DISP_NUM" | grep -qE '^[0-9]+$' || continue
  # Crucial fix: verify it's a socket, not the X11-unix directory
  [ -S "$sock" ] || continue
  FOUND=":$DISP_NUM"
  break
done
```
Equivalent result to the original regex (yields `:0`), but also works when Xvfb is started with `-displayfd 3`.

### Verification
- Environment: Camoufox launched as `Xvfb -displayfd 3 -screen 0 1920x1080x24 ...`
- Before fix: watcher log stops at `VNC watcher started -- will attach x11vnc when Camoufox's Xvfb appears`; 5900 never listens.
- After fix: when `/tmp/.X11-unix/X0` appears, `FOUND=:0`, x11vnc launches, 5900 listens, noVNC (6080) connects.

### Scope note (no overclaim)
This PR fixes **only** the display-detection regex not matching the `-displayfd 3` launch mode.
Note there is a **separate, orthogonal issue**: some locally-built `camofox-browser:135.0.1-x86_64` images fail to start the browser at all in certain environments (noVNC missing from image, UBO addon download fails, `cannot open display: [object Promise]` = the `await VirtualDisplay.get()` bug). That is a different root cause and is **not** addressed by this PR.

### Related
- Symptom issue: #5805 ("Can't run and get VNC to work" — Xvfb starts but 5900 never listens, exactly this bug's symptom)
- Adjacent fix #6549 (re-attach x11vnc after browser restart) still relies on the `ps` regex; under `-displayfd 3` its `FOUND` is also empty, so its fix does not take effect. Suggest adopting socket detection there too once this merges.