### PR TITLE
fix: pass CAMOUFOX_ARCH to Docker build instead of ARCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ YTDLP_URL    := https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp
 ## Build the Docker image for the current ARCH (default: x86_64)
 build: fetch
 	docker build --no-cache \
-	  --build-arg ARCH=$(ARCH) \
+	  --build-arg ARCH=$(CAMOUFOX_ARCH) \
 	  --build-arg CAMOUFOX_VERSION=$(VERSION) \
 	  --build-arg CAMOUFOX_RELEASE=$(RELEASE) \
 	  -t $(IMAGE) .


### PR DESCRIPTION
## Problem

On ARM64 hosts (uname -m = aarch64), docker build fails at the Camoufox download step with "End-of-central-directory signature not found."

The Makefile correctly maps ARCH=aarch64 → CAMOUFOX_ARCH=arm64 for the fetch target (line 14), but the build target (line 33) passes the raw ARCH value to Docker via --build-arg ARCH=$(ARCH).

The Dockerfile then uses ${ARCH} directly in the download URL (line 48): camoufox-${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}-lin.${ARCH}.zip

GitHub releases use arm64 in filenames (e.g. camoufox-135.0.1-beta.24-lin.arm64.zip), not aarch64. So the download 404s, curl saves the GitHub 404 HTML page as the zip file, and unzip fails.

## Fix

Pass `CAMOUFOX_ARCH` (already correctly mapped) instead of `ARCH`:

```diff
 build: fetch
        docker build --no-cache \
-         --build-arg ARCH=$(ARCH) \
+         --build-arg ARCH=$(CAMOUFOX_ARCH) \
          --build-arg CAMOUFOX_VERSION=$(VERSION) \
          --build-arg CAMOUFOX_RELEASE=$(RELEASE) \
          -t $(IMAGE) .
```

This ensures the Dockerfile receives arm64 (not aarch64) on ARM hosts, matching the actual GitHub release filenames.

## Verification

- [x] make build ARCH=aarch64 succeeds on ARM64 host
- [x] make build ARCH=x86_64 still works (no regression)