### PR TITLE
feat(mcp): add stdio MCP server (Claude Code, Codex, agy, Cursor, opencode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,30 @@ openclaw plugins install @askjo/camofox-browser
 
 **Tools:** `camofox_create_tab`  |  `camofox_snapshot`  |  `camofox_click`  |  `camofox_type`  |  `camofox_navigate`  |  `camofox_scroll`  |  `camofox_screenshot`  |  `camofox_close_tab`  |  `camofox_list_tabs`  |  `camofox_import_cookies`
 
+### MCP Server (Claude Code / any MCP host)
+
+A standalone [Model Context Protocol](https://modelcontextprotocol.io) server (`mcp/server.mjs`) exposes the same 11 tools to any MCP-compatible host — Claude Code, Cursor, etc. It mirrors the OpenClaw plugin 1:1 (same tool names, schemas, and REST routes), so behavior is identical regardless of which host reaches camofox.
+
+The MCP server only **forwards** calls — start the REST server first (`npm start`), then register the MCP server with your host:
+
+```bash
+# Claude Code
+claude mcp add camofox-browser \
+  --env CAMOFOX_BASE_URL=http://localhost:9377 \
+  -- node ./mcp/server.mjs
+```
+
+Verify with `/mcp` in Claude Code — you should see `camofox-browser` connected with all 11 tools.
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `CAMOFOX_BASE_URL` | `http://localhost:9377` | REST server URL |
+| `CAMOFOX_USER_ID` | `mcp-<random>` | Session isolation (one MCP server = one camofox session) |
+| `CAMOFOX_SESSION_KEY` | `default` | Tab partition within the user |
+| `CAMOFOX_API_KEY` | _(unset)_ | Required only for `camofox_import_cookies` |
+
+Run directly with `npm run mcp`, or use the `camofox-mcp` bin after install.
+
 ### Standalone
 
 Run from npm:

--- a/README.md
+++ b/README.md
@@ -78,30 +78,6 @@ openclaw plugins install @askjo/camofox-browser
 
 **Tools:** `camofox_create_tab`  |  `camofox_snapshot`  |  `camofox_click`  |  `camofox_type`  |  `camofox_navigate`  |  `camofox_scroll`  |  `camofox_screenshot`  |  `camofox_close_tab`  |  `camofox_list_tabs`  |  `camofox_import_cookies`
 
-### MCP Server (Claude Code / any MCP host)
-
-A standalone [Model Context Protocol](https://modelcontextprotocol.io) server (`mcp/server.mjs`) exposes the same 11 tools to any MCP-compatible host — Claude Code, Cursor, etc. It mirrors the OpenClaw plugin 1:1 (same tool names, schemas, and REST routes), so behavior is identical regardless of which host reaches camofox.
-
-The MCP server only **forwards** calls — start the REST server first (`npm start`), then register the MCP server with your host:
-
-```bash
-# Claude Code
-claude mcp add camofox-browser \
-  --env CAMOFOX_BASE_URL=http://localhost:9377 \
-  -- node ./mcp/server.mjs
-```
-
-Verify with `/mcp` in Claude Code — you should see `camofox-browser` connected with all 11 tools.
-
-| Env var | Default | Purpose |
-|---------|---------|---------|
-| `CAMOFOX_BASE_URL` | `http://localhost:9377` | REST server URL |
-| `CAMOFOX_USER_ID` | `mcp-<random>` | Session isolation (one MCP server = one camofox session) |
-| `CAMOFOX_SESSION_KEY` | `default` | Tab partition within the user |
-| `CAMOFOX_API_KEY` | _(unset)_ | Required only for `camofox_import_cookies` |
-
-Run directly with `npm run mcp`, or use the `camofox-mcp` bin after install.
-
 ### Standalone
 
 Run from npm:

--- a/lib/mcp-tool-contracts.mjs
+++ b/lib/mcp-tool-contracts.mjs
@@ -1,0 +1,491 @@
+/**
+ * Canonical tool contracts for the camofox-browser REST API.
+ *
+ * Single source of truth shared by two hosts that expose the same 11 tools:
+ *   - mcp/server.mjs   (stdio MCP server for Claude Code, Codex, agy, Cursor, opencode)
+ *   - plugin.ts        (OpenClaw plugin)
+ *
+ * Importing this module from both hosts means tool names, JSON-Schema
+ * parameters, REST routes, request bodies, auth semantics, and response
+ * shaping cannot drift — the REST server sees identical traffic regardless of
+ * which host the agent reached it through.
+ *
+ * Auth model (mirrors lib/auth.js):
+ *   - CAMOFOX_ACCESS_KEY (global superkey): when set, every route except
+ *     /health, cookie import, /auth-sessions, /stop requires
+ *     `Authorization: Bearer <accessKey>`.
+ *   - CAMOFOX_API_KEY (cookie-only gate): the cookie-import route requires
+ *     `Authorization: Bearer <apiKey>` (or loopback + non-production).
+ *
+ * Each buildRequest() result declares `auth: 'accessKey' | 'apiKey' | 'none'`
+ * and `responseKind: 'json' | 'snapshot' | 'image'` so the host's fetch layer
+ * and response adapter stay declarative.
+ */
+
+import { readCookieFile } from './cookies.js';
+
+/**
+ * @typedef {Object} ToolDef
+ * @property {string} name
+ * @property {string} description
+ * @property {object} inputSchema - JSON Schema (object) for tool arguments.
+ */
+
+/**
+ * @typedef {Object} RequestSpec
+ * @property {string} method - HTTP method.
+ * @property {string} path - Path (already includes query string when needed).
+ * @property {'accessKey'|'apiKey'|'none'} auth
+ * @property {'json'|'snapshot'|'image'} responseKind
+ * @property {object} [body] - JSON body.
+ * @property {object} [meta] - Extra metadata for response shaping.
+ */
+
+/**
+ * @typedef {Object} CallContext
+ * @property {string} userId - Session owner (scopes cookie/storage partition).
+ * @property {string} [sessionKey] - Tab partition within a user.
+ */
+
+const SEARCH_MACROS = [
+  '@google_search',
+  '@youtube_search',
+  '@amazon_search',
+  '@reddit_search',
+  '@wikipedia_search',
+  '@twitter_search',
+  '@yelp_search',
+  '@spotify_search',
+  '@netflix_search',
+  '@linkedin_search',
+  '@instagram_search',
+  '@tiktok_search',
+  '@twitch_search',
+];
+
+/**
+ * The 11 tools, identical schema for both hosts. Edit here and both update.
+ * @type {ToolDef[]}
+ */
+export const TOOL_DEFS = [
+  {
+    name: 'camofox_create_tab',
+    description:
+      'PREFERRED: Create a new browser tab using Camoufox anti-detection browser. Use camofox tools instead of Chrome/built-in browser - they bypass bot detection on Google, Amazon, LinkedIn, etc. Returns tabId for subsequent operations.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'Initial URL to navigate to' },
+      },
+      required: ['url'],
+    },
+  },
+  {
+    name: 'camofox_snapshot',
+    description:
+      'Get accessibility snapshot of a Camoufox page with element refs (e1, e2, etc.) for interaction, plus a visual screenshot. ' +
+      'Large pages are truncated with pagination links preserved at the bottom. ' +
+      'If the response includes hasMore=true and nextOffset, call again with that offset to see more content.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: { type: 'string', description: 'Tab identifier' },
+        offset: {
+          type: 'number',
+          description: 'Character offset for paginated snapshots. Use nextOffset from a previous truncated response.',
+        },
+      },
+      required: ['tabId'],
+    },
+  },
+  {
+    name: 'camofox_click',
+    description: 'Click an element in a Camoufox tab by ref (e.g., e1) or CSS selector.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: { type: 'string', description: 'Tab identifier' },
+        ref: { type: 'string', description: 'Element ref from snapshot (e.g., e1)' },
+        selector: { type: 'string', description: 'CSS selector (alternative to ref)' },
+      },
+      required: ['tabId'],
+    },
+  },
+  {
+    name: 'camofox_type',
+    description: 'Type text into an element in a Camoufox tab.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: { type: 'string', description: 'Tab identifier' },
+        ref: { type: 'string', description: 'Element ref from snapshot (e.g., e2)' },
+        selector: { type: 'string', description: 'CSS selector (alternative to ref)' },
+        text: { type: 'string', description: 'Text to type' },
+        pressEnter: { type: 'boolean', description: 'Press Enter after typing' },
+      },
+      required: ['tabId', 'text'],
+    },
+  },
+  {
+    name: 'camofox_navigate',
+    description:
+      'Navigate a Camoufox tab to a URL or use a search macro (@google_search, @youtube_search, etc.). Preferred over Chrome for sites with bot detection.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: { type: 'string', description: 'Tab identifier' },
+        url: { type: 'string', description: 'URL to navigate to' },
+        macro: {
+          type: 'string',
+          description: 'Search macro (e.g., @google_search, @youtube_search)',
+          enum: SEARCH_MACROS,
+        },
+        query: { type: 'string', description: 'Search query (when using macro)' },
+      },
+      required: ['tabId'],
+    },
+  },
+  {
+    name: 'camofox_scroll',
+    description: 'Scroll a Camoufox page.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: { type: 'string', description: 'Tab identifier' },
+        direction: { type: 'string', enum: ['up', 'down', 'left', 'right'] },
+        amount: { type: 'number', description: 'Pixels to scroll' },
+      },
+      required: ['tabId', 'direction'],
+    },
+  },
+  {
+    name: 'camofox_screenshot',
+    description: 'Take a screenshot of a Camoufox page.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: { type: 'string', description: 'Tab identifier' },
+      },
+      required: ['tabId'],
+    },
+  },
+  {
+    name: 'camofox_close_tab',
+    description: 'Close a Camoufox browser tab.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: { type: 'string', description: 'Tab identifier' },
+      },
+      required: ['tabId'],
+    },
+  },
+  {
+    name: 'camofox_evaluate',
+    description:
+      "Execute JavaScript in a Camoufox tab's page context. Returns the result of the expression. Use for injecting scripts, reading page state, or calling web app APIs.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: { type: 'string', description: 'Tab identifier' },
+        expression: {
+          type: 'string',
+          description: 'JavaScript expression to evaluate in the page context',
+        },
+      },
+      required: ['tabId', 'expression'],
+    },
+  },
+  {
+    name: 'camofox_list_tabs',
+    description: 'List all open Camofox tabs for the current session.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'camofox_import_cookies',
+    description:
+      'Import cookies into the current Camoufox session (Netscape cookie file). Use to authenticate to sites like LinkedIn without interactive login. Requires CAMOFOX_API_KEY on the REST server.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        cookiesPath: {
+          type: 'string',
+          description: 'Relative path to a Netscape-format cookies.txt file within the server cookies directory',
+        },
+        domainSuffix: {
+          type: 'string',
+          description: 'Only import cookies whose domain ends with this suffix',
+        },
+      },
+      required: ['cookiesPath'],
+    },
+  },
+];
+
+/** Quick name → def lookup. */
+export const TOOL_BY_NAME = Object.fromEntries(TOOL_DEFS.map((t) => [t.name, t]));
+
+/** Tool names in canonical order. */
+export const TOOL_NAMES = TOOL_DEFS.map((t) => t.name);
+
+/**
+ * Strip the routing key (tabId) from args, returning the REST body fields.
+ * @param {Record<string, unknown>} args
+ * @param {string} [dropKey]
+ * @returns {Record<string, unknown>}
+ */
+function without(args, dropKey = 'tabId') {
+  const { [dropKey]: _omit, ...rest } = args;
+  return rest;
+}
+
+/**
+ * Build a REST request spec for a tool. Pure / synchronous — except cookie
+ * import, which needs async file parsing; use buildCookieRequest() for that.
+ *
+ * @param {string} name - Tool name.
+ * @param {Record<string, unknown>} args - Tool arguments.
+ * @param {CallContext} ctx - { userId, sessionKey }.
+ * @returns {RequestSpec}
+ * @throws {Error} if the tool is unknown.
+ */
+export function buildRequest(name, args, ctx) {
+  const userId = ctx.userId;
+  const sessionKey = ctx.sessionKey;
+  switch (name) {
+    case 'camofox_create_tab':
+      return {
+        method: 'POST',
+        path: '/tabs',
+        auth: 'accessKey',
+        responseKind: 'json',
+        body: { url: args.url, userId, sessionKey },
+      };
+    case 'camofox_snapshot': {
+      const params = new URLSearchParams({ userId, includeScreenshot: 'true' });
+      if (args.offset != null && args.offset !== '') params.set('offset', String(args.offset));
+      return {
+        method: 'GET',
+        path: `/tabs/${args.tabId}/snapshot?${params}`,
+        auth: 'accessKey',
+        responseKind: 'snapshot',
+      };
+    }
+    case 'camofox_click':
+      return {
+        method: 'POST',
+        path: `/tabs/${args.tabId}/click`,
+        auth: 'accessKey',
+        responseKind: 'json',
+        body: { ...without(args), userId },
+      };
+    case 'camofox_type':
+      return {
+        method: 'POST',
+        path: `/tabs/${args.tabId}/type`,
+        auth: 'accessKey',
+        responseKind: 'json',
+        body: { ...without(args), userId },
+      };
+    case 'camofox_navigate':
+      return {
+        method: 'POST',
+        path: `/tabs/${args.tabId}/navigate`,
+        auth: 'accessKey',
+        responseKind: 'json',
+        body: { ...without(args), userId },
+      };
+    case 'camofox_scroll':
+      return {
+        method: 'POST',
+        path: `/tabs/${args.tabId}/scroll`,
+        auth: 'accessKey',
+        responseKind: 'json',
+        body: { ...without(args), userId },
+      };
+    case 'camofox_screenshot':
+      return {
+        method: 'GET',
+        path: `/tabs/${args.tabId}/screenshot?${new URLSearchParams({ userId })}`,
+        auth: 'accessKey',
+        responseKind: 'image',
+      };
+    case 'camofox_close_tab':
+      return {
+        method: 'DELETE',
+        path: `/tabs/${args.tabId}?${new URLSearchParams({ userId })}`,
+        auth: 'accessKey',
+        responseKind: 'json',
+      };
+    case 'camofox_evaluate':
+      return {
+        method: 'POST',
+        path: `/tabs/${args.tabId}/evaluate`,
+        auth: 'accessKey',
+        responseKind: 'json',
+        body: { userId, expression: args.expression },
+      };
+    case 'camofox_list_tabs':
+      return {
+        method: 'GET',
+        path: `/tabs?${new URLSearchParams({ userId })}`,
+        auth: 'accessKey',
+        responseKind: 'json',
+      };
+    case 'camofox_import_cookies':
+      // Async (Netscape parse + path check) — caller must use buildCookieRequest().
+      throw new Error('camofox_import_cookies requires buildCookieRequest() (async cookie parsing)');
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+/**
+ * Cookie import is special: the Netscape file must be parsed locally (matching
+ * the OpenClaw plugin) and the REST route accepts a parsed `{ cookies: [...] }`
+ * body, never a path. This function does the parse and returns a request spec
+ * that the host fetch layer can dispatch like any other tool.
+ *
+ * @param {{cookiesPath: string, domainSuffix?: string}} args
+ * @param {CallContext} ctx
+ * @param {{apiKey: string, cookiesDir: string}} config - server config (apiKey + cookiesDir).
+ * @returns {Promise<RequestSpec & {meta: {imported: number, userId: string}}>}
+ * @throws {Error} if CAMOFOX_API_KEY is unset.
+ */
+export async function buildCookieRequest(args, ctx, config) {
+  if (!config.apiKey) {
+    throw new Error(
+      'CAMOFOX_API_KEY is not set. Cookie import is disabled unless both the server and the host (MCP/OpenClaw) have CAMOFOX_API_KEY.'
+    );
+  }
+  const cookies = await readCookieFile({
+    cookiesDir: config.cookiesDir,
+    cookiesPath: args.cookiesPath,
+    domainSuffix: args.domainSuffix,
+  });
+  return {
+    method: 'POST',
+    path: `/sessions/${encodeURIComponent(ctx.userId)}/cookies`,
+    auth: 'apiKey',
+    responseKind: 'json',
+    body: { cookies },
+    meta: { imported: cookies.length, userId: ctx.userId },
+  };
+}
+
+/**
+ * Resolve which bearer token a request needs, given server config.
+ * @param {RequestSpec} spec
+ * @param {{accessKey?: string, apiKey?: string}} config
+ * @returns {{header?: {Authorization: string}, missing?: string}}
+ */
+export function authHeaders(spec, config) {
+  if (spec.auth === 'accessKey') {
+    if (!config.accessKey) return {}; // server not gated — no header needed
+    return { Authorization: `Bearer ${config.accessKey}` };
+  }
+  if (spec.auth === 'apiKey') {
+    // apiKey presence is enforced by buildCookieRequest(); here we only attach it.
+    return { Authorization: `Bearer ${config.apiKey}` };
+  }
+  return {};
+}
+
+/**
+ * Execute a request spec against a REST base URL. Shared by the MCP server and
+ * the OpenClaw plugin so the wire-level behavior (auth headers, image decoding,
+ * error formatting) is identical across hosts.
+ *
+ * @param {string} baseUrl - REST server origin (e.g. http://localhost:9377).
+ * @param {RequestSpec} spec
+ * @param {{accessKey?: string, apiKey?: string}} config
+ * @returns {Promise<unknown>} JSON value, or an image content block for image specs.
+ * @throws {Error} on non-2xx, or when an image route returns non-image bytes.
+ */
+export async function fetchSpec(baseUrl, spec, config) {
+  const headers = {
+    'Content-Type': 'application/json',
+    ...authHeaders(spec, config),
+  };
+  const res = await fetch(`${baseUrl}${spec.path}`, {
+    method: spec.method,
+    headers,
+    body: spec.body ? JSON.stringify(spec.body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${res.status}: ${text}`);
+  }
+  if (spec.responseKind === 'image') {
+    const contentType = res.headers.get('content-type') || '';
+    // Guard: server may return JSON/text (e.g. error with 200) — don't base64 it.
+    if (!contentType.startsWith('image/')) {
+      const text = await res.text();
+      throw new Error(`Screenshot failed: ${text}`);
+    }
+    const data = Buffer.from(await res.arrayBuffer()).toString('base64');
+    return { type: 'image', data, mimeType: contentType };
+  }
+  return res.json();
+}
+
+/**
+ * Build + dispatch a tool call end-to-end. The single entry point both hosts
+ * call, so a tool's full behavior (request shape + auth + transport + response
+ * shaping) lives in exactly one place. Hosts only differ in how they source
+ * `ctx` (userId/sessionKey) and `config`.
+ *
+ * @param {string} name - Tool name.
+ * @param {Record<string, unknown>} args - Tool arguments.
+ * @param {CallContext} ctx - { userId, sessionKey }.
+ * @param {string} baseUrl - REST server origin.
+ * @param {{apiKey?: string, accessKey?: string, cookiesDir: string}} config - server config.
+ * @returns {Promise<{spec: RequestSpec, payload: unknown}>}
+ */
+export async function runTool(name, args, ctx, baseUrl, config) {
+  const spec =
+    name === 'camofox_import_cookies'
+      ? await buildCookieRequest(args, ctx, config)
+      : buildRequest(name, args, ctx);
+  const payload = await fetchSpec(baseUrl, spec, config);
+  return { spec, payload };
+}
+
+/**
+ * Shape a REST JSON payload into MCP/OpenClaw content blocks.
+ *
+ * - snapshot: splits the embedded screenshot out as an image block
+ * - image: already an image block produced by the fetch layer
+ * - json (default): pretty-printed JSON text block
+ *
+ * @param {RequestSpec} spec
+ * @param {unknown} payload - JSON value ('json'/'snapshot') or an image block ('image').
+ * @returns {Array<{type: string, text?: string, data?: string, mimeType?: string}>}
+ */
+export function adaptResponse(spec, payload) {
+  if (spec.responseKind === 'image') {
+    return [payload];
+  }
+  if (spec.responseKind === 'snapshot') {
+    const { screenshot, ...rest } = /** @type {any} */ (payload) || {};
+    const content = [{ type: 'text', text: JSON.stringify(rest, null, 2) }];
+    if (screenshot?.data) {
+      content.push({
+        type: 'image',
+        data: screenshot.data,
+        mimeType: screenshot.mimeType || 'image/png',
+      });
+    }
+    return content;
+  }
+  // Cookie import: surface the parsed count alongside the server reply.
+  if (spec.meta && spec.meta.imported != null) {
+    return [
+      {
+        type: 'text',
+        text: JSON.stringify({ imported: spec.meta.imported, userId: spec.meta.userId, result: payload }, null, 2),
+      },
+    ];
+  }
+  return [{ type: 'text', text: JSON.stringify(payload, null, 2) }];
+}

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -13,6 +13,8 @@ The MCP server is a thin stdio client over the camofox REST server. Two pieces:
 
 Registering the MCP server does **not** require being inside the camofox-browser checkout. The examples below work from any directory.
 
+`mcp/` is also an **independently installable package** (`@askjo/camofox-mcp`, its own `package.json`). It depends on nothing but `@modelcontextprotocol/sdk` — no `camoufox-js`, `playwright-core`, `express`, or the ~300MB browser binary download that the core server pulls in. Tool names, JSON-Schema parameters, REST routes, and response shaping are imported from `../lib/mcp-tool-contracts.mjs`, the same canonical module the OpenClaw plugin (`plugin.ts`) uses, so the two hosts cannot drift. See **Option D** below if you only want the MCP adapter (e.g. pointing `CAMOFOX_BASE_URL` at a REST server running elsewhere).
+
 ## 1. Start the REST server
 
 Clone the repo and start the server (one-time binary download on first run):
@@ -38,6 +40,14 @@ npm install -g @askjo/camofox-browser
 
 # Option C — npx (no install; pins to a published version)
 #   use `npx -y @askjo/camofox-browser mcp` wherever a command is expected below
+
+# Option D — MCP adapter only, no core server deps (lightest footprint)
+#   Skips camoufox-js/playwright-core/express and the browser binary download —
+#   use this if a camofox-browser REST server is already running (locally or
+#   remotely) and you only need the stdio adapter.
+git clone https://github.com/jo-inc/camofox-browser && cd camofox-browser/mcp
+npm install   # installs only @modelcontextprotocol/sdk (~24MB, no postinstall)
+npm link      # camofox-mcp now resolves from any directory
 ```
 
 Verify the bin resolves from any directory:
@@ -145,7 +155,7 @@ For the other hosts, add the same keys to the `env` / `environment` field of tha
 claude mcp add camofox-browser -- node /Users/you/src/camofox-browser/mcp/server.mjs
 ```
 
-> ⚠️ Always prefer the `camofox-mcp` bin (options A/B/C above). The `node ./mcp/server.mjs` form is **path-dependent** — relative paths break outside the checkout.
+> ⚠️ Always prefer the `camofox-mcp` bin (options A/B/C/D above). The `node ./mcp/server.mjs` form is **path-dependent** — relative paths break outside the checkout.
 
 ## 4. Verify
 
@@ -194,6 +204,7 @@ Element refs are unambiguous and preferred over CSS selectors — a selector tha
 | `CAMOFOX_BASE_URL` | `http://localhost:9377` | REST server URL |
 | `CAMOFOX_USER_ID` | `mcp-<random>` | Session isolation (one MCP server = one camofox session) |
 | `CAMOFOX_SESSION_KEY` | `default` | Tab partition within the user |
+| `CAMOFOX_ACCESS_KEY` | _(unset)_ | Global bearer token gating the REST server (superkey). If set, forwarded as `Authorization: Bearer <key>` on **every** tool call automatically — must match the REST server's own `CAMOFOX_ACCESS_KEY`. Without this, a globally-authenticated REST server rejects all tool calls except cookie import. |
 | `CAMOFOX_API_KEY` | _(unset)_ | Self-chosen secret gating cookie import. Optional on localhost; required on remote/production and must match the REST server's `CAMOFOX_API_KEY`. Only affects `camofox_import_cookies`. |
 
 ## Troubleshooting
@@ -202,11 +213,25 @@ Element refs are unambiguous and preferred over CSS selectors — a selector tha
 - **`camofox_scroll` returns `{ok:true}` but the page doesn't move** — expected on lazy-load / virtual-scroll pages; the server's `mouse.wheel` no-ops there. Use `camofox_evaluate` with `window.scrollTo` / `scrollBy`.
 - **`422 strict mode violation ... resolved to N elements`** on `click` — CSS selector matched multiple elements. Re-snapshot and click by element ref.
 - **`403 Forbidden` on `camofox_import_cookies`** — key mismatch between REST server and MCP server, or hitting a remote server without `CAMOFOX_API_KEY`.
+- **`401`/`403` on every tool call, not just cookie import** — the REST server has `CAMOFOX_ACCESS_KEY` set. Set the same `CAMOFOX_ACCESS_KEY` in the MCP server's env (see table above) — it's forwarded automatically as `Authorization: Bearer` once set.
 
-## Smoke test (developer)
+## Testing (developer)
 
-A dependency-free smoke test exercises the handshake, all 11 tools, and schemas — no REST server required:
+Two layers, covering different things:
 
 ```bash
+# 1. Handshake + schema smoke test — spawns the real stdio server, checks
+#    initialize/tools/list return all 11 tools with the right shape.
+#    No REST server required.
 npm run test:mcp
+
+# 2. Mock-HTTP contract tests — verifies the actual REST traffic each tool
+#    produces: routes, methods, request bodies, CAMOFOX_ACCESS_KEY/CAMOFOX_API_KEY
+#    auth headers, cookie parsing (Netscape file → `{ cookies }` body, never a
+#    path), screenshot decoding, and error handling. Mocked REST server — no
+#    live camofox-browser process needed. This is what makes the "OpenClaw and
+#    MCP send identical requests" claim verifiable, not just asserted.
+NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit/mcp-contracts.test.js
 ```
+
+Both hosts (this MCP server and the OpenClaw plugin, `plugin.ts`) share one contract module, [`lib/mcp-tool-contracts.mjs`](../lib/mcp-tool-contracts.mjs) — tool schemas, REST routes, auth, and response shaping are defined once and imported by both, so they cannot drift out of sync.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,30 +4,78 @@ A standalone [Model Context Protocol](https://modelcontextprotocol.io) server th
 
 It mirrors the existing OpenClaw plugin **1:1**: same 11 tool names, identical JSON-Schema parameters, and the same REST routes. Whether an agent reaches camofox via OpenClaw or MCP, the behavior is identical.
 
-## How it works
+## Architecture
 
-The MCP server only **forwards** calls to the camofox REST server (`localhost:9377` by default). It does not launch the browser itself — start the REST server first, then register the MCP server with your host.
+The MCP server is a thin stdio client over the camofox REST server. Two pieces:
 
-## Quick start
+- **REST server** (`server.js`) — launches Camoufox, exposes the HTTP API on `:9377`. Run **once**, it stays up.
+- **MCP server** (`mcp/server.mjs`, exposed as the `camofox-mcp` bin) — translates MCP tool calls into REST calls. Claude Code spawns one **per session**.
 
-1. Start the REST server (one-time binary download on first run):
+Registering the MCP server does **not** require being inside the camofox-browser checkout. The examples below work from any directory.
 
-   ```bash
-   npm install   # downloads Camoufox (~300MB) on first run
-   npm start     # → http://localhost:9377
-   ```
+## 1. Start the REST server
 
-2. Register the MCP server with your host. For Claude Code:
+Clone the repo and start the server (one-time binary download on first run):
 
-   ```bash
-   claude mcp add camofox-browser \
-     --env CAMOFOX_BASE_URL=http://localhost:9377 \
-     -- node ./mcp/server.mjs
-   ```
+```bash
+git clone https://github.com/jo-inc/camofox-browser && cd camofox-browser
+npm install   # downloads Camoufox (~300MB) on first run
+npm start     # → http://localhost:9377
+```
 
-   Or run directly with `npm run mcp`, or via the `camofox-mcp` bin after `npm install`.
+This stays running in the background. It does not need to be your cwd afterwards.
 
-3. Verify — run `/mcp` in Claude Code. You should see `camofox-browser` connected with all 11 tools.
+## 2. Register the MCP server
+
+Pick one — they all expose the same `camofox-mcp` bin so they work from **any directory**.
+
+**Option A — `npm link` (recommended for local development)**
+
+From the camofox-browser checkout (once):
+
+```bash
+npm link           # exposes the `camofox-mcp` bin globally
+```
+
+Then register from anywhere:
+
+```bash
+claude mcp add camofox-browser -- camofox-mcp
+```
+
+**Option B — `npm install -g` (global install without the source checkout)**
+
+```bash
+npm install -g @askjo/camofox-browser
+claude mcp add camofox-browser -- camofox-mcp
+```
+
+**Option C — `npx` (no install; pins to a published version)**
+
+```bash
+claude mcp add camofox-browser -- npx -y @askjo/camofox-browser mcp
+```
+
+**From-source fallback** (only if you're working inside the checkout and haven't linked):
+
+```bash
+claude mcp add camofox-browser -- node ./mcp/server.mjs
+```
+
+> ⚠️ The `node ./mcp/server.mjs` form is **path-dependent** — it only works when cwd is the checkout. Prefer options A–C for use outside the repo.
+
+If you need cookie import or a non-default REST URL, pass env:
+
+```bash
+claude mcp add camofox-browser \
+  --env CAMOFOX_BASE_URL=http://localhost:9377 \
+  --env CAMOFOX_API_KEY=<key> \
+  -- camofox-mcp
+```
+
+## 3. Verify
+
+Run `/mcp` in Claude Code. You should see `camofox-browser` connected with all 11 tools.
 
 ## Tools
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,82 @@
+# camofox-browser MCP server
+
+A standalone [Model Context Protocol](https://modelcontextprotocol.io) server that exposes camofox-browser to any MCP-compatible host — Claude Code, Cursor, etc. — without requiring OpenClaw.
+
+It mirrors the existing OpenClaw plugin **1:1**: same 11 tool names, identical JSON-Schema parameters, and the same REST routes. Whether an agent reaches camofox via OpenClaw or MCP, the behavior is identical.
+
+## How it works
+
+The MCP server only **forwards** calls to the camofox REST server (`localhost:9377` by default). It does not launch the browser itself — start the REST server first, then register the MCP server with your host.
+
+## Quick start
+
+1. Start the REST server (one-time binary download on first run):
+
+   ```bash
+   npm install   # downloads Camoufox (~300MB) on first run
+   npm start     # → http://localhost:9377
+   ```
+
+2. Register the MCP server with your host. For Claude Code:
+
+   ```bash
+   claude mcp add camofox-browser \
+     --env CAMOFOX_BASE_URL=http://localhost:9377 \
+     -- node ./mcp/server.mjs
+   ```
+
+   Or run directly with `npm run mcp`, or via the `camofox-mcp` bin after `npm install`.
+
+3. Verify — run `/mcp` in Claude Code. You should see `camofox-browser` connected with all 11 tools.
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `camofox_create_tab` | Open a URL → returns `tabId` |
+| `camofox_snapshot` | Accessibility snapshot + element refs (`e1`, `e2`, ...) + screenshot |
+| `camofox_navigate` | Go to a URL **or** use a search macro (`@google_search`, `@reddit_search`, ...) |
+| `camofox_click` | Click by element ref (`e1`) or CSS selector |
+| `camofox_type` | Type text into a ref/selector, optional `pressEnter` |
+| `camofox_scroll` | Scroll by pixels (unreliable on lazy-load pages — prefer `camofox_evaluate`) |
+| `camofox_screenshot` | Standalone screenshot |
+| `camofox_evaluate` | Run JS in page context — extract data, call page APIs, scroll via `window.scrollTo` |
+| `camofox_list_tabs` | List open tabs in this session |
+| `camofox_close_tab` | Close a tab |
+| `camofox_import_cookies` | Import a Netscape cookie file (needs `CAMOFOX_API_KEY`) |
+
+## Workflow
+
+Every interaction follows the same shape — **snapshot before you act**:
+
+1. `create_tab({ url })` → `tabId`
+2. `snapshot({ tabId })` → element refs (`e1`, `e2`, ...)
+3. `click`/`type` using those refs
+4. `snapshot` again to read the new state
+5. `close_tab` when done
+
+Element refs are unambiguous and preferred over CSS selectors — a selector that matches multiple elements returns `422 strict mode violation`, in which case re-snapshot and click by ref.
+
+## Environment variables
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `CAMOFOX_BASE_URL` | `http://localhost:9377` | REST server URL |
+| `CAMOFOX_USER_ID` | `mcp-<random>` | Session isolation (one MCP server = one camofox session) |
+| `CAMOFOX_SESSION_KEY` | `default` | Tab partition within the user |
+| `CAMOFOX_API_KEY` | _(unset)_ | Self-chosen secret gating cookie import. Optional on localhost; required on remote/production and must match the REST server's `CAMOFOX_API_KEY`. Only affects `camofox_import_cookies`. |
+
+## Troubleshooting
+
+- **`503 session_expired` / `tab create timed out`** — the REST server's browser session died (often after a prior failed call destabilized it). Restart `npm start`.
+- **`camofox_scroll` returns `{ok:true}` but the page doesn't move** — expected on lazy-load / virtual-scroll pages; the server's `mouse.wheel` no-ops there. Use `camofox_evaluate` with `window.scrollTo` / `scrollBy`.
+- **`422 strict mode violation ... resolved to N elements`** on `click` — CSS selector matched multiple elements. Re-snapshot and click by element ref.
+- **`403 Forbidden` on `camofox_import_cookies`** — key mismatch between REST server and MCP server, or hitting a remote server without `CAMOFOX_API_KEY`.
+
+## Verification
+
+A dependency-free smoke test exercises the handshake, all 11 tools, and schemas — no REST server required:
+
+```bash
+npm run test:mcp
+```

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -25,57 +25,139 @@ npm start     # → http://localhost:9377
 
 This stays running in the background. It does not need to be your cwd afterwards.
 
-## 2. Register the MCP server
+## 2. Install the `camofox-mcp` bin
 
-Pick one — they all expose the same `camofox-mcp` bin so they work from **any directory**.
-
-**Option A — `npm link` (recommended for local development)**
-
-From the camofox-browser checkout (once):
+The MCP server is the same for every host — what differs is only the config file you paste into. First, make the `camofox-mcp` bin available on your PATH. Pick one:
 
 ```bash
-npm link           # exposes the `camofox-mcp` bin globally
-```
+# Option A — npm link (if you have the source checkout; picks up local edits)
+cd camofox-browser && npm link
 
-Then register from anywhere:
-
-```bash
-claude mcp add camofox-browser -- camofox-mcp
-```
-
-**Option B — `npm install -g` (global install without the source checkout)**
-
-```bash
+# Option B — global install (no source checkout needed)
 npm install -g @askjo/camofox-browser
-claude mcp add camofox-browser -- camofox-mcp
+
+# Option C — npx (no install; pins to a published version)
+#   use `npx -y @askjo/camofox-browser mcp` wherever a command is expected below
 ```
 
-**Option C — `npx` (no install; pins to a published version)**
+Verify the bin resolves from any directory:
 
 ```bash
-claude mcp add camofox-browser -- npx -y @askjo/camofox-browser mcp
+which camofox-mcp   # → .../bin/camofox-mcp
 ```
 
-**From-source fallback** (only if you're working inside the checkout and haven't linked):
+## 3. Register with your host
+
+All five hosts speak standard MCP, so they all run the same `camofox-mcp` bin. Pick your host's config snippet below.
+
+### Claude Code
 
 ```bash
-claude mcp add camofox-browser -- node ./mcp/server.mjs
+# CLI (user scope = available in every project)
+claude mcp add camofox-browser -s user -- camofox-mcp
 ```
 
-> ⚠️ The `node ./mcp/server.mjs` form is **path-dependent** — it only works when cwd is the checkout. Prefer options A–C for use outside the repo.
+Or in `~/.claude.json` (user) / `.mcp.json` (project, checked in):
 
-If you need cookie import or a non-default REST URL, pass env:
+```json
+{
+  "mcpServers": {
+    "camofox-browser": {
+      "command": "camofox-mcp"
+    }
+  }
+}
+```
+
+### Codex CLI
+
+`~/.codex/config.toml` (user) or `.codex/config.toml` (project, trusted dirs only):
+
+```toml
+[mcp_servers.camofox-browser]
+command = "camofox-mcp"
+env = { CAMOFOX_BASE_URL = "http://localhost:9377" }
+```
+
+### Antigravity / agy
+
+Global `~/.gemini/config/mcp_config.json` or workspace `.agents/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "camofox-browser": {
+      "command": "camofox-mcp"
+    }
+  }
+}
+```
+
+### Cursor
+
+Global `~/.cursor/mcp.json` or project `.cursor/mcp.json` (checked in):
+
+```json
+{
+  "mcpServers": {
+    "camofox-browser": {
+      "command": "camofox-mcp"
+    }
+  }
+}
+```
+
+(Or via UI: Settings → Cursor Settings → MCP → Add New MCP Server.)
+
+### opencode
+
+`opencode.json` in the project root, or global `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "camofox-browser": {
+      "type": "local",
+      "command": ["camofox-mcp"]
+    }
+  }
+}
+```
+
+### Common: env vars and from-source fallback
+
+If you need cookie import or a non-default REST URL, add env. Example for Claude Code:
 
 ```bash
-claude mcp add camofox-browser \
+claude mcp add camofox-browser -s user \
   --env CAMOFOX_BASE_URL=http://localhost:9377 \
   --env CAMOFOX_API_KEY=<key> \
   -- camofox-mcp
 ```
 
-## 3. Verify
+For the other hosts, add the same keys to the `env` / `environment` field of that host's snippet.
 
-Run `/mcp` in Claude Code. You should see `camofox-browser` connected with all 11 tools.
+**From-source fallback** (only if you're inside the checkout and haven't linked the bin):
+
+```bash
+# Replace `camofox-mcp` with `node /absolute/path/to/mcp/server.mjs`
+claude mcp add camofox-browser -- node /Users/you/src/camofox-browser/mcp/server.mjs
+```
+
+> ⚠️ Always prefer the `camofox-mcp` bin (options A/B/C above). The `node ./mcp/server.mjs` form is **path-dependent** — relative paths break outside the checkout.
+
+## 4. Verify
+
+| Host | How to verify |
+|------|---------------|
+| Claude Code | `/mcp` — `camofox-browser` shows connected |
+| Codex CLI | `codex` then check MCP server list |
+| agy | `/mcp` overlay in the `agy` CLI |
+| Cursor | Settings → MCP — server shows green |
+| opencode | `opencode mcp list` |
+
+You should see 11 tools: `camofox_create_tab`, `camofox_snapshot`, `camofox_click`, `camofox_type`, `camofox_navigate`, `camofox_scroll`, `camofox_screenshot`, `camofox_evaluate`, `camofox_list_tabs`, `camofox_close_tab`, `camofox_import_cookies`.
 
 ## Tools
 
@@ -121,7 +203,7 @@ Element refs are unambiguous and preferred over CSS selectors — a selector tha
 - **`422 strict mode violation ... resolved to N elements`** on `click` — CSS selector matched multiple elements. Re-snapshot and click by element ref.
 - **`403 Forbidden` on `camofox_import_cookies`** — key mismatch between REST server and MCP server, or hitting a remote server without `CAMOFOX_API_KEY`.
 
-## Verification
+## Smoke test (developer)
 
 A dependency-free smoke test exercises the handshake, all 11 tools, and schemas — no REST server required:
 

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1181 @@
+{
+  "name": "@askjo/camofox-mcp",
+  "version": "1.12.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@askjo/camofox-mcp",
+      "version": "1.12.1",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
+      "bin": {
+        "camofox-mcp": "server.mjs"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@askjo/camofox-mcp",
+  "version": "1.12.1",
+  "description": "Standalone stdio MCP server exposing the camofox-browser REST API as MCP tools (Claude Code, Codex, agy, Cursor, opencode). Proxies to an already-running camofox-browser REST server — does not itself require the browser binary, Playwright, or the core server's dependencies.",
+  "type": "module",
+  "main": "server.mjs",
+  "license": "MIT",
+  "author": "Jo Inc <oss@askjo.ai>",
+  "homepage": "https://github.com/jo-inc/camofox-browser/tree/master/mcp#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jo-inc/camofox-browser.git",
+    "directory": "mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/jo-inc/camofox-browser/issues"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "camofox",
+    "camoufox",
+    "browser-automation",
+    "claude-code",
+    "codex",
+    "cursor",
+    "opencode"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "bin": {
+    "camofox-mcp": "./server.mjs"
+  },
+  "files": [
+    "server.mjs",
+    "README.md"
+  ],
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0"
+  }
+}

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -2,320 +2,81 @@
 // camofox-browser MCP server
 //
 // Standalone Model Context Protocol server that exposes the camofox-browser
-// REST API (default http://localhost:9377) as MCP tools. Mirrors the 11 tools
-// defined in plugin.ts (the OpenClaw plugin) 1:1 — same names, schemas, routes —
-// so behavior is identical whether an agent reaches camofox via OpenClaw or MCP.
+// REST API (default http://localhost:9377) as MCP tools. Tool names, schemas,
+// REST routes, request bodies, auth, and response shaping are imported from
+// lib/mcp-tool-contracts.mjs — the SAME source of truth the OpenClaw plugin
+// (plugin.ts) uses — so behavior is identical whether an agent reaches camofox
+// via OpenClaw or MCP. Drift is structurally impossible.
 //
-// Transport: stdio (Claude Code spawns this as a child process).
-// The camofox REST server itself must be running (npm start) — this server only
-// forwards calls, it does not launch the browser.
+// Transport: stdio (Claude Code / Codex / agy / Cursor / opencode spawn this as
+// a child process). The camofox REST server itself must be running (npm start) —
+// this server only forwards calls, it does not launch the browser.
+//
+// Auth:
+//   - CAMOFOX_ACCESS_KEY (global): forwarded as `Authorization: Bearer` on every
+//     request so globally-authenticated REST servers accept MCP traffic.
+//   - CAMOFOX_API_KEY (cookie import): forwarded as `Authorization: Bearer` on
+//     the cookie-import route only.
 
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
 import { randomUUID } from "node:crypto";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
 
-const BASE_URL = process.env.CAMOFOX_BASE_URL || "http://localhost:9377";
-// Per-MCP-server userId so each Claude Code session gets an isolated camofox
-// session (cookie/storage partition). Falls back to a random id.
+import { loadConfig } from "../lib/config.js";
+import {
+  TOOL_DEFS,
+  runTool,
+  adaptResponse,
+} from "../lib/mcp-tool-contracts.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Version from this package's own package.json (single source — no hardcoded
+// duplicate). mcp/ is an independently installable package (@askjo/camofox-mcp)
+// with its own manifest, so this reads locally rather than the parent repo's.
+const VERSION = JSON.parse(
+  readFileSync(join(__dirname, "package.json"), "utf8")
+).version;
+
+// Server config (apiKey / accessKey / cookiesDir / port). Loaded once; env wins
+// over loadConfig() for MCP-specific overrides via CAMOFOX_BASE_URL.
+const CONFIG = loadConfig();
+const BASE_URL = process.env.CAMOFOX_BASE_URL || `http://localhost:${CONFIG.port}`;
+
+// Per-MCP-server userId so each host session gets an isolated camofox session
+// (cookie/storage partition). Falls back to a random id.
 const USER_ID = process.env.CAMOFOX_USER_ID || `mcp-${randomUUID()}`;
 // sessionKey partitions tabs within a user (matches plugin.ts fallback "default").
 const SESSION_KEY = process.env.CAMOFOX_SESSION_KEY || "default";
 
-async function fetchApi(path, options = {}) {
-  const res = await fetch(`${BASE_URL}${path}`, {
-    ...options,
-    headers: { "Content-Type": "application/json", ...(options.headers || {}) },
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`${res.status}: ${text}`);
-  }
-  return res;
+// MCP SDK is an optional dependency so the core camofox install stays light.
+// Surface a clear, actionable error if it is missing instead of a stack trace.
+let Server, StdioServerTransport, CallToolRequestSchema, ListToolsRequestSchema;
+try {
+  const serverMod = await import("@modelcontextprotocol/sdk/server/index.js");
+  Server = serverMod.Server;
+  const stdioMod = await import("@modelcontextprotocol/sdk/server/stdio.js");
+  StdioServerTransport = stdioMod.StdioServerTransport;
+  const typesMod = await import("@modelcontextprotocol/sdk/types.js");
+  CallToolRequestSchema = typesMod.CallToolRequestSchema;
+  ListToolsRequestSchema = typesMod.ListToolsRequestSchema;
+} catch {
+  console.error(
+    "[camofox-mcp] @modelcontextprotocol/sdk is not installed.\n" +
+      "Install it with:  npm install @modelcontextprotocol/sdk\n" +
+      "(It is an optionalDependency of this package — add it where you run the MCP server.)"
+  );
+  process.exit(1);
 }
-
-async function fetchJson(path, options) {
-  return (await fetchApi(path, options)).json();
-}
-
-// Build user-scoped query string.
-const q = (extra = "") => `userId=${USER_ID}${extra}`;
-
-// --- Tool definitions: name / description / JSON-Schema parameters / handler ---
-// Schemas are copied verbatim from plugin.ts so OpenClaw and MCP stay in sync.
-const TOOLS = [
-  {
-    name: "camofox_create_tab",
-    description:
-      "PREFERRED: Create a new browser tab using Camoufox anti-detection browser. Use camofox tools instead of Chrome/built-in browser - they bypass bot detection on Google, Amazon, LinkedIn, etc. Returns tabId for subsequent operations.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        url: { type: "string", description: "Initial URL to navigate to" },
-      },
-      required: ["url"],
-    },
-    async run({ url }) {
-      return fetchJson("/tabs", {
-        method: "POST",
-        body: JSON.stringify({ url, userId: USER_ID, sessionKey: SESSION_KEY }),
-      });
-    },
-  },
-  {
-    name: "camofox_snapshot",
-    description:
-      "Get accessibility snapshot of a Camoufox page with element refs (e1, e2, etc.) for interaction, plus a visual screenshot. " +
-      "Large pages are truncated with pagination links preserved at the bottom. " +
-      "If the response includes hasMore=true and nextOffset, call again with that offset to see more content.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-        offset: {
-          type: "number",
-          description:
-            "Character offset for paginated snapshots. Use nextOffset from a previous truncated response.",
-        },
-      },
-      required: ["tabId"],
-    },
-    async run({ tabId, offset }) {
-      const qs = `&includeScreenshot=true${offset ? `&offset=${offset}` : ""}`;
-      const r = await fetchJson(`/tabs/${tabId}/snapshot?${q(qs)}`);
-      // Strip the raw screenshot from the text payload; return it as an image
-      // content block so the host renders it instead of dumping base64.
-      const { screenshot, ...rest } = r;
-      const content = [{ type: "text", text: JSON.stringify(rest, null, 2) }];
-      if (screenshot?.data) {
-        content.push({
-          type: "image",
-          data: screenshot.data,
-          mimeType: screenshot.mimeType || "image/png",
-        });
-      }
-      return content;
-    },
-  },
-  {
-    name: "camofox_click",
-    description: "Click an element in a Camoufox tab by ref (e.g., e1) or CSS selector.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-        ref: { type: "string", description: "Element ref from snapshot (e.g., e1)" },
-        selector: { type: "string", description: "CSS selector (alternative to ref)" },
-      },
-      required: ["tabId"],
-    },
-    async run({ tabId, ...rest }) {
-      return fetchJson(`/tabs/${tabId}/click`, {
-        method: "POST",
-        body: JSON.stringify({ ...rest, userId: USER_ID }),
-      });
-    },
-  },
-  {
-    name: "camofox_type",
-    description: "Type text into an element in a Camoufox tab.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-        ref: { type: "string", description: "Element ref from snapshot (e.g., e2)" },
-        selector: { type: "string", description: "CSS selector (alternative to ref)" },
-        text: { type: "string", description: "Text to type" },
-        pressEnter: { type: "boolean", description: "Press Enter after typing" },
-      },
-      required: ["tabId", "text"],
-    },
-    async run({ tabId, ...rest }) {
-      return fetchJson(`/tabs/${tabId}/type`, {
-        method: "POST",
-        body: JSON.stringify({ ...rest, userId: USER_ID }),
-      });
-    },
-  },
-  {
-    name: "camofox_navigate",
-    description:
-      "Navigate a Camoufox tab to a URL or use a search macro (@google_search, @youtube_search, etc.). Preferred over Chrome for sites with bot detection.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-        url: { type: "string", description: "URL to navigate to" },
-        macro: {
-          type: "string",
-          description: "Search macro (e.g., @google_search, @youtube_search)",
-          enum: [
-            "@google_search",
-            "@youtube_search",
-            "@amazon_search",
-            "@reddit_search",
-            "@wikipedia_search",
-            "@twitter_search",
-            "@yelp_search",
-            "@spotify_search",
-            "@netflix_search",
-            "@linkedin_search",
-            "@instagram_search",
-            "@tiktok_search",
-            "@twitch_search",
-          ],
-        },
-        query: { type: "string", description: "Search query (when using macro)" },
-      },
-      required: ["tabId"],
-    },
-    async run({ tabId, ...rest }) {
-      return fetchJson(`/tabs/${tabId}/navigate`, {
-        method: "POST",
-        body: JSON.stringify({ ...rest, userId: USER_ID }),
-      });
-    },
-  },
-  {
-    name: "camofox_scroll",
-    description: "Scroll a Camoufox page.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-        direction: { type: "string", enum: ["up", "down", "left", "right"] },
-        amount: { type: "number", description: "Pixels to scroll" },
-      },
-      required: ["tabId", "direction"],
-    },
-    async run({ tabId, ...rest }) {
-      return fetchJson(`/tabs/${tabId}/scroll`, {
-        method: "POST",
-        body: JSON.stringify({ ...rest, userId: USER_ID }),
-      });
-    },
-  },
-  {
-    name: "camofox_screenshot",
-    description: "Take a screenshot of a Camoufox page.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-      },
-      required: ["tabId"],
-    },
-    async run({ tabId }) {
-      const res = await fetchApi(`/tabs/${tabId}/screenshot?${q()}`);
-      const contentType = res.headers.get("content-type") || "";
-      // Guard: server may return JSON/text (e.g. error with 200) — don't base64 it.
-      if (!contentType.startsWith("image/")) {
-        const text = await res.text();
-        return [{ type: "text", text: `Screenshot failed: ${text}` }];
-      }
-      const buf = Buffer.from(await res.arrayBuffer()).toString("base64");
-      return [{ type: "image", data: buf, mimeType: contentType }];
-    },
-  },
-  {
-    name: "camofox_close_tab",
-    description: "Close a Camoufox browser tab.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-      },
-      required: ["tabId"],
-    },
-    async run({ tabId }) {
-      return fetchJson(`/tabs/${tabId}?${q()}`, { method: "DELETE" });
-    },
-  },
-  {
-    name: "camofox_evaluate",
-    description:
-      "Execute JavaScript in a Camoufox tab's page context. Returns the result of the expression. Use for injecting scripts, reading page state, or calling web app APIs.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-        expression: {
-          type: "string",
-          description: "JavaScript expression to evaluate in the page context",
-        },
-      },
-      required: ["tabId", "expression"],
-    },
-    async run({ tabId, expression }) {
-      return fetchJson(`/tabs/${tabId}/evaluate`, {
-        method: "POST",
-        body: JSON.stringify({ userId: USER_ID, expression }),
-      });
-    },
-  },
-  {
-    name: "camofox_list_tabs",
-    description: "List all open Camoufox tabs for the current session.",
-    inputSchema: { type: "object", properties: {}, required: [] },
-    async run() {
-      return fetchJson(`/tabs?${q()}`);
-    },
-  },
-  {
-    name: "camofox_import_cookies",
-    description:
-      "Import cookies into the current Camoufox session (Netscape cookie file). Use to authenticate to sites like LinkedIn without interactive login. Requires CAMOFOX_API_KEY on the REST server.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        cookiesPath: {
-          type: "string",
-          description: "Path to Netscape-format cookies.txt file",
-        },
-        domainSuffix: {
-          type: "string",
-          description: "Only import cookies whose domain ends with this suffix",
-        },
-      },
-      required: ["cookiesPath"],
-    },
-    async run(args, extra) {
-      // Cookie import needs the server-side API key as a bearer token. We pass it
-      // through from the MCP server env; the host (Claude Code) must provide it.
-      const apiKey = extra?.apiKey || process.env.CAMOFOX_API_KEY;
-      if (!apiKey) {
-        throw new Error(
-          "CAMOFOX_API_KEY is not set. Cookie import is disabled unless the server and the MCP server both have CAMOFOX_API_KEY."
-        );
-      }
-      // Server-side reads + validates the cookie file, so we just forward the path
-      // alongside the user-scoped session. (REST route accepts a path under the
-      // configured cookiesDir; for arbitrary paths the file must be reachable by
-      // the server process.)
-      const body = {
-        userId: USER_ID,
-        cookiesPath: args.cookiesPath,
-        ...(args.domainSuffix ? { domainSuffix: args.domainSuffix } : {}),
-      };
-      return fetchJson(`/sessions/${encodeURIComponent(USER_ID)}/cookies`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${apiKey}` },
-        body: JSON.stringify(body),
-      });
-    },
-  },
-];
 
 const server = new Server(
-  { name: "camofox-browser", version: "1.12.1" },
+  { name: "camofox-browser", version: VERSION },
   { capabilities: { tools: {} } }
 );
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: TOOLS.map((t) => ({
+  tools: TOOL_DEFS.map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: t.inputSchema,
@@ -324,19 +85,22 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 
 server.setRequestHandler(CallToolRequestSchema, async (req) => {
   const { name, arguments: args } = req.params;
-  const tool = TOOLS.find((t) => t.name === name);
-  if (!tool) {
+  const def = TOOL_DEFS.find((t) => t.name === name);
+  if (!def) {
     return {
       isError: true,
       content: [{ type: "text", text: `Unknown tool: ${name}` }],
     };
   }
   try {
-    const result = await tool.run(args || {}, {});
-    // Handlers may return either a raw value (wrap as text) or a content array.
-    const content = Array.isArray(result)
-      ? result
-      : [{ type: "text", text: JSON.stringify(result, null, 2) }];
+    const { spec, payload } = await runTool(
+      name,
+      args || {},
+      { userId: USER_ID, sessionKey: SESSION_KEY },
+      BASE_URL,
+      CONFIG
+    );
+    const content = adaptResponse(spec, payload);
     return { content };
   } catch (err) {
     return {
@@ -348,4 +112,6 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 
 const transport = new StdioServerTransport();
 await server.connect(transport);
-console.error(`[camofox-mcp] connected → ${BASE_URL} (user=${USER_ID})`);
+console.error(
+  `[camofox-mcp] v${VERSION} connected → ${BASE_URL} (user=${USER_ID})`
+);

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -1,0 +1,351 @@
+#!/usr/bin/env node
+// camofox-browser MCP server
+//
+// Standalone Model Context Protocol server that exposes the camofox-browser
+// REST API (default http://localhost:9377) as MCP tools. Mirrors the 11 tools
+// defined in plugin.ts (the OpenClaw plugin) 1:1 — same names, schemas, routes —
+// so behavior is identical whether an agent reaches camofox via OpenClaw or MCP.
+//
+// Transport: stdio (Claude Code spawns this as a child process).
+// The camofox REST server itself must be running (npm start) — this server only
+// forwards calls, it does not launch the browser.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { randomUUID } from "node:crypto";
+
+const BASE_URL = process.env.CAMOFOX_BASE_URL || "http://localhost:9377";
+// Per-MCP-server userId so each Claude Code session gets an isolated camofox
+// session (cookie/storage partition). Falls back to a random id.
+const USER_ID = process.env.CAMOFOX_USER_ID || `mcp-${randomUUID()}`;
+// sessionKey partitions tabs within a user (matches plugin.ts fallback "default").
+const SESSION_KEY = process.env.CAMOFOX_SESSION_KEY || "default";
+
+async function fetchApi(path, options = {}) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    ...options,
+    headers: { "Content-Type": "application/json", ...(options.headers || {}) },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${res.status}: ${text}`);
+  }
+  return res;
+}
+
+async function fetchJson(path, options) {
+  return (await fetchApi(path, options)).json();
+}
+
+// Build user-scoped query string.
+const q = (extra = "") => `userId=${USER_ID}${extra}`;
+
+// --- Tool definitions: name / description / JSON-Schema parameters / handler ---
+// Schemas are copied verbatim from plugin.ts so OpenClaw and MCP stay in sync.
+const TOOLS = [
+  {
+    name: "camofox_create_tab",
+    description:
+      "PREFERRED: Create a new browser tab using Camoufox anti-detection browser. Use camofox tools instead of Chrome/built-in browser - they bypass bot detection on Google, Amazon, LinkedIn, etc. Returns tabId for subsequent operations.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        url: { type: "string", description: "Initial URL to navigate to" },
+      },
+      required: ["url"],
+    },
+    async run({ url }) {
+      return fetchJson("/tabs", {
+        method: "POST",
+        body: JSON.stringify({ url, userId: USER_ID, sessionKey: SESSION_KEY }),
+      });
+    },
+  },
+  {
+    name: "camofox_snapshot",
+    description:
+      "Get accessibility snapshot of a Camoufox page with element refs (e1, e2, etc.) for interaction, plus a visual screenshot. " +
+      "Large pages are truncated with pagination links preserved at the bottom. " +
+      "If the response includes hasMore=true and nextOffset, call again with that offset to see more content.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tabId: { type: "string", description: "Tab identifier" },
+        offset: {
+          type: "number",
+          description:
+            "Character offset for paginated snapshots. Use nextOffset from a previous truncated response.",
+        },
+      },
+      required: ["tabId"],
+    },
+    async run({ tabId, offset }) {
+      const qs = `&includeScreenshot=true${offset ? `&offset=${offset}` : ""}`;
+      const r = await fetchJson(`/tabs/${tabId}/snapshot?${q(qs)}`);
+      // Strip the raw screenshot from the text payload; return it as an image
+      // content block so the host renders it instead of dumping base64.
+      const { screenshot, ...rest } = r;
+      const content = [{ type: "text", text: JSON.stringify(rest, null, 2) }];
+      if (screenshot?.data) {
+        content.push({
+          type: "image",
+          data: screenshot.data,
+          mimeType: screenshot.mimeType || "image/png",
+        });
+      }
+      return content;
+    },
+  },
+  {
+    name: "camofox_click",
+    description: "Click an element in a Camoufox tab by ref (e.g., e1) or CSS selector.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tabId: { type: "string", description: "Tab identifier" },
+        ref: { type: "string", description: "Element ref from snapshot (e.g., e1)" },
+        selector: { type: "string", description: "CSS selector (alternative to ref)" },
+      },
+      required: ["tabId"],
+    },
+    async run({ tabId, ...rest }) {
+      return fetchJson(`/tabs/${tabId}/click`, {
+        method: "POST",
+        body: JSON.stringify({ ...rest, userId: USER_ID }),
+      });
+    },
+  },
+  {
+    name: "camofox_type",
+    description: "Type text into an element in a Camoufox tab.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tabId: { type: "string", description: "Tab identifier" },
+        ref: { type: "string", description: "Element ref from snapshot (e.g., e2)" },
+        selector: { type: "string", description: "CSS selector (alternative to ref)" },
+        text: { type: "string", description: "Text to type" },
+        pressEnter: { type: "boolean", description: "Press Enter after typing" },
+      },
+      required: ["tabId", "text"],
+    },
+    async run({ tabId, ...rest }) {
+      return fetchJson(`/tabs/${tabId}/type`, {
+        method: "POST",
+        body: JSON.stringify({ ...rest, userId: USER_ID }),
+      });
+    },
+  },
+  {
+    name: "camofox_navigate",
+    description:
+      "Navigate a Camoufox tab to a URL or use a search macro (@google_search, @youtube_search, etc.). Preferred over Chrome for sites with bot detection.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tabId: { type: "string", description: "Tab identifier" },
+        url: { type: "string", description: "URL to navigate to" },
+        macro: {
+          type: "string",
+          description: "Search macro (e.g., @google_search, @youtube_search)",
+          enum: [
+            "@google_search",
+            "@youtube_search",
+            "@amazon_search",
+            "@reddit_search",
+            "@wikipedia_search",
+            "@twitter_search",
+            "@yelp_search",
+            "@spotify_search",
+            "@netflix_search",
+            "@linkedin_search",
+            "@instagram_search",
+            "@tiktok_search",
+            "@twitch_search",
+          ],
+        },
+        query: { type: "string", description: "Search query (when using macro)" },
+      },
+      required: ["tabId"],
+    },
+    async run({ tabId, ...rest }) {
+      return fetchJson(`/tabs/${tabId}/navigate`, {
+        method: "POST",
+        body: JSON.stringify({ ...rest, userId: USER_ID }),
+      });
+    },
+  },
+  {
+    name: "camofox_scroll",
+    description: "Scroll a Camoufox page.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tabId: { type: "string", description: "Tab identifier" },
+        direction: { type: "string", enum: ["up", "down", "left", "right"] },
+        amount: { type: "number", description: "Pixels to scroll" },
+      },
+      required: ["tabId", "direction"],
+    },
+    async run({ tabId, ...rest }) {
+      return fetchJson(`/tabs/${tabId}/scroll`, {
+        method: "POST",
+        body: JSON.stringify({ ...rest, userId: USER_ID }),
+      });
+    },
+  },
+  {
+    name: "camofox_screenshot",
+    description: "Take a screenshot of a Camoufox page.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tabId: { type: "string", description: "Tab identifier" },
+      },
+      required: ["tabId"],
+    },
+    async run({ tabId }) {
+      const res = await fetchApi(`/tabs/${tabId}/screenshot?${q()}`);
+      const contentType = res.headers.get("content-type") || "";
+      // Guard: server may return JSON/text (e.g. error with 200) — don't base64 it.
+      if (!contentType.startsWith("image/")) {
+        const text = await res.text();
+        return [{ type: "text", text: `Screenshot failed: ${text}` }];
+      }
+      const buf = Buffer.from(await res.arrayBuffer()).toString("base64");
+      return [{ type: "image", data: buf, mimeType: contentType }];
+    },
+  },
+  {
+    name: "camofox_close_tab",
+    description: "Close a Camoufox browser tab.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tabId: { type: "string", description: "Tab identifier" },
+      },
+      required: ["tabId"],
+    },
+    async run({ tabId }) {
+      return fetchJson(`/tabs/${tabId}?${q()}`, { method: "DELETE" });
+    },
+  },
+  {
+    name: "camofox_evaluate",
+    description:
+      "Execute JavaScript in a Camoufox tab's page context. Returns the result of the expression. Use for injecting scripts, reading page state, or calling web app APIs.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tabId: { type: "string", description: "Tab identifier" },
+        expression: {
+          type: "string",
+          description: "JavaScript expression to evaluate in the page context",
+        },
+      },
+      required: ["tabId", "expression"],
+    },
+    async run({ tabId, expression }) {
+      return fetchJson(`/tabs/${tabId}/evaluate`, {
+        method: "POST",
+        body: JSON.stringify({ userId: USER_ID, expression }),
+      });
+    },
+  },
+  {
+    name: "camofox_list_tabs",
+    description: "List all open Camoufox tabs for the current session.",
+    inputSchema: { type: "object", properties: {}, required: [] },
+    async run() {
+      return fetchJson(`/tabs?${q()}`);
+    },
+  },
+  {
+    name: "camofox_import_cookies",
+    description:
+      "Import cookies into the current Camoufox session (Netscape cookie file). Use to authenticate to sites like LinkedIn without interactive login. Requires CAMOFOX_API_KEY on the REST server.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        cookiesPath: {
+          type: "string",
+          description: "Path to Netscape-format cookies.txt file",
+        },
+        domainSuffix: {
+          type: "string",
+          description: "Only import cookies whose domain ends with this suffix",
+        },
+      },
+      required: ["cookiesPath"],
+    },
+    async run(args, extra) {
+      // Cookie import needs the server-side API key as a bearer token. We pass it
+      // through from the MCP server env; the host (Claude Code) must provide it.
+      const apiKey = extra?.apiKey || process.env.CAMOFOX_API_KEY;
+      if (!apiKey) {
+        throw new Error(
+          "CAMOFOX_API_KEY is not set. Cookie import is disabled unless the server and the MCP server both have CAMOFOX_API_KEY."
+        );
+      }
+      // Server-side reads + validates the cookie file, so we just forward the path
+      // alongside the user-scoped session. (REST route accepts a path under the
+      // configured cookiesDir; for arbitrary paths the file must be reachable by
+      // the server process.)
+      const body = {
+        userId: USER_ID,
+        cookiesPath: args.cookiesPath,
+        ...(args.domainSuffix ? { domainSuffix: args.domainSuffix } : {}),
+      };
+      return fetchJson(`/sessions/${encodeURIComponent(USER_ID)}/cookies`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}` },
+        body: JSON.stringify(body),
+      });
+    },
+  },
+];
+
+const server = new Server(
+  { name: "camofox-browser", version: "1.12.1" },
+  { capabilities: { tools: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: TOOLS.map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: t.inputSchema,
+  })),
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const { name, arguments: args } = req.params;
+  const tool = TOOLS.find((t) => t.name === name);
+  if (!tool) {
+    return {
+      isError: true,
+      content: [{ type: "text", text: `Unknown tool: ${name}` }],
+    };
+  }
+  try {
+    const result = await tool.run(args || {}, {});
+    // Handlers may return either a raw value (wrap as text) or a content array.
+    const content = Array.isArray(result)
+      ? result
+      : [{ type: "text", text: JSON.stringify(result, null, 2) }];
+    return { content };
+  } catch (err) {
+    return {
+      isError: true,
+      content: [{ type: "text", text: `camofox error: ${err.message}` }],
+    };
+  }
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+console.error(`[camofox-mcp] connected → ${BASE_URL} (user=${USER_ID})`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "camoufox-js": "0.10.2",
         "express": "^4.18.2",
         "playwright-core": "^1.58.0",
@@ -637,6 +638,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1065,6 +1078,376 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "license": "MIT"
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -1255,6 +1638,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -1939,6 +2355,23 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -1965,7 +2398,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2289,6 +2721,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -2394,12 +2847,76 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -2711,6 +3228,15 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2981,6 +3507,15 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -3051,6 +3586,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-standalone-pwa": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
@@ -3088,7 +3629,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -3902,6 +4442,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3942,6 +4491,18 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4346,6 +4907,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -4527,7 +5097,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4598,6 +5167,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -4863,6 +5441,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -4916,6 +5503,55 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-buffer": {
@@ -5018,7 +5654,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5031,7 +5666,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5805,7 +6439,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -5973,6 +6606,24 @@
       "optional": true,
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
         "camoufox-js": "0.10.2",
         "express": "^4.18.2",
         "playwright-core": "^1.58.0",
@@ -18,7 +17,8 @@
         "swagger-jsdoc": "^6.2.8"
       },
       "bin": {
-        "camofox-browser": "bin/camofox-browser.js"
+        "camofox-browser": "bin/camofox-browser.js",
+        "camofox-mcp": "mcp/server.mjs"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -28,6 +28,9 @@
       },
       "engines": {
         "node": ">=22"
+      },
+      "optionalDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -643,6 +646,7 @@
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -1083,6 +1087,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -1123,6 +1128,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -1136,6 +1142,7 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^2.0.0",
@@ -1160,6 +1167,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       },
@@ -1173,6 +1181,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       },
@@ -1186,6 +1195,7 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -1195,6 +1205,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1212,6 +1223,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1255,6 +1267,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -1276,6 +1289,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1285,6 +1299,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -1301,6 +1316,7 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1310,6 +1326,7 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       },
@@ -1322,6 +1339,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1331,6 +1349,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -1346,13 +1365,15 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1362,6 +1383,7 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -1377,6 +1399,7 @@
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -1403,6 +1426,7 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -1422,6 +1446,7 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
@@ -1440,6 +1465,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       },
@@ -1645,6 +1671,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1661,6 +1688,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -2360,6 +2388,7 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -2398,6 +2427,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2726,6 +2756,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -2738,6 +2769,7 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -2852,6 +2884,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
       "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^4.4.3",
         "ip-address": "^10.2.0"
@@ -2871,6 +2904,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2887,13 +2921,15 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2916,7 +2952,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -3233,6 +3270,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
       "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3512,6 +3550,7 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 12"
       }
@@ -3590,7 +3629,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-standalone-pwa": {
       "version": "0.1.1",
@@ -3629,6 +3669,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -4447,6 +4488,7 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -4496,13 +4538,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4912,6 +4956,7 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5097,6 +5142,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5174,6 +5220,7 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -5446,6 +5493,7 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5510,6 +5558,7 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -5526,6 +5575,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -5542,13 +5592,15 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/router/node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
+      "optional": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -5654,6 +5706,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5666,6 +5719,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6439,6 +6493,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6613,6 +6668,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6622,6 +6678,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
+      "optional": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -135,12 +135,14 @@
     "fetch-bin": "npx camoufox-js fetch"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "camoufox-js": "0.10.2",
     "express": "^4.18.2",
     "playwright-core": "^1.58.0",
     "prom-client": "^15.1.3",
     "swagger-jsdoc": "^6.2.8"
+  },
+  "optionalDependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "dist/plugin.js",
     "tsconfig.json",
     "openclaw.plugin.json",
+    "mcp/",
     "bin/",
     "scripts/",
     "run.sh",
@@ -119,6 +120,8 @@
     "build": "tsc -p . || true; mkdir -p dist && cp plugin.js dist/plugin.js",
     "prepublishOnly": "npm run build",
     "start": "node server.js",
+    "mcp": "node mcp/server.mjs",
+    "test:mcp": "node scripts/test-mcp.mjs",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest --runInBand --forceExit",
     "test:e2e": "NODE_OPTIONS='--experimental-vm-modules' jest --config jest.config.e2e.cjs --runInBand --forceExit",
     "test:plugins": "NODE_OPTIONS='--experimental-vm-modules' jest --forceExit plugins/",
@@ -132,6 +135,7 @@
     "fetch-bin": "npx camoufox-js fetch"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "camoufox-js": "0.10.2",
     "express": "^4.18.2",
     "playwright-core": "^1.58.0",
@@ -145,6 +149,7 @@
     "typescript": "^5.7.0"
   },
   "bin": {
-    "camofox-browser": "./bin/camofox-browser.js"
+    "camofox-browser": "./bin/camofox-browser.js",
+    "camofox-mcp": "./mcp/server.mjs"
   }
 }

--- a/plugin.js
+++ b/plugin.js
@@ -4,12 +4,15 @@
  * Provides browser automation tools using the Camoufox anti-detection browser.
  * Server auto-starts when plugin loads (configurable via autoStart: false).
  */
-import { dirname, resolve } from "path";
+import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { randomUUID } from "crypto";
 import { loadConfig } from "./lib/config.js";
 import { launchServer } from "./lib/launcher.js";
-import { readCookieFile } from "./lib/cookies.js";
+// Shared tool contracts — the single source of truth also used by mcp/server.mjs.
+// OpenClaw and MCP expose identical tool schemas, REST routes, auth, and response
+// shaping, so they cannot drift.
+import { TOOL_DEFS, runTool, adaptResponse } from "./lib/mcp-tool-contracts.mjs";
 // Get plugin directory - works in both ESM and CJS contexts
 const getPluginDir = () => {
     try {
@@ -72,24 +75,24 @@ async function checkServerRunning(baseUrl) {
     }
 }
 async function fetchApi(baseUrl, path, options = {}) {
+    // Forward the global access key so plugin traffic is accepted by REST servers
+    // gated with CAMOFOX_ACCESS_KEY. /health is exempt server-side, so attaching
+    // the header to health checks is harmless.
+    const cfg = loadConfig();
+    const headers = {
+        "Content-Type": "application/json",
+        ...(options.headers || {}),
+    };
+    if (cfg.accessKey && !headers.Authorization) {
+        headers.Authorization = `Bearer ${cfg.accessKey}`;
+    }
     const url = `${baseUrl}${path}`;
-    const res = await fetch(url, {
-        ...options,
-        headers: {
-            "Content-Type": "application/json",
-            ...options.headers,
-        },
-    });
+    const res = await fetch(url, { ...options, headers });
     if (!res.ok) {
         const text = await res.text();
         throw new Error(`${res.status}: ${text}`);
     }
     return res.json();
-}
-function toToolResult(data) {
-    return {
-        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
-    };
 }
 export default function register(api) {
     const cfg = api.pluginConfig ?? api.config;
@@ -115,293 +118,24 @@ export default function register(api) {
             }
         })();
     }
-    api.registerTool((ctx) => ({
-        name: "camofox_create_tab",
-        description: "PREFERRED: Create a new browser tab using Camoufox anti-detection browser. Use camofox tools instead of Chrome/built-in browser - they bypass bot detection on Google, Amazon, LinkedIn, etc. Returns tabId for subsequent operations.",
-        parameters: {
-            type: "object",
-            properties: {
-                url: { type: "string", description: "Initial URL to navigate to" },
+    // --- Tool registration -----------------------------------------------------
+    // Schemas, REST routes, auth, and response shaping come from the shared
+    // contract module (lib/mcp-tool-contracts.mjs) — the same source mcp/server.mjs
+    // imports — so the OpenClaw plugin and the MCP server behave identically and
+    // cannot drift. Only the userId/sessionKey source (OpenClaw ctx) differs.
+    for (const def of TOOL_DEFS) {
+        api.registerTool((ctx) => ({
+            name: def.name,
+            description: def.description,
+            parameters: def.inputSchema,
+            async execute(_id, params) {
+                const userId = ctx.agentId || fallbackUserId;
+                const cfg = loadConfig();
+                const { spec, payload } = await runTool(def.name, params, { userId, sessionKey: ctx.sessionKey }, baseUrl, cfg);
+                return { content: adaptResponse(spec, payload) };
             },
-            required: ["url"],
-        },
-        async execute(_id, params) {
-            const sessionKey = ctx.sessionKey || "default";
-            const userId = ctx.agentId || fallbackUserId;
-            const result = await fetchApi(baseUrl, "/tabs", {
-                method: "POST",
-                body: JSON.stringify({ ...params, userId, sessionKey }),
-            });
-            return toToolResult(result);
-        },
-    }), { name: "camofox_create_tab" });
-    api.registerTool((ctx) => ({
-        name: "camofox_snapshot",
-        description: "Get accessibility snapshot of a Camoufox page with element refs (e1, e2, etc.) for interaction, plus a visual screenshot. " +
-            "Large pages are truncated with pagination links preserved at the bottom. " +
-            "If the response includes hasMore=true and nextOffset, call again with that offset to see more content.",
-        parameters: {
-            type: "object",
-            properties: {
-                tabId: { type: "string", description: "Tab identifier" },
-                offset: { type: "number", description: "Character offset for paginated snapshots. Use nextOffset from a previous truncated response." },
-            },
-            required: ["tabId"],
-        },
-        async execute(_id, params) {
-            const { tabId, offset } = params;
-            const userId = ctx.agentId || fallbackUserId;
-            const qs = offset ? `&offset=${offset}` : '';
-            const result = await fetchApi(baseUrl, `/tabs/${tabId}/snapshot?userId=${userId}&includeScreenshot=true${qs}`);
-            const content = [
-                { type: "text", text: JSON.stringify({ url: result.url, refsCount: result.refsCount, snapshot: result.snapshot, truncated: result.truncated, totalChars: result.totalChars, hasMore: result.hasMore, nextOffset: result.nextOffset }, null, 2) },
-            ];
-            const screenshot = result.screenshot;
-            if (screenshot?.data) {
-                content.push({ type: "image", data: screenshot.data, mimeType: screenshot.mimeType || "image/png" });
-            }
-            return { content };
-        },
-    }), { name: "camofox_snapshot" });
-    api.registerTool((ctx) => ({
-        name: "camofox_click",
-        description: "Click an element in a Camoufox tab by ref (e.g., e1) or CSS selector.",
-        parameters: {
-            type: "object",
-            properties: {
-                tabId: { type: "string", description: "Tab identifier" },
-                ref: { type: "string", description: "Element ref from snapshot (e.g., e1)" },
-                selector: { type: "string", description: "CSS selector (alternative to ref)" },
-            },
-            required: ["tabId"],
-        },
-        async execute(_id, params) {
-            const { tabId, ...rest } = params;
-            const userId = ctx.agentId || fallbackUserId;
-            const result = await fetchApi(baseUrl, `/tabs/${tabId}/click`, {
-                method: "POST",
-                body: JSON.stringify({ ...rest, userId }),
-            });
-            return toToolResult(result);
-        },
-    }), { name: "camofox_click" });
-    api.registerTool((ctx) => ({
-        name: "camofox_type",
-        description: "Type text into an element in a Camoufox tab.",
-        parameters: {
-            type: "object",
-            properties: {
-                tabId: { type: "string", description: "Tab identifier" },
-                ref: { type: "string", description: "Element ref from snapshot (e.g., e2)" },
-                selector: { type: "string", description: "CSS selector (alternative to ref)" },
-                text: { type: "string", description: "Text to type" },
-                pressEnter: { type: "boolean", description: "Press Enter after typing" },
-            },
-            required: ["tabId", "text"],
-        },
-        async execute(_id, params) {
-            const { tabId, ...rest } = params;
-            const userId = ctx.agentId || fallbackUserId;
-            const result = await fetchApi(baseUrl, `/tabs/${tabId}/type`, {
-                method: "POST",
-                body: JSON.stringify({ ...rest, userId }),
-            });
-            return toToolResult(result);
-        },
-    }), { name: "camofox_type" });
-    api.registerTool((ctx) => ({
-        name: "camofox_navigate",
-        description: "Navigate a Camoufox tab to a URL or use a search macro (@google_search, @youtube_search, etc.). Preferred over Chrome for sites with bot detection.",
-        parameters: {
-            type: "object",
-            properties: {
-                tabId: { type: "string", description: "Tab identifier" },
-                url: { type: "string", description: "URL to navigate to" },
-                macro: {
-                    type: "string",
-                    description: "Search macro (e.g., @google_search, @youtube_search)",
-                    enum: [
-                        "@google_search",
-                        "@youtube_search",
-                        "@amazon_search",
-                        "@reddit_search",
-                        "@wikipedia_search",
-                        "@twitter_search",
-                        "@yelp_search",
-                        "@spotify_search",
-                        "@netflix_search",
-                        "@linkedin_search",
-                        "@instagram_search",
-                        "@tiktok_search",
-                        "@twitch_search",
-                    ],
-                },
-                query: { type: "string", description: "Search query (when using macro)" },
-            },
-            required: ["tabId"],
-        },
-        async execute(_id, params) {
-            const { tabId, ...rest } = params;
-            const userId = ctx.agentId || fallbackUserId;
-            const result = await fetchApi(baseUrl, `/tabs/${tabId}/navigate`, {
-                method: "POST",
-                body: JSON.stringify({ ...rest, userId }),
-            });
-            return toToolResult(result);
-        },
-    }), { name: "camofox_navigate" });
-    api.registerTool((ctx) => ({
-        name: "camofox_scroll",
-        description: "Scroll a Camoufox page.",
-        parameters: {
-            type: "object",
-            properties: {
-                tabId: { type: "string", description: "Tab identifier" },
-                direction: { type: "string", enum: ["up", "down", "left", "right"] },
-                amount: { type: "number", description: "Pixels to scroll" },
-            },
-            required: ["tabId", "direction"],
-        },
-        async execute(_id, params) {
-            const { tabId, ...rest } = params;
-            const userId = ctx.agentId || fallbackUserId;
-            const result = await fetchApi(baseUrl, `/tabs/${tabId}/scroll`, {
-                method: "POST",
-                body: JSON.stringify({ ...rest, userId }),
-            });
-            return toToolResult(result);
-        },
-    }), { name: "camofox_scroll" });
-    api.registerTool((ctx) => ({
-        name: "camofox_screenshot",
-        description: "Take a screenshot of a Camoufox page.",
-        parameters: {
-            type: "object",
-            properties: {
-                tabId: { type: "string", description: "Tab identifier" },
-            },
-            required: ["tabId"],
-        },
-        async execute(_id, params) {
-            const { tabId } = params;
-            const userId = ctx.agentId || fallbackUserId;
-            const url = `${baseUrl}/tabs/${tabId}/screenshot?userId=${userId}`;
-            const res = await fetch(url);
-            if (!res.ok) {
-                const text = await res.text();
-                throw new Error(`${res.status}: ${text}`);
-            }
-            // Guard: if server returns JSON/text instead of image (e.g. error with 200),
-            // return as text to avoid crashing the client with base64-encoded JSON.
-            const contentType = res.headers.get('content-type') || '';
-            if (!contentType.startsWith('image/')) {
-                const text = await res.text();
-                return { content: [{ type: "text", text: `Screenshot failed: ${text}` }] };
-            }
-            const arrayBuffer = await res.arrayBuffer();
-            const base64 = Buffer.from(arrayBuffer).toString("base64");
-            return {
-                content: [
-                    {
-                        type: "image",
-                        data: base64,
-                        mimeType: contentType || "image/png",
-                    },
-                ],
-            };
-        },
-    }), { name: "camofox_screenshot" });
-    api.registerTool((ctx) => ({
-        name: "camofox_close_tab",
-        description: "Close a Camoufox browser tab.",
-        parameters: {
-            type: "object",
-            properties: {
-                tabId: { type: "string", description: "Tab identifier" },
-            },
-            required: ["tabId"],
-        },
-        async execute(_id, params) {
-            const { tabId } = params;
-            const userId = ctx.agentId || fallbackUserId;
-            const result = await fetchApi(baseUrl, `/tabs/${tabId}?userId=${userId}`, {
-                method: "DELETE",
-            });
-            return toToolResult(result);
-        },
-    }), { name: "camofox_close_tab" });
-    api.registerTool((ctx) => ({
-        name: "camofox_evaluate",
-        description: "Execute JavaScript in a Camoufox tab's page context. Returns the result of the expression. Use for injecting scripts, reading page state, or calling web app APIs.",
-        parameters: {
-            type: "object",
-            properties: {
-                tabId: { type: "string", description: "Tab identifier" },
-                expression: { type: "string", description: "JavaScript expression to evaluate in the page context" },
-            },
-            required: ["tabId", "expression"],
-        },
-        async execute(_id, params) {
-            const { tabId, expression } = params;
-            const userId = ctx.agentId || fallbackUserId;
-            const result = await fetchApi(baseUrl, `/tabs/${tabId}/evaluate`, {
-                method: "POST",
-                body: JSON.stringify({ userId, expression }),
-            });
-            return toToolResult(result);
-        },
-    }), { name: "camofox_evaluate" });
-    api.registerTool((ctx) => ({
-        name: "camofox_list_tabs",
-        description: "List all open Camoufox tabs for a user.",
-        parameters: {
-            type: "object",
-            properties: {},
-            required: [],
-        },
-        async execute(_id, _params) {
-            const userId = ctx.agentId || fallbackUserId;
-            const result = await fetchApi(baseUrl, `/tabs?userId=${userId}`);
-            return toToolResult(result);
-        },
-    }), { name: "camofox_list_tabs" });
-    api.registerTool((ctx) => ({
-        name: "camofox_import_cookies",
-        description: "Import cookies into the current Camoufox user session (Netscape cookie file). Use to authenticate to sites like LinkedIn without interactive login.",
-        parameters: {
-            type: "object",
-            properties: {
-                cookiesPath: { type: "string", description: "Path to Netscape-format cookies.txt file" },
-                domainSuffix: {
-                    type: "string",
-                    description: "Only import cookies whose domain ends with this suffix",
-                },
-            },
-            required: ["cookiesPath"],
-        },
-        async execute(_id, params) {
-            const { cookiesPath, domainSuffix } = params;
-            const userId = ctx.agentId || fallbackUserId;
-            const envCfg = loadConfig();
-            const cookiesDir = resolve(envCfg.cookiesDir);
-            const pwCookies = await readCookieFile({
-                cookiesDir,
-                cookiesPath,
-                domainSuffix,
-            });
-            if (!envCfg.apiKey) {
-                throw new Error("CAMOFOX_API_KEY is not set. Cookie import is disabled unless you set CAMOFOX_API_KEY for both the server and the OpenClaw plugin environment.");
-            }
-            const result = await fetchApi(baseUrl, `/sessions/${encodeURIComponent(userId)}/cookies`, {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${envCfg.apiKey}`,
-                },
-                body: JSON.stringify({ cookies: pwCookies }),
-            });
-            return toToolResult({ imported: pwCookies.length, userId, result });
-        },
-    }), { name: "camofox_import_cookies" });
+        }), { name: def.name });
+    }
     api.registerCommand({
         name: "camofox",
         description: "Camoufox browser server control (status, start, stop)",

--- a/plugin.ts
+++ b/plugin.ts
@@ -6,13 +6,16 @@
  */
 
 import type { ChildProcess } from "child_process";
-import { join, dirname, resolve } from "path";
+import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { randomUUID } from "crypto";
 
 import { loadConfig } from "./lib/config.js";
 import { launchServer } from "./lib/launcher.js";
-import { readCookieFile } from "./lib/cookies.js";
+// Shared tool contracts — the single source of truth also used by mcp/server.mjs.
+// OpenClaw and MCP expose identical tool schemas, REST routes, auth, and response
+// shaping, so they cannot drift.
+import { TOOL_DEFS, runTool, adaptResponse } from "./lib/mcp-tool-contracts.mjs";
 
 // Get plugin directory - works in both ESM and CJS contexts
 const getPluginDir = (): string => {
@@ -169,25 +172,24 @@ async function fetchApi(
   path: string,
   options: RequestInit = {}
 ): Promise<unknown> {
+  // Forward the global access key so plugin traffic is accepted by REST servers
+  // gated with CAMOFOX_ACCESS_KEY. /health is exempt server-side, so attaching
+  // the header to health checks is harmless.
+  const cfg = loadConfig();
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...((options.headers as Record<string, string>) || {}),
+  };
+  if (cfg.accessKey && !headers.Authorization) {
+    headers.Authorization = `Bearer ${cfg.accessKey}`;
+  }
   const url = `${baseUrl}${path}`;
-  const res = await fetch(url, {
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options.headers,
-    },
-  });
+  const res = await fetch(url, { ...options, headers });
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`${res.status}: ${text}`);
   }
   return res.json();
-}
-
-function toToolResult(data: unknown): ToolResult {
-  return {
-    content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
-  };
 }
 
 export default function register(api: PluginApi) {
@@ -214,319 +216,31 @@ export default function register(api: PluginApi) {
     })();
   }
 
-  api.registerTool((ctx: ToolContext) => ({
-    name: "camofox_create_tab",
-    description:
-      "PREFERRED: Create a new browser tab using Camoufox anti-detection browser. Use camofox tools instead of Chrome/built-in browser - they bypass bot detection on Google, Amazon, LinkedIn, etc. Returns tabId for subsequent operations.",
-    parameters: {
-      type: "object",
-      properties: {
-        url: { type: "string", description: "Initial URL to navigate to" },
-      },
-      required: ["url"],
-    },
-    async execute(_id, params) {
-      const sessionKey = ctx.sessionKey || "default";
-      const userId = ctx.agentId || fallbackUserId;
-      const result = await fetchApi(baseUrl, "/tabs", {
-        method: "POST",
-        body: JSON.stringify({ ...params, userId, sessionKey }),
-      });
-      return toToolResult(result);
-    },
-  }), { name: "camofox_create_tab" });
-
-  api.registerTool((ctx: ToolContext) => ({
-    name: "camofox_snapshot",
-    description:
-      "Get accessibility snapshot of a Camoufox page with element refs (e1, e2, etc.) for interaction, plus a visual screenshot. " +
-      "Large pages are truncated with pagination links preserved at the bottom. " +
-      "If the response includes hasMore=true and nextOffset, call again with that offset to see more content.",
-    parameters: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-        offset: { type: "number", description: "Character offset for paginated snapshots. Use nextOffset from a previous truncated response." },
-      },
-      required: ["tabId"],
-    },
-    async execute(_id, params) {
-      const { tabId, offset } = params as { tabId: string; offset?: number };
-      const userId = ctx.agentId || fallbackUserId;
-      const qs = offset ? `&offset=${offset}` : '';
-      const result = await fetchApi(baseUrl, `/tabs/${tabId}/snapshot?userId=${userId}&includeScreenshot=true${qs}`) as Record<string, unknown>;
-      const content: ToolResult["content"] = [
-        { type: "text", text: JSON.stringify({ url: result.url, refsCount: result.refsCount, snapshot: result.snapshot, truncated: result.truncated, totalChars: result.totalChars, hasMore: result.hasMore, nextOffset: result.nextOffset }, null, 2) },
-      ];
-      const screenshot = result.screenshot as { data?: string; mimeType?: string } | undefined;
-      if (screenshot?.data) {
-        content.push({ type: "image", data: screenshot.data, mimeType: screenshot.mimeType || "image/png" });
-      }
-      return { content };
-    },
-  }), { name: "camofox_snapshot" });
-
-  api.registerTool((ctx: ToolContext) => ({
-    name: "camofox_click",
-    description: "Click an element in a Camoufox tab by ref (e.g., e1) or CSS selector.",
-    parameters: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-        ref: { type: "string", description: "Element ref from snapshot (e.g., e1)" },
-        selector: { type: "string", description: "CSS selector (alternative to ref)" },
-      },
-      required: ["tabId"],
-    },
-    async execute(_id, params) {
-      const { tabId, ...rest } = params as { tabId: string } & Record<string, unknown>;
-      const userId = ctx.agentId || fallbackUserId;
-      const result = await fetchApi(baseUrl, `/tabs/${tabId}/click`, {
-        method: "POST",
-        body: JSON.stringify({ ...rest, userId }),
-      });
-      return toToolResult(result);
-    },
-  }), { name: "camofox_click" });
-
-  api.registerTool((ctx: ToolContext) => ({
-    name: "camofox_type",
-    description: "Type text into an element in a Camoufox tab.",
-    parameters: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-        ref: { type: "string", description: "Element ref from snapshot (e.g., e2)" },
-        selector: { type: "string", description: "CSS selector (alternative to ref)" },
-        text: { type: "string", description: "Text to type" },
-        pressEnter: { type: "boolean", description: "Press Enter after typing" },
-      },
-      required: ["tabId", "text"],
-    },
-    async execute(_id, params) {
-      const { tabId, ...rest } = params as { tabId: string } & Record<string, unknown>;
-      const userId = ctx.agentId || fallbackUserId;
-      const result = await fetchApi(baseUrl, `/tabs/${tabId}/type`, {
-        method: "POST",
-        body: JSON.stringify({ ...rest, userId }),
-      });
-      return toToolResult(result);
-    },
-  }), { name: "camofox_type" });
-
-  api.registerTool((ctx: ToolContext) => ({
-    name: "camofox_navigate",
-    description:
-      "Navigate a Camoufox tab to a URL or use a search macro (@google_search, @youtube_search, etc.). Preferred over Chrome for sites with bot detection.",
-    parameters: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-        url: { type: "string", description: "URL to navigate to" },
-        macro: {
-          type: "string",
-          description: "Search macro (e.g., @google_search, @youtube_search)",
-          enum: [
-            "@google_search",
-            "@youtube_search",
-            "@amazon_search",
-            "@reddit_search",
-            "@wikipedia_search",
-            "@twitter_search",
-            "@yelp_search",
-            "@spotify_search",
-            "@netflix_search",
-            "@linkedin_search",
-            "@instagram_search",
-            "@tiktok_search",
-            "@twitch_search",
-          ],
-        },
-        query: { type: "string", description: "Search query (when using macro)" },
-      },
-      required: ["tabId"],
-    },
-    async execute(_id, params) {
-      const { tabId, ...rest } = params as { tabId: string } & Record<string, unknown>;
-      const userId = ctx.agentId || fallbackUserId;
-      const result = await fetchApi(baseUrl, `/tabs/${tabId}/navigate`, {
-        method: "POST",
-        body: JSON.stringify({ ...rest, userId }),
-      });
-      return toToolResult(result);
-    },
-  }), { name: "camofox_navigate" });
-
-  api.registerTool((ctx: ToolContext) => ({
-    name: "camofox_scroll",
-    description: "Scroll a Camoufox page.",
-    parameters: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-        direction: { type: "string", enum: ["up", "down", "left", "right"] },
-        amount: { type: "number", description: "Pixels to scroll" },
-      },
-      required: ["tabId", "direction"],
-    },
-    async execute(_id, params) {
-      const { tabId, ...rest } = params as { tabId: string } & Record<string, unknown>;
-      const userId = ctx.agentId || fallbackUserId;
-      const result = await fetchApi(baseUrl, `/tabs/${tabId}/scroll`, {
-        method: "POST",
-        body: JSON.stringify({ ...rest, userId }),
-      });
-      return toToolResult(result);
-    },
-  }), { name: "camofox_scroll" });
-
-  api.registerTool((ctx: ToolContext) => ({
-    name: "camofox_screenshot",
-    description: "Take a screenshot of a Camoufox page.",
-    parameters: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-      },
-      required: ["tabId"],
-    },
-    async execute(_id, params) {
-      const { tabId } = params as { tabId: string };
-      const userId = ctx.agentId || fallbackUserId;
-      const url = `${baseUrl}/tabs/${tabId}/screenshot?userId=${userId}`;
-      const res = await fetch(url);
-      if (!res.ok) {
-        const text = await res.text();
-        throw new Error(`${res.status}: ${text}`);
-      }
-      // Guard: if server returns JSON/text instead of image (e.g. error with 200),
-      // return as text to avoid crashing the client with base64-encoded JSON.
-      const contentType = res.headers.get('content-type') || '';
-      if (!contentType.startsWith('image/')) {
-        const text = await res.text();
-        return { content: [{ type: "text", text: `Screenshot failed: ${text}` }] };
-      }
-      const arrayBuffer = await res.arrayBuffer();
-      const base64 = Buffer.from(arrayBuffer).toString("base64");
-      return {
-        content: [
-          {
-            type: "image",
-            data: base64,
-            mimeType: contentType || "image/png",
-          },
-        ],
-      };
-    },
-  }), { name: "camofox_screenshot" });
-
-  api.registerTool((ctx: ToolContext) => ({
-    name: "camofox_close_tab",
-    description: "Close a Camoufox browser tab.",
-    parameters: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-      },
-      required: ["tabId"],
-    },
-    async execute(_id, params) {
-      const { tabId } = params as { tabId: string };
-      const userId = ctx.agentId || fallbackUserId;
-      const result = await fetchApi(baseUrl, `/tabs/${tabId}?userId=${userId}`, {
-        method: "DELETE",
-      });
-      return toToolResult(result);
-    },
-  }), { name: "camofox_close_tab" });
-
-  api.registerTool((ctx: ToolContext) => ({
-    name: "camofox_evaluate",
-    description:
-      "Execute JavaScript in a Camoufox tab's page context. Returns the result of the expression. Use for injecting scripts, reading page state, or calling web app APIs.",
-    parameters: {
-      type: "object",
-      properties: {
-        tabId: { type: "string", description: "Tab identifier" },
-        expression: { type: "string", description: "JavaScript expression to evaluate in the page context" },
-      },
-      required: ["tabId", "expression"],
-    },
-    async execute(_id, params) {
-      const { tabId, expression } = params as { tabId: string; expression: string };
-      const userId = ctx.agentId || fallbackUserId;
-      const result = await fetchApi(baseUrl, `/tabs/${tabId}/evaluate`, {
-        method: "POST",
-        body: JSON.stringify({ userId, expression }),
-      });
-      return toToolResult(result);
-    },
-  }), { name: "camofox_evaluate" });
-
-  api.registerTool((ctx: ToolContext) => ({
-    name: "camofox_list_tabs",
-    description: "List all open Camoufox tabs for a user.",
-    parameters: {
-      type: "object",
-      properties: {},
-      required: [],
-    },
-    async execute(_id, _params) {
-      const userId = ctx.agentId || fallbackUserId;
-      const result = await fetchApi(baseUrl, `/tabs?userId=${userId}`);
-      return toToolResult(result);
-    },
-  }), { name: "camofox_list_tabs" });
-
-  api.registerTool((ctx: ToolContext) => ({
-    name: "camofox_import_cookies",
-    description:
-      "Import cookies into the current Camoufox user session (Netscape cookie file). Use to authenticate to sites like LinkedIn without interactive login.",
-    parameters: {
-      type: "object",
-      properties: {
-        cookiesPath: { type: "string", description: "Path to Netscape-format cookies.txt file" },
-        domainSuffix: {
-          type: "string",
-          description: "Only import cookies whose domain ends with this suffix",
-        },
-      },
-      required: ["cookiesPath"],
-    },
-    async execute(_id, params) {
-      const { cookiesPath, domainSuffix } = params as {
-        cookiesPath: string;
-        domainSuffix?: string;
-      };
-
-      const userId = ctx.agentId || fallbackUserId;
-
-      const envCfg = loadConfig();
-      const cookiesDir = resolve(envCfg.cookiesDir);
-
-      const pwCookies = await readCookieFile({
-        cookiesDir,
-        cookiesPath,
-        domainSuffix,
-      });
-
-      if (!envCfg.apiKey) {
-        throw new Error(
-          "CAMOFOX_API_KEY is not set. Cookie import is disabled unless you set CAMOFOX_API_KEY for both the server and the OpenClaw plugin environment."
+  // --- Tool registration -----------------------------------------------------
+  // Schemas, REST routes, auth, and response shaping come from the shared
+  // contract module (lib/mcp-tool-contracts.mjs) — the same source mcp/server.mjs
+  // imports — so the OpenClaw plugin and the MCP server behave identically and
+  // cannot drift. Only the userId/sessionKey source (OpenClaw ctx) differs.
+  for (const def of TOOL_DEFS) {
+    api.registerTool((ctx: ToolContext) => ({
+      name: def.name,
+      description: def.description,
+      parameters: def.inputSchema,
+      async execute(_id, params) {
+        const userId = ctx.agentId || fallbackUserId;
+        const cfg = loadConfig();
+        const { spec, payload } = await runTool(
+          def.name,
+          params as Record<string, unknown>,
+          { userId, sessionKey: ctx.sessionKey },
+          baseUrl,
+          cfg
         );
-      }
+        return { content: adaptResponse(spec, payload) };
+      },
+    }), { name: def.name });
+  }
 
-      const result = await fetchApi(baseUrl, `/sessions/${encodeURIComponent(userId)}/cookies`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${envCfg.apiKey}`,
-        },
-        body: JSON.stringify({ cookies: pwCookies }),
-      });
-
-      return toToolResult({ imported: pwCookies.length, userId, result });
-    },
-  }), { name: "camofox_import_cookies" });
 
   api.registerCommand({
     name: "camofox",

--- a/scripts/mcp-call.mjs
+++ b/scripts/mcp-call.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// MCP 도구 호출 헬퍼 — create_tab/snapshot 등 실행 후 결과를 JSON으로 출력.
+// 사용: node scripts/mcp-call.mjs <tool_name> '<json_args>'
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
+const SERVER = resolve(ROOT, "mcp", "server.mjs");
+
+const [toolName, argsJson] = process.argv.slice(2);
+if (!toolName) {
+  console.error("usage: mcp-call.mjs <tool> '<json-args>'");
+  process.exit(2);
+}
+let args = {};
+if (argsJson) {
+  try { args = JSON.parse(argsJson); }
+  catch (e) { console.error("bad json:", e.message); process.exit(2); }
+}
+
+const proc = spawn(process.execPath, [SERVER], {
+  cwd: ROOT,
+  env: {
+    PATH: process.env.PATH, HOME: process.env.HOME, USER: process.env.USER,
+    NODE_OPTIONS: process.env.NODE_OPTIONS || "",
+    CAMOFOX_BASE_URL: process.env.CAMOFOX_BASE_URL || "http://localhost:9377",
+  },
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
+let buf = "";
+const results = new Map();
+proc.stdout.on("data", (chunk) => {
+  buf += chunk.toString();
+  let nl;
+  while ((nl = buf.indexOf("\n")) >= 0) {
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    if (!line.trim()) continue;
+    try { const m = JSON.parse(line); if (m.id != null) results.set(m.id, m); }
+    catch {}
+  }
+});
+let stderr = "";
+proc.stderr.on("data", (c) => (stderr += c.toString()));
+
+await new Promise((r) => setTimeout(r, 300));
+send({ jsonrpc: "2.0", id: 1, method: "initialize",
+  params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "cli", version: "0" } } });
+send({ jsonrpc: "2.0", method: "notifications/initialized" });
+send({ jsonrpc: "2.0", id: 2, method: "tools/call",
+  params: { name: toolName, arguments: args } });
+
+// wait for id:2
+const deadline = Date.now() + 90000;
+while (!results.has(2) && Date.now() < deadline) {
+  await new Promise((r) => setTimeout(r, 200));
+}
+proc.kill();
+
+const res = results.get(2);
+if (!res) {
+  console.error("NO RESPONSE (timeout)\nstderr:", stderr);
+  process.exit(1);
+}
+if (res.result?.isError) {
+  console.error("TOOL ERROR:", res.result.content[0]?.text);
+  process.exit(1);
+}
+// 결과 출력 (이미지 콘텐츠는 data 길이만)
+const out = res.result.content.map((c) => {
+  if (c.type === "image") return `[image: ${c.mimeType}, ${c.data.length} chars base64]`;
+  if (c.type === "text") {
+    // text 안에 JSON이면 pretty, 아니면 그대로
+    try { return JSON.stringify(JSON.parse(c.text), null, 2); }
+    catch { return c.text; }
+  }
+  return c;
+});
+console.log(out.join("\n"));

--- a/scripts/mcp-call.mjs
+++ b/scripts/mcp-call.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-// MCP 도구 호출 헬퍼 — create_tab/snapshot 등 실행 후 결과를 JSON으로 출력.
-// 사용: node scripts/mcp-call.mjs <tool_name> '<json_args>'
+// MCP tool-call helper — invoke one tool (e.g. create_tab/snapshot) and print
+// the result as JSON.
+// Usage: node scripts/mcp-call.mjs <tool_name> '<json-args>'
 import { spawn } from "node:child_process";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -69,11 +70,11 @@ if (res.result?.isError) {
   console.error("TOOL ERROR:", res.result.content[0]?.text);
   process.exit(1);
 }
-// 결과 출력 (이미지 콘텐츠는 data 길이만)
+// Emit the result (for image content, only show the data length).
 const out = res.result.content.map((c) => {
   if (c.type === "image") return `[image: ${c.mimeType}, ${c.data.length} chars base64]`;
   if (c.type === "text") {
-    // text 안에 JSON이면 pretty, 아니면 그대로
+    // Pretty-print if the text is JSON, otherwise leave it as-is.
     try { return JSON.stringify(JSON.parse(c.text), null, 2); }
     catch { return c.text; }
   }

--- a/scripts/mcp-run.mjs
+++ b/scripts/mcp-run.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-// 단일 MCP 프로세스 안에서 도구들을 순차 호출 — 실제 Claude Code 사용(장기 프로세스,
-// 고정 userId)을 시뮬레이션. 스크립트 인자로 JSON 시퀀스를 받는다.
+// Run a sequence of tool calls inside a single MCP process — simulates real
+// Claude Code usage (long-lived process, fixed userId). Takes a JSON sequence
+// as a CLI argument.
 //
-// 사용: node scripts/mcp-run.mjs '[["camofox_create_tab",{"url":"..."}],["camofox_snapshot",{}]]'
-// snapshot의 tabId는 이전 create_tab 결과에서 자동 치환("${tabId}").
+// Usage: node scripts/mcp-run.mjs '[["camofox_create_tab",{"url":"..."}],["camofox_snapshot",{}]]'
+// A snapshot's tabId is auto-substituted from the prior create_tab result ("${tabId}").
 import { spawn } from "node:child_process";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -43,18 +44,18 @@ const wait = async (id, ms = 60000) => {
   return results.get(id);
 };
 
-// 핸드셰이크
+// Handshake.
 send({ jsonrpc: "2.0", id: 1, method: "initialize",
   params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "cli", version: "0" } } });
 const init = await wait(1);
 if (!init) { console.error("init failed:", stderr); proc.kill(); process.exit(1); }
 send({ jsonrpc: "2.0", method: "notifications/initialized" });
 
-const ctx = {}; // 직전 호출 결과에서 키값 보관 (tabId 등)
+const ctx = {}; // carries key values (e.g. tabId) from the previous call
 for (let i = 0; i < seq.length; i++) {
   let [name, args] = seq[i];
   args = args || {};
-  // ${var} 치환
+  // Substitute ${var} placeholders.
   const subst = (v) => typeof v === "string"
     ? v.replace(/\$\{(\w+)\}/g, (_, k) => (k in ctx ? String(ctx[k]) : `\${${k}}`))
     : v;
@@ -69,7 +70,7 @@ for (let i = 0; i < seq.length; i++) {
     console.log(`\n[${i}] ${name} → ERROR\n  ${res.result.content[0]?.text}`);
     continue;
   }
-  // 텍스트 콘텐츠에서 tabId 등 추출해 ctx에 보관
+  // Pull tabId (and similar) out of text content and stash it in ctx.
   for (const c of res.result.content) {
     if (c.type === "text") {
       try {

--- a/scripts/mcp-run.mjs
+++ b/scripts/mcp-run.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// 단일 MCP 프로세스 안에서 도구들을 순차 호출 — 실제 Claude Code 사용(장기 프로세스,
+// 고정 userId)을 시뮬레이션. 스크립트 인자로 JSON 시퀀스를 받는다.
+//
+// 사용: node scripts/mcp-run.mjs '[["camofox_create_tab",{"url":"..."}],["camofox_snapshot",{}]]'
+// snapshot의 tabId는 이전 create_tab 결과에서 자동 치환("${tabId}").
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
+const SERVER = resolve(ROOT, "mcp", "server.mjs");
+
+const seq = JSON.parse(process.argv[2]);
+const proc = spawn(process.execPath, [SERVER], {
+  cwd: ROOT,
+  env: {
+    PATH: process.env.PATH, HOME: process.env.HOME, USER: process.env.USER,
+    NODE_OPTIONS: process.env.NODE_OPTIONS || "",
+    CAMOFOX_BASE_URL: process.env.CAMOFOX_BASE_URL || "http://localhost:9377",
+  },
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
+let buf = "";
+const results = new Map();
+proc.stdout.on("data", (chunk) => {
+  buf += chunk.toString();
+  let nl;
+  while ((nl = buf.indexOf("\n")) >= 0) {
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    if (!line.trim()) continue;
+    try { const m = JSON.parse(line); if (m.id != null) results.set(m.id, m); } catch {}
+  }
+});
+let stderr = "";
+proc.stderr.on("data", (c) => (stderr += c.toString()));
+const wait = async (id, ms = 60000) => {
+  const dl = Date.now() + ms;
+  while (!results.has(id) && Date.now() < dl) await new Promise((r) => setTimeout(r, 150));
+  return results.get(id);
+};
+
+// 핸드셰이크
+send({ jsonrpc: "2.0", id: 1, method: "initialize",
+  params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "cli", version: "0" } } });
+const init = await wait(1);
+if (!init) { console.error("init failed:", stderr); proc.kill(); process.exit(1); }
+send({ jsonrpc: "2.0", method: "notifications/initialized" });
+
+const ctx = {}; // 직전 호출 결과에서 키값 보관 (tabId 등)
+for (let i = 0; i < seq.length; i++) {
+  let [name, args] = seq[i];
+  args = args || {};
+  // ${var} 치환
+  const subst = (v) => typeof v === "string"
+    ? v.replace(/\$\{(\w+)\}/g, (_, k) => (k in ctx ? String(ctx[k]) : `\${${k}}`))
+    : v;
+  args = Object.fromEntries(Object.entries(args).map(([k, v]) => [k, subst(v)]));
+
+  const id = 10 + i;
+  send({ jsonrpc: "2.0", id, method: "tools/call", params: { name, arguments: args } });
+  const res = await wait(id);
+  if (!res) { console.log(`\n[${i}] ${name}: NO RESPONSE`); continue; }
+
+  if (res.result?.isError) {
+    console.log(`\n[${i}] ${name} → ERROR\n  ${res.result.content[0]?.text}`);
+    continue;
+  }
+  // 텍스트 콘텐츠에서 tabId 등 추출해 ctx에 보관
+  for (const c of res.result.content) {
+    if (c.type === "text") {
+      try {
+        const parsed = JSON.parse(c.text);
+        if (parsed.tabId) ctx.tabId = parsed.tabId;
+        const summary = JSON.stringify(parsed).slice(0, 400);
+        console.log(`\n[${i}] ${name} → OK\n  ${summary}`);
+      } catch {
+        console.log(`\n[${i}] ${name} → OK (text)\n  ${c.text.slice(0, 400)}`);
+      }
+    } else if (c.type === "image") {
+      console.log(`\n[${i}] ${name} → OK (image ${c.mimeType}, ${c.data.length}b64)`);
+    }
+  }
+}
+proc.kill();

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Sync openclaw.plugin.json version with package.json.
+ * Sync openclaw.plugin.json and mcp/package.json versions with package.json.
  * Run via: npm run version:sync
  * Auto-runs on npm version via the "version" lifecycle script.
  */
@@ -13,13 +13,23 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
 
 const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
+
 const pluginPath = join(root, 'openclaw.plugin.json');
 const plugin = JSON.parse(await readFile(pluginPath, 'utf8'));
-
 if (plugin.version !== pkg.version) {
   plugin.version = pkg.version;
   await writeFile(pluginPath, JSON.stringify(plugin, null, 2) + '\n');
   console.log(`openclaw.plugin.json version synced to ${pkg.version}`);
 } else {
   console.log(`openclaw.plugin.json already at ${pkg.version}`);
+}
+
+const mcpPkgPath = join(root, 'mcp', 'package.json');
+const mcpPkg = JSON.parse(await readFile(mcpPkgPath, 'utf8'));
+if (mcpPkg.version !== pkg.version) {
+  mcpPkg.version = pkg.version;
+  await writeFile(mcpPkgPath, JSON.stringify(mcpPkg, null, 2) + '\n');
+  console.log(`mcp/package.json version synced to ${pkg.version}`);
+} else {
+  console.log(`mcp/package.json already at ${pkg.version}`);
 }

--- a/scripts/test-mcp.mjs
+++ b/scripts/test-mcp.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// Self-contained smoke test for mcp/server.mjs — no Jest, no REST server.
+// Verifies: handshake completes, all 11 tools are listed with valid schemas,
+// and an unknown tool call returns isError. Tool *execution* (which needs the
+// camofox REST server) is out of scope here.
+//
+// Run: node scripts/test-mcp.mjs   (or `npm run test:mcp`)
+// Exits non-zero on any failure.
+
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
+const SERVER = resolve(ROOT, "mcp", "server.mjs");
+
+const EXPECTED_TOOLS = [
+  "camofox_create_tab",
+  "camofox_snapshot",
+  "camofox_click",
+  "camofox_type",
+  "camofox_navigate",
+  "camofox_scroll",
+  "camofox_screenshot",
+  "camofox_close_tab",
+  "camofox_evaluate",
+  "camofox_list_tabs",
+  "camofox_import_cookies",
+];
+
+const proc = spawn(process.execPath, [SERVER], {
+  cwd: ROOT,
+  // Whitelist only what the server needs (CONTRIBUTING.md: never spread process.env).
+  env: {
+    PATH: process.env.PATH,
+    HOME: process.env.HOME,
+    USER: process.env.USER,
+    NODE_OPTIONS: process.env.NODE_OPTIONS || "",
+    CAMOFOX_BASE_URL: "http://localhost:1",
+  },
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+const pending = new Map();
+let buf = "";
+let failures = 0;
+let stderr = "";
+
+proc.stdout.on("data", (chunk) => {
+  buf += chunk.toString();
+  let nl;
+  while ((nl = buf.indexOf("\n")) >= 0) {
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    if (!line.trim()) continue;
+    try {
+      const msg = JSON.parse(line);
+      if (msg.id != null && pending.has(msg.id)) {
+        const { resolve, reject, timer } = pending.get(msg.id);
+        clearTimeout(timer);
+        pending.delete(msg.id);
+        if (msg.error) reject(new Error(JSON.stringify(msg.error)));
+        else resolve(msg);
+      }
+    } catch {
+      /* ignore non-JSON */
+    }
+  }
+});
+proc.stderr.on("data", (c) => {
+  stderr += c.toString();
+});
+
+let nextId = 1;
+function call(method, params, timeoutMs = 15000) {
+  return new Promise((resolveP, rejectP) => {
+    const id = nextId++;
+    const timer = setTimeout(() => {
+      pending.delete(id);
+      rejectP(new Error(`timeout: ${method} id=${id}\nstderr:\n${stderr}`));
+    }, timeoutMs);
+    pending.set(id, { resolve: resolveP, reject: rejectP, timer });
+    proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+  });
+}
+function notify(method, params) {
+  proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
+}
+
+function check(name, cond, detail = "") {
+  if (cond) {
+    console.log(`  ✓ ${name}`);
+  } else {
+    console.error(`  ✗ ${name} ${detail}`);
+    failures++;
+  }
+}
+
+async function main() {
+  console.log("mcp/server.mjs smoke test");
+
+  const init = await call("initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "test", version: "0" },
+  });
+  check("handshake returns server name", init.result.serverInfo.name === "camofox-browser", `got ${init.result.serverInfo?.name}`);
+  notify("notifications/initialized");
+
+  const list = await call("tools/list", {});
+  const tools = list.result.tools;
+  const names = tools.map((t) => t.name).sort();
+  check("lists exactly 11 tools", tools.length === 11, `got ${tools.length}`);
+  check("tool names match expected", names.join(",") === [...EXPECTED_TOOLS].sort().join(","), `got: ${names.join(",")}`);
+
+  for (const t of tools) {
+    check(`"${t.name}" has description`, typeof t.description === "string" && t.description.length > 0);
+    check(`"${t.name}" has inputSchema.object`, t.inputSchema?.type === "object" && t.inputSchema.properties !== undefined);
+  }
+
+  const nav = tools.find((t) => t.name === "camofox_navigate");
+  const macros = nav.inputSchema.properties.macro.enum;
+  check("navigate exposes google + reddit macros", macros.includes("@google_search") && macros.includes("@reddit_search"), `got ${macros.length} macros`);
+  check("navigate has >=13 macros", macros.length >= 13, `got ${macros.length}`);
+
+  const unknown = await call("tools/call", { name: "does_not_exist", arguments: {} });
+  check("unknown tool returns isError", unknown.result.isError === true, `got isError=${unknown.result.isError}`);
+  check("unknown tool mentions Unknown tool", /Unknown tool/.test(unknown.result.content[0].text));
+
+  proc.kill();
+  if (failures > 0) {
+    console.error(`\n${failures} check(s) failed`);
+    process.exit(1);
+  }
+  console.log("\nall checks passed");
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("FATAL:", err.message);
+  proc.kill();
+  process.exit(1);
+});

--- a/tests/unit/mcp-contracts.test.js
+++ b/tests/unit/mcp-contracts.test.js
@@ -1,0 +1,339 @@
+/**
+ * Mock-HTTP contract tests for the shared tool contract module
+ * (lib/mcp-tool-contracts.mjs).
+ *
+ * These tests are the "1:1 compatibility is verifiable" guard the reviewer
+ * asked for: every tool's REST route, method, body shape, auth header, and
+ * response decoding is asserted against a mock REST server. Because plugin.ts
+ * (OpenClaw) and mcp/server.mjs both call the same runTool()/adaptResponse(),
+ * passing these tests proves both hosts issue identical REST traffic.
+ *
+ * No network: globalThis.fetch is swapped per-test.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import {
+  TOOL_DEFS,
+  TOOL_NAMES,
+  buildRequest,
+  buildCookieRequest,
+  fetchSpec,
+  runTool,
+  adaptResponse,
+  authHeaders,
+} from '../../lib/mcp-tool-contracts.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BASE = 'http://localhost:9377';
+const CTX = { userId: 'u1', sessionKey: 'default' };
+const cfg = (overrides = {}) => ({
+  apiKey: 'API-KEY',
+  accessKey: 'ACCESS-KEY',
+  cookiesDir: '/tmp/cookies',
+  ...overrides,
+});
+
+// --- Minimal fetch mock -----------------------------------------------------
+const originalFetch = globalThis.fetch;
+
+function makeResponse(res) {
+  const status = res.status ?? 200;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (k) => (res.headers ? res.headers[k.toLowerCase()] ?? null : null),
+    },
+    async text() {
+      return typeof res.body === 'string' ? res.body : JSON.stringify(res.body ?? {});
+    },
+    async json() {
+      return typeof res.body === 'string' ? JSON.parse(res.body) : res.body;
+    },
+    async arrayBuffer() {
+      return res.buffer ?? Buffer.from(res.body ?? '');
+    },
+  };
+}
+
+function installFetch(routes) {
+  globalThis.fetch = async (url, init = {}) => {
+    const u = new URL(url);
+    const rawHeaders = init.headers || {};
+    const headers = rawHeaders instanceof Headers
+      ? Object.fromEntries(rawHeaders.entries())
+      : { ...rawHeaders };
+    const req = {
+      path: `${u.pathname}${u.search}`,
+      method: (init.method || 'GET').toUpperCase(),
+      headers,
+      body: init.body,
+    };
+    const route = routes.find((r) => r.match(req));
+    if (!route) {
+      throw new Error(`no mock route for ${req.method} ${req.path}`);
+    }
+    return makeResponse(await route.respond(req));
+  };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// --- Schema sanity ----------------------------------------------------------
+describe('TOOL_DEFS', () => {
+  test('exposes exactly 11 tools', () => {
+    expect(TOOL_DEFS).toHaveLength(11);
+  });
+
+  test('every def has a unique name and a valid JSON-Schema object', () => {
+    const names = TOOL_DEFS.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+    for (const t of TOOL_DEFS) {
+      expect(t.inputSchema.type).toBe('object');
+      expect(Array.isArray(t.inputSchema.required)).toBe(true);
+    }
+  });
+});
+
+// --- buildRequest: per-tool REST contract (source of truth assertions) -------
+describe('buildRequest', () => {
+  test.each([
+    ['camofox_create_tab', { url: 'https://x.com' }, { method: 'POST', path: '/tabs', auth: 'accessKey', kind: 'json' }],
+    ['camofox_snapshot', { tabId: 't1' }, { method: 'GET', path: '/tabs/t1/snapshot?userId=u1&includeScreenshot=true', auth: 'accessKey', kind: 'snapshot' }],
+    ['camofox_snapshot', { tabId: 't1', offset: 40 }, { method: 'GET', path: '/tabs/t1/snapshot?userId=u1&includeScreenshot=true&offset=40', auth: 'accessKey', kind: 'snapshot' }],
+    ['camofox_click', { tabId: 't1', ref: 'e1' }, { method: 'POST', path: '/tabs/t1/click', auth: 'accessKey', kind: 'json' }],
+    ['camofox_type', { tabId: 't1', text: 'hi', pressEnter: true }, { method: 'POST', path: '/tabs/t1/type', auth: 'accessKey', kind: 'json' }],
+    ['camofox_navigate', { tabId: 't1', url: 'https://y.com' }, { method: 'POST', path: '/tabs/t1/navigate', auth: 'accessKey', kind: 'json' }],
+    ['camofox_scroll', { tabId: 't1', direction: 'down', amount: 200 }, { method: 'POST', path: '/tabs/t1/scroll', auth: 'accessKey', kind: 'json' }],
+    ['camofox_screenshot', { tabId: 't1' }, { method: 'GET', path: '/tabs/t1/screenshot?userId=u1', auth: 'accessKey', kind: 'image' }],
+    ['camofox_close_tab', { tabId: 't1' }, { method: 'DELETE', path: '/tabs/t1?userId=u1', auth: 'accessKey', kind: 'json' }],
+    ['camofox_evaluate', { tabId: 't1', expression: '1+1' }, { method: 'POST', path: '/tabs/t1/evaluate', auth: 'accessKey', kind: 'json' }],
+    ['camofox_list_tabs', {}, { method: 'GET', path: '/tabs?userId=u1', auth: 'accessKey', kind: 'json' }],
+  ])('%s → %s %s (auth=%s)', (name, args, expected) => {
+    const spec = buildRequest(name, args, CTX);
+    expect(spec.method).toBe(expected.method);
+    expect(spec.path).toBe(expected.path);
+    expect(spec.auth).toBe(expected.auth);
+    expect(spec.responseKind).toBe(expected.kind);
+  });
+
+  test('create_tab body carries url + userId + sessionKey', () => {
+    const spec = buildRequest('camofox_create_tab', { url: 'https://x.com' }, CTX);
+    expect(spec.body).toEqual({ url: 'https://x.com', userId: 'u1', sessionKey: 'default' });
+  });
+
+  test('click/type/navigate/scroll forward all non-routing args + userId in body', () => {
+    const spec = buildRequest('camofox_type', { tabId: 't1', ref: 'e2', text: 'hi', pressEnter: true }, CTX);
+    expect(spec.body).toEqual({ ref: 'e2', text: 'hi', pressEnter: true, userId: 'u1' });
+    expect(spec.body.tabId).toBeUndefined();
+  });
+
+  test('evaluate body is exactly { userId, expression }', () => {
+    const spec = buildRequest('camofox_evaluate', { tabId: 't1', expression: 'document.title' }, CTX);
+    expect(spec.body).toEqual({ userId: 'u1', expression: 'document.title' });
+  });
+
+  test('import_cookies is NOT synchronous (must use buildCookieRequest)', () => {
+    expect(() => buildRequest('camofox_import_cookies', {}, CTX)).toThrow(/buildCookieRequest/);
+  });
+
+  test('unknown tool throws', () => {
+    expect(() => buildRequest('camofox_bogus', {}, CTX)).toThrow(/Unknown tool/);
+  });
+});
+
+// --- authHeaders: accessKey vs apiKey vs none -------------------------------
+describe('authHeaders', () => {
+  test('accessKey present → Bearer accessKey', () => {
+    expect(authHeaders({ auth: 'accessKey' }, cfg())).toEqual({
+      Authorization: 'Bearer ACCESS-KEY',
+    });
+  });
+  test('accessKey absent on ungated server → no header (pass-through)', () => {
+    expect(authHeaders({ auth: 'accessKey' }, cfg({ accessKey: '' }))).toEqual({});
+  });
+  test('apiKey → Bearer apiKey', () => {
+    expect(authHeaders({ auth: 'apiKey' }, cfg())).toEqual({
+      Authorization: 'Bearer API-KEY',
+    });
+  });
+  test('none → empty', () => {
+    expect(authHeaders({ auth: 'none' }, cfg())).toEqual({});
+  });
+});
+
+// --- adaptResponse: content-block shaping -----------------------------------
+describe('adaptResponse', () => {
+  test('json → single text block', () => {
+    const spec = { responseKind: 'json' };
+    const c = adaptResponse(spec, { ok: true });
+    expect(c).toHaveLength(1);
+    expect(c[0].type).toBe('text');
+    expect(JSON.parse(c[0].text)).toEqual({ ok: true });
+  });
+  test('snapshot → text block + screenshot image block', () => {
+    const spec = { responseKind: 'snapshot' };
+    const c = adaptResponse(spec, { url: 'u', snapshot: 's', screenshot: { data: 'IMG', mimeType: 'image/png' } });
+    expect(c).toHaveLength(2);
+    expect(c[0].type).toBe('text');
+    expect(c[1]).toEqual({ type: 'image', data: 'IMG', mimeType: 'image/png' });
+    expect(JSON.parse(c[0].text).screenshot).toBeUndefined();
+  });
+  test('snapshot without screenshot → text only', () => {
+    const c = adaptResponse({ responseKind: 'snapshot' }, { snapshot: 's' });
+    expect(c).toHaveLength(1);
+  });
+  test('image → passes the prebuilt image block through', () => {
+    const block = { type: 'image', data: 'IMG', mimeType: 'image/png' };
+    expect(adaptResponse({ responseKind: 'image' }, block)).toEqual([block]);
+  });
+  test('cookie import → surfaces imported count', () => {
+    const spec = { responseKind: 'json', meta: { imported: 3, userId: 'u1' } };
+    const c = adaptResponse(spec, { ok: true });
+    expect(JSON.parse(c[0].text)).toEqual({ imported: 3, userId: 'u1', result: { ok: true } });
+  });
+});
+
+// --- fetchSpec: wire-level behavior with a mocked REST server ----------------
+describe('fetchSpec (mock REST)', () => {
+  test('attaches accessKey bearer to an accessKey request', async () => {
+    let seen;
+    installFetch([
+      { match: (r) => r.method === 'POST' && r.path === '/tabs', respond: (r) => { seen = r; return { body: { tabId: 't1' } }; } },
+    ]);
+    const spec = buildRequest('camofox_create_tab', { url: 'https://x.com' }, CTX);
+    await fetchSpec(BASE, spec, cfg());
+    expect(seen.headers.Authorization).toBe('Bearer ACCESS-KEY');
+    expect(JSON.parse(seen.body)).toEqual({ url: 'https://x.com', userId: 'u1', sessionKey: 'default' });
+  });
+
+  test('omits Authorization when server has no accessKey', async () => {
+    let seen;
+    installFetch([{ match: (r) => r.method === 'GET' && r.path === '/tabs?userId=u1', respond: (r) => { seen = r; return { body: [] }; } }]);
+    await fetchSpec(BASE, buildRequest('camofox_list_tabs', {}, CTX), cfg({ accessKey: '' }));
+    expect(seen.headers.Authorization).toBeUndefined();
+  });
+
+  test('throws on non-2xx with status + body', async () => {
+    installFetch([{ match: () => true, respond: () => ({ status: 403, body: { error: 'Forbidden' } }) }]);
+    await expect(fetchSpec(BASE, buildRequest('camofox_list_tabs', {}, CTX), cfg())).rejects.toThrow(/403/);
+  });
+
+  test('screenshot decodes image bytes to a base64 image block', async () => {
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    installFetch([
+      { match: (r) => r.method === 'GET' && r.path === '/tabs/t1/screenshot?userId=u1', respond: () => ({ headers: { 'content-type': 'image/png' }, buffer: pngBytes }) },
+    ]);
+    const out = await fetchSpec(BASE, buildRequest('camofox_screenshot', { tabId: 't1' }, CTX), cfg());
+    expect(out).toMatchObject({ type: 'image', mimeType: 'image/png' });
+    expect(out.data).toBe(pngBytes.toString('base64'));
+  });
+
+  test('screenshot that returns JSON (error with 200) is not base64-encoded', async () => {
+    installFetch([
+      { match: () => true, respond: () => ({ headers: { 'content-type': 'application/json' }, body: { error: 'tab closed' } }) },
+    ]);
+    await expect(fetchSpec(BASE, buildRequest('camofox_screenshot', { tabId: 't1' }, CTX), cfg())).rejects.toThrow(/Screenshot failed/);
+  });
+});
+
+// --- runTool end-to-end: a few representative tools -------------------------
+describe('runTool (end-to-end)', () => {
+  test('create_tab round-trips through the real REST shape', async () => {
+    installFetch([{ match: (r) => r.method === 'POST' && r.path === '/tabs', respond: () => ({ body: { tabId: 't9', url: 'https://x.com' } }) }]);
+    const { spec, payload } = await runTool('camofox_create_tab', { url: 'https://x.com' }, CTX, BASE, cfg());
+    expect(payload).toEqual({ tabId: 't9', url: 'https://x.com' });
+    const content = adaptResponse(spec, payload);
+    expect(content[0].type).toBe('text');
+  });
+
+  test('snapshot splits the embedded screenshot into an image block', async () => {
+    installFetch([
+      { match: (r) => r.method === 'GET' && r.path.startsWith('/tabs/t1/snapshot'), respond: () => ({ body: { url: 'u', snapshot: 's', screenshot: { data: 'IMG', mimeType: 'image/png' } } }) },
+    ]);
+    const { spec, payload } = await runTool('camofox_snapshot', { tabId: 't1' }, CTX, BASE, cfg());
+    const content = adaptResponse(spec, payload);
+    expect(content).toHaveLength(2);
+    expect(content[1]).toMatchObject({ type: 'image', data: 'IMG' });
+  });
+});
+
+// --- Cookie import: the core contract fix ----------------------------------
+// Reviewer: MCP previously POSTed { cookiesPath } but the REST route requires a
+// parsed { cookies: [...] } payload. This proves the MCP path now parses the
+// Netscape file locally (like OpenClaw) and sends { cookies } + Bearer apiKey.
+describe('cookie import contract', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'camofox-mcp-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const NETSCAPE = [
+    '# Netscape HTTP Cookie File',
+    '#HttpOnly_.example.com\tTRUE\t/\tTRUE\t9999999999\tsess\tabc123',
+    '.other.com\tTRUE\t/\tFALSE\t0\tunwanted\tnope',
+  ].join('\n');
+
+  test('parses Netscape locally and sends { cookies } body with apiKey bearer', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'cookies.txt'), NETSCAPE);
+    let seen;
+    installFetch([
+      {
+        match: (r) => r.method === 'POST' && r.path === '/sessions/u1/cookies',
+        respond: (r) => { seen = r; return { body: { ok: true, userId: 'u1', count: 1 } }; },
+      },
+    ]);
+    const { spec, payload } = await runTool(
+      'camofox_import_cookies',
+      { cookiesPath: 'cookies.txt', domainSuffix: 'example.com' },
+      CTX,
+      BASE,
+      cfg({ cookiesDir: tmpDir })
+    );
+    // REST route receives the PARSED cookie array, never a path.
+    expect(spec.body.cookies).toEqual([
+      expect.objectContaining({ name: 'sess', value: 'abc123', domain: '.example.com', httpOnly: true, secure: true }),
+    ]);
+    expect(spec.body.cookiesPath).toBeUndefined();
+    expect(spec.auth).toBe('apiKey');
+    expect(seen.headers.Authorization).toBe('Bearer API-KEY');
+    expect(JSON.parse(seen.body)).toEqual({ cookies: spec.body.cookies });
+    // Response surfaces the parsed count.
+    expect(JSON.parse(adaptResponse(spec, payload)[0].text).imported).toBe(1);
+  });
+
+  test('throws when CAMOFOX_API_KEY is unset (cookie import disabled)', async () => {
+    await expect(
+      buildCookieRequest({ cookiesPath: 'cookies.txt' }, CTX, cfg({ apiKey: '' }))
+    ).rejects.toThrow(/CAMOFOX_API_KEY/);
+  });
+
+  test('rejects cookiesPath outside the cookies directory (path traversal)', async () => {
+    await expect(
+      buildCookieRequest({ cookiesPath: '../escape.txt' }, CTX, cfg({ cookiesDir: tmpDir }))
+    ).rejects.toThrow(/within the cookies directory/);
+  });
+});
+
+// --- Cross-host equivalence: every tool name resolves via both entry points --
+describe('host equivalence', () => {
+  test('every tool name is buildable and listed', () => {
+    for (const name of TOOL_NAMES) {
+      if (name === 'camofox_import_cookies') {
+        expect(() => buildRequest(name, {}, CTX)).toThrow(/buildCookieRequest/);
+      } else {
+        expect(() => buildRequest(name, { tabId: 't1', url: 'u', expression: 'e', text: 'x', direction: 'down' }, CTX)).not.toThrow();
+      }
+    }
+  });
+});

--- a/tests/unit/openclawManifest.test.js
+++ b/tests/unit/openclawManifest.test.js
@@ -1,23 +1,27 @@
 import { describe, test, expect } from '@jest/globals';
 import fs from 'fs';
+import { TOOL_NAMES } from '../../lib/mcp-tool-contracts.mjs';
 
-const RUNTIME_TOOL_RE = /name:\s*["'](camofox_[^"']+)["']/g;
+// Canonical tool contracts (lib/mcp-tool-contracts.mjs) are the single source
+// of truth shared by the OpenClaw plugin (plugin.ts) and the MCP server
+// (mcp/server.mjs). The OpenClaw manifests must mirror that list exactly — this
+// guard fails if a tool is added/removed/renamed in one place but not the others.
 
-function runtimeToolNames() {
-  const plugin = fs.readFileSync(new URL('../../plugin.js', import.meta.url), 'utf8');
-  return [...new Set([...plugin.matchAll(RUNTIME_TOOL_RE)].map(match => match[1]))];
+function readJson(rel) {
+  return JSON.parse(fs.readFileSync(new URL(`../../${rel}`, import.meta.url), 'utf8'));
 }
 
 describe('OpenClaw manifest', () => {
-  test('declares ownership contracts for every runtime tool', () => {
-    const manifest = JSON.parse(fs.readFileSync(new URL('../../openclaw.plugin.json', import.meta.url), 'utf8'));
-    const pkg = JSON.parse(fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf8'));
-    const runtimeTools = runtimeToolNames();
-    const packageTools = pkg.openclaw.tools.map(tool => tool.name);
+  test('declares ownership contracts for every canonical tool', () => {
+    const manifest = readJson('openclaw.plugin.json');
+    const pkg = readJson('package.json');
 
-    expect(manifest.contracts).toBeDefined();
-    expect(manifest.contracts.tools).toEqual(runtimeTools);
-    expect(manifest.tools).toEqual(runtimeTools);
-    expect(packageTools).toEqual(runtimeTools);
+    const manifestContracts = manifest.contracts.tools;
+    const manifestTools = manifest.tools;
+    const packageTools = pkg.openclaw.tools.map((tool) => tool.name);
+
+    expect(manifestContracts).toEqual(TOOL_NAMES);
+    expect(manifestTools).toEqual(TOOL_NAMES);
+    expect(packageTools).toEqual(TOOL_NAMES);
   });
 });


### PR DESCRIPTION
## Update — addressed review feedback

@skyfallsin thanks for the detailed review. All four contract issues, the architecture suggestion, and the test-coverage ask are addressed below, each verified with a new test or a direct runtime check.

| Review point | Fix | Verified by |
|---|---|---|
| `camofox_import_cookies` sent `{ cookiesPath }`, REST wants `{ cookies: [...] }` | Now parses the Netscape file locally via `lib/cookies.js` (same helper OpenClaw uses) and sends the parsed array | `tests/unit/mcp-contracts.test.js` (cookie import contract) |
| `CAMOFOX_ACCESS_KEY` not forwarded | Every tool call now attaches `Authorization: Bearer <accessKey>` automatically when set (fixed for both MCP and OpenClaw) | `tests/unit/mcp-contracts.test.js` (authHeaders / fetchSpec) |
| 11 tool schemas/handlers copied between `plugin.ts` and `mcp/server.mjs` (drift risk) | Extracted into `lib/mcp-tool-contracts.mjs` — single source of truth both hosts import (schema, REST route, auth, response shaping) | `tests/unit/openclawManifest.test.js`, plus a runtime check loading the built `plugin.js` and confirming registered tools dispatch through the same `runTool()` |
| MCP server version hardcoded | Reads from `package.json` at startup | stdio smoke test asserts `serverInfo.version` matches |
| Architecture: independently installable MCP package, avoid SDK dep on every core install | `mcp/` is now its own npm package (`@askjo/camofox-mcp`, own `package.json`), depending on nothing but `@modelcontextprotocol/sdk` — no `camoufox-js`/`playwright-core`/`express`/browser download. `cd mcp && npm install` pulls ~24MB vs. the core package's 140MB+ (node_modules) + ~300MB (browser binary). The SDK reference on the root package stays as `optionalDependencies` (kept for the existing `npm install -g` / `npx` distribution path documented in `mcp/README.md`) | Verified by installing `mcp/` standalone and running the stdio smoke test against it |
| No focused mock-HTTP contract tests | Added `tests/unit/mcp-contracts.test.js` — 38 tests covering every tool's REST route/method/body, `CAMOFOX_ACCESS_KEY`/`CAMOFOX_API_KEY` auth headers, cookie parsing, screenshot decoding, and error handling | `npm test` |

Since `plugin.ts` and `mcp/server.mjs` now share `lib/mcp-tool-contracts.mjs`, the "1:1 compatibility" claim is structural, not just asserted — both hosts call the same `runTool()`/`adaptResponse()`, so they cannot drift independently.

---

## What

Adds a standalone [Model Context Protocol](https://modelcontextprotocol.io) server that exposes camofox-browser to **any MCP-compatible host** — verified for Claude Code, Codex CLI, Antigravity/agy, Cursor, and opencode. Full guide lives in **[`mcp/README.md`](https://github.com/jo-inc/camofox-browser/blob/master/mcp/README.md)**.

Because it speaks standard stdio MCP, all five hosts run the **same `camofox-mcp` bin** — only the config file differs (`mcp/README.md` §3 has a per-host snippet for each).

The MCP server mirrors the existing OpenClaw plugin **1:1**: same 11 tool names, identical JSON-Schema parameters, and the same REST routes — enforced by sharing `lib/mcp-tool-contracts.mjs` as a single source of truth.

## Why

OpenClaw isn't every agent's host. Claude Code, Codex, agy, Cursor, and opencode all want camofox as a plain MCP server. Today they'd have to re-implement the REST calls themselves. This PR ships that integration in-tree, keeping it in sync with the OpenClaw plugin automatically via a shared contract module.

## What's included

- **`lib/mcp-tool-contracts.mjs`** — canonical tool contracts (schema, REST route, auth, response shaping) shared by `mcp/server.mjs` and `plugin.ts`.
- **`mcp/server.mjs`** — stdio MCP server. Forwards every tool call to the REST API (default `localhost:9377`), attaching `CAMOFOX_ACCESS_KEY`/`CAMOFOX_API_KEY` as needed. Per-server `userId`/`sessionKey` give each MCP session an isolated camofox session.
- **`mcp/package.json`** — `mcp/` is now an independently installable package (`@askjo/camofox-mcp`), own dependency graph (`@modelcontextprotocol/sdk` only).
- **`plugin.ts`** — now imports the same canonical contracts for tool registration; `fetchApi` forwards `CAMOFOX_ACCESS_KEY`.
- **`mcp/README.md`** — full guide: architecture, 4 install options (bin/global/npx/standalone-adapter-only), per-host registration, 11-tool table, env vars (incl. `CAMOFOX_ACCESS_KEY`), troubleshooting, testing.
- **`tests/unit/mcp-contracts.test.js`** — 38 mock-HTTP contract tests (no live REST server needed).
- **`tests/unit/openclawManifest.test.js`** — now checks the OpenClaw manifest against the canonical tool list instead of a `plugin.js` regex.
- **`package.json`** — `@modelcontextprotocol/sdk` moved to `optionalDependencies`.
- **`scripts/test-mcp.mjs`** — unchanged: dependency-free handshake/schema smoke test.

## What's NOT touched

- **Main `README.md`** — unchanged.
- **REST API, server behavior** — purely additive.

## Verification

```
$ npm run test:mcp        # handshake + schema smoke test, 29 checks
$ npm test tests/unit/mcp-contracts.test.js tests/unit/openclawManifest.test.js  # 40 tests
```

Also verified end-to-end:
- MCP: `create_tab` → `snapshot` → `list_tabs` → `screenshot` → `close_tab` against a live REST server.
- OpenClaw: installed via `openclaw plugins install .`, confirmed `Status: loaded`, `openclaw plugins doctor` clean, and loaded `plugin.js` via a mock `PluginApi` to confirm all 11 tools register and dispatch through the shared contract (including cookie import producing `{ cookies }`, not a path, and `CAMOFOX_ACCESS_KEY` attached).
- Standalone `mcp/` install: `cd mcp && npm install` (~24MB, no `camoufox-js`/`playwright-core`/browser download) + stdio smoke test.

## Notes

- Follows `CONTRIBUTING.md`: child-process env whitelisted.
- The MCP server does not launch the browser — it forwards to the REST server, which must already be running.
- `mcp/README.md` documents 4 install options now (bin via source checkout / global / npx / standalone MCP-adapter-only).
