### PR TITLE
feat: add CAMOFOX_NET_INTERFACE to bind server to specific network interface

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -70,6 +70,7 @@ function loadConfig() {
   const browserIdleTimeoutMs = parseInt(process.env.BROWSER_IDLE_TIMEOUT_MS, 10);
   return {
     port: parseInt(process.env.CAMOFOX_PORT || process.env.PORT || '9377', 10),
+    host: process.env.CAMOFOX_NET_INTERFACE || '',
     nodeEnv: process.env.NODE_ENV || 'development',
     flyMachineId: process.env.FLY_MACHINE_ID || '',
     flyAppName: process.env.FLY_APP_NAME || '',

--- a/server.js
+++ b/server.js
@@ -6072,11 +6072,11 @@ const server = app.listen(PORT, HOST, async () => {
   startMemoryReporter();
   refreshActiveTabsGauge();
   refreshTabLockQueueDepth();
-  pluginEvents.emit('server:started', { port: PORT, pid: process.pid, plugins: loadedPlugins });
+  pluginEvents.emit('server:started', { port: PORT, host: HOST, pid: process.pid, plugins: loadedPlugins });
   if (FLY_MACHINE_ID) {
-    log('info', 'server started (fly)', { port: PORT, pid: process.pid, machineId: FLY_MACHINE_ID, nodeVersion: process.version });
+    log('info', 'server started (fly)', { port: PORT, host: HOST || '0.0.0.0', pid: process.pid, machineId: FLY_MACHINE_ID, nodeVersion: process.version });
   } else {
-    log('info', 'server started', { port: PORT, pid: process.pid, nodeVersion: process.version });
+    log('info', 'server started', { port: PORT, host: HOST || '0.0.0.0', pid: process.pid, nodeVersion: process.version });
   }
   const tmpCleanup = cleanupOrphanedTempFiles({ tmpDir: os.tmpdir() });
   if (tmpCleanup.removed > 0) {

--- a/server.js
+++ b/server.js
@@ -6031,7 +6031,8 @@ process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 // Fly's auto_stop_machines=false + min_machines_running=2 handles scaling.
 
 const PORT = CONFIG.port;
-pluginEvents.emit('server:starting', { port: PORT });
+const HOST = CONFIG.host;
+pluginEvents.emit('server:starting', { port: PORT, host: HOST });
 
 // Load plugins before starting the server
 const pluginCtx = {
@@ -6067,7 +6068,7 @@ mountDocs(app);
 // --- Sentry Express error handler (after all routes, before app.listen) ---
 setupSentryErrorHandler(app);
 
-const server = app.listen(PORT, async () => {
+const server = app.listen(PORT, HOST, async () => {
   startMemoryReporter();
   refreshActiveTabsGauge();
   refreshTabLockQueueDepth();

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -71,4 +71,18 @@ describe('loadConfig', () => {
       VNC_BIND: '0.0.0.0',
     });
   });
+
+  test('configures network interface binding', () => {
+    delete process.env.CAMOFOX_NET_INTERFACE;
+    expect(loadConfig().host).toBe('');
+
+    process.env.CAMOFOX_NET_INTERFACE = '127.0.0.1';
+    expect(loadConfig().host).toBe('127.0.0.1');
+
+    process.env.CAMOFOX_NET_INTERFACE = '0.0.0.0';
+    expect(loadConfig().host).toBe('0.0.0.0');
+
+    process.env.CAMOFOX_NET_INTERFACE = '192.168.1.100';
+    expect(loadConfig().host).toBe('192.168.1.100');
+  });
 });

--- a/tests/unit/serverBinding.test.js
+++ b/tests/unit/serverBinding.test.js
@@ -1,0 +1,103 @@
+import { describe, expect, test, afterEach, beforeEach } from '@jest/globals';
+import { loadConfig } from '../../lib/config.js';
+import net from 'net';
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('Server network interface binding', () => {
+  test('default binding (no CAMOFOX_NET_INTERFACE) should listen on all interfaces', () => {
+    delete process.env.CAMOFOX_NET_INTERFACE;
+    const config = loadConfig();
+    expect(config.host).toBe('');
+  });
+
+  test('CAMOFOX_NET_INTERFACE=127.0.0.1 should configure loopback binding', () => {
+    process.env.CAMOFOX_NET_INTERFACE = '127.0.0.1';
+    const config = loadConfig();
+    expect(config.host).toBe('127.0.0.1');
+  });
+
+  test('CAMOFOX_NET_INTERFACE=0.0.0.0 should configure all interfaces binding', () => {
+    process.env.CAMOFOX_NET_INTERFACE = '0.0.0.0';
+    const config = loadConfig();
+    expect(config.host).toBe('0.0.0.0');
+  });
+
+  test('CAMOFOX_NET_INTERFACE with specific IP should be preserved', () => {
+    process.env.CAMOFOX_NET_INTERFACE = '192.168.1.100';
+    const config = loadConfig();
+    expect(config.host).toBe('192.168.1.100');
+  });
+
+  // Integration test - verify actual socket binding behavior
+  test('Express server binds to configured host', async () => {
+    const testPort = 38456;
+    const testHost = '127.0.0.1';
+    
+    // Create a simple Express app to test binding
+    const { default: express } = await import('express');
+    const app = express();
+    app.get('/health', (req, res) => res.json({ ok: true }));
+    
+    // Start server with specific host
+    const server = app.listen(testPort, testHost, () => {
+      // Server started successfully
+    });
+    
+    try {
+      // Wait a bit for the server to start
+      await new Promise(resolve => setTimeout(resolve, 100));
+      
+      // Verify the server is listening on the correct address
+      const address = server.address();
+      if (!address) {
+        throw new Error('Server failed to start - no address');
+      }
+      expect(address.port).toBe(testPort);
+      expect(address.address).toBe(testHost);
+      
+      // Verify we can connect to it
+      const response = await fetch(`http://${testHost}:${testPort}/health`);
+      expect(response.ok).toBe(true);
+      const data = await response.json();
+      expect(data.ok).toBe(true);
+      
+    } finally {
+      server.close();
+    }
+  }, 10000);
+
+  test('Express server binds to all interfaces by default', async () => {
+    const testPort = 38457;
+    
+    // Create a simple Express app to test default binding
+    const { default: express } = await import('express');
+    const app = express();
+    app.get('/health', (req, res) => res.json({ ok: true }));
+    
+    // Start server without specific host (default behavior)
+    const server = app.listen(testPort);
+    
+    try {
+      // Verify the server is listening on all interfaces (IPv6 any address)
+      const address = server.address();
+      expect(address.port).toBe(testPort);
+      // When no host is specified, Express listens on all interfaces
+      // The address will be '::' for IPv6 or '0.0.0.0' for IPv4
+      expect(['::', '0.0.0.0']).toContain(address.address);
+      
+      // Verify we can connect to it via localhost
+      const response = await fetch(`http://localhost:${testPort}/health`);
+      expect(response.ok).toBe(true);
+      const data = await response.json();
+      expect(data.ok).toBe(true);
+      
+    } finally {
+      server.close();
+    }
+  }, 10000);
+});


### PR DESCRIPTION
This adds a new environment variable CAMOFOX_NET_INTERFACE that allows configuring which network interface the server should listen on.

By default, it listens on all interfaces (empty string), but can be configured to listen only on loopback (127.0.0.1) for improved security.

Fixes security issue where server was always listening on all network interfaces, which could expose the service to unauthorized access from other machines on the same network.

Usage:
```
  CAMOFOX_NET_INTERFACE=127.0.0.1 npm start  # Loopback only (secure)

  CAMOFOX_NET_INTERFACE=0.0.0.0 npm start    # All interfaces (explicit)

  npm start                                  # All interfaces (default)
```

Testing:
- Unit tests: npm test -- tests/unit/config.test.js tests/unit/serverBinding.test.js
- Added 6 new tests covering configuration parsing and server binding behavior
- Integration tests verify actual Express server binds to correct interfaces
- Functional testing performed with these exact commands:
  * Launch loopback: CAMOFOX_PORT=9380 CAMOFOX_NET_INTERFACE=127.0.0.1 npm start
  * Verify binding: ss -tlpn 'sport = 9380'  # Shows 127.0.0.1:9380
  * Test access: curl -s http://127.0.0.1:9380/health
  * Launch default: CAMOFOX_PORT=9381 npm start
  * Verify binding: ss -tlpn 'sport = 9381'  # Shows *:9381
  * Test access: curl -s http://127.0.0.1:9381/health

All tests pass, backward compatibility preserved.