### PR TITLE
feat: support configurable server bind host

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,7 @@ Reddit macros return JSON directly (no HTML parsing needed):
 |----------|-------------|---------|
 | `CAMOFOX_PORT` | Server port | `9377` |
 | `PORT` | Server port (fallback, for platforms like Fly.io, Railway) | `9377` |
+| `CAMOFOX_BIND_HOST` | Optional server bind host. Set to `127.0.0.1` for loopback-only access or `0.0.0.0` for IPv4 on all interfaces. When unset, Node uses its default all-interface binding. | - |
 | `CAMOFOX_API_KEY` | Enable cookie import endpoint (disabled if unset) | - |
 | `CAMOFOX_ADMIN_KEY` | Required for `POST /stop` | - |
 | `CAMOFOX_ACCESS_KEY` | If set, all routes (except `/health`, cookie import, and `/stop`) require `Authorization: Bearer <key>`. Lets you safely expose the server beyond loopback. | - |
@@ -696,7 +697,7 @@ The persistence plugin saves cookies and localStorage to `~/.camofox/profiles/<h
 
 ### Network access
 
-Outbound connections are made to: (1) URLs the agent navigates to (core functionality), (2) the telemetry endpoint (anonymized, opt-out available). Inbound: the REST API on localhost:9377 (default), optionally protected by `CAMOFOX_ACCESS_KEY`.
+Outbound connections are made to: (1) URLs the agent navigates to (core functionality), (2) the telemetry endpoint (anonymized, opt-out available). Inbound: the REST API on port 9377, bound to all interfaces by default or to `CAMOFOX_BIND_HOST` when configured, optionally protected by `CAMOFOX_ACCESS_KEY`.
 
 ### Subprocess usage
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -70,6 +70,7 @@ function loadConfig() {
   const browserIdleTimeoutMs = parseInt(process.env.BROWSER_IDLE_TIMEOUT_MS, 10);
   return {
     port: parseInt(process.env.CAMOFOX_PORT || process.env.PORT || '9377', 10),
+    bindHost: (process.env.CAMOFOX_BIND_HOST || '').trim(),
     nodeEnv: process.env.NODE_ENV || 'development',
     flyMachineId: process.env.FLY_MACHINE_ID || '',
     flyAppName: process.env.FLY_APP_NAME || '',
@@ -121,6 +122,7 @@ function loadConfig() {
       PATH: process.env.PATH,
       HOME: process.env.HOME,
       NODE_ENV: process.env.NODE_ENV,
+      CAMOFOX_BIND_HOST: process.env.CAMOFOX_BIND_HOST,
       CAMOFOX_ADMIN_KEY: process.env.CAMOFOX_ADMIN_KEY,
       CAMOFOX_API_KEY: process.env.CAMOFOX_API_KEY,
       CAMOFOX_ACCESS_KEY: process.env.CAMOFOX_ACCESS_KEY,

--- a/server.js
+++ b/server.js
@@ -6067,7 +6067,7 @@ mountDocs(app);
 // --- Sentry Express error handler (after all routes, before app.listen) ---
 setupSentryErrorHandler(app);
 
-const server = app.listen(PORT, async () => {
+const server = app.listen(PORT, CONFIG.bindHost || undefined, async () => {
   startMemoryReporter();
   refreshActiveTabsGauge();
   refreshTabLockQueueDepth();

--- a/server.js
+++ b/server.js
@@ -6071,11 +6071,13 @@ const server = app.listen(PORT, CONFIG.bindHost || undefined, async () => {
   startMemoryReporter();
   refreshActiveTabsGauge();
   refreshTabLockQueueDepth();
-  pluginEvents.emit('server:started', { port: PORT, pid: process.pid, plugins: loadedPlugins });
+  const address = server.address();
+  const bindHost = typeof address === 'object' && address ? address.address : CONFIG.bindHost;
+  pluginEvents.emit('server:started', { port: PORT, host: bindHost, pid: process.pid, plugins: loadedPlugins });
   if (FLY_MACHINE_ID) {
-    log('info', 'server started (fly)', { port: PORT, pid: process.pid, machineId: FLY_MACHINE_ID, nodeVersion: process.version });
+    log('info', 'server started (fly)', { port: PORT, host: bindHost, pid: process.pid, machineId: FLY_MACHINE_ID, nodeVersion: process.version });
   } else {
-    log('info', 'server started', { port: PORT, pid: process.pid, nodeVersion: process.version });
+    log('info', 'server started', { port: PORT, host: bindHost, pid: process.pid, nodeVersion: process.version });
   }
   const tmpCleanup = cleanupOrphanedTempFiles({ tmpDir: os.tmpdir() });
   if (tmpCleanup.removed > 0) {

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -8,6 +8,15 @@ afterEach(() => {
 });
 
 describe('loadConfig', () => {
+  test('reads the optional API bind host and forwards it to server subprocesses', () => {
+    process.env.CAMOFOX_BIND_HOST = '127.0.0.1';
+
+    const config = loadConfig();
+
+    expect(config.bindHost).toBe('127.0.0.1');
+    expect(config.serverEnv.CAMOFOX_BIND_HOST).toBe('127.0.0.1');
+  });
+
   test('prefers CAMOUFOX_EXECUTABLE for external Camoufox executable', () => {
     process.env.CAMOUFOX_EXECUTABLE = '/nix/store/camoufox/bin/camoufox';
     process.env.CAMOUFOX_EXECUTABLE_PATH = '/ignored/camoufox';


### PR DESCRIPTION
## Summary

- add optional `CAMOFOX_BIND_HOST` configuration
- pass the configured host to `app.listen`
- forward the setting to launched server subprocesses
- preserve the existing all-interface behavior when unset

## Why

Local-only deployments currently bind the API to every interface. This option lets operators explicitly bind to `127.0.0.1` without changing cloud or container defaults.

## Verification

- `npm test -- --runInBand tests/unit/config.test.js` passes (3/3)
- manual server smoke test succeeds with `CAMOFOX_BIND_HOST=127.0.0.1`
- listener verified on `127.0.0.1:9377`
- loopback request succeeds and ordinary-LAN request times out
- browser navigation smoke test succeeds

The full `npm test` run completed 40 suites with 668 passing tests; the E2E suites that require `/tmp/camofox-e2e-env.json` failed because that shared environment was not started in this standalone checkout.
