### PR TITLE
Harden tab creation admission and session reaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,10 +639,14 @@ Browser behavior can be tuned in `camofox.config.json`:
 | `CAMOFOX_TRACES_TTL_HOURS` | Traces older than this are swept on startup | `24` |
 | `MAX_SESSIONS` | Max concurrent browser sessions | `50` |
 | `MAX_TABS_PER_SESSION` | Max tabs per session | `10` |
+| `MAX_TABS_GLOBAL` | Max tabs globally and concurrent tab creations | `50` |
 | `SESSION_TIMEOUT_MS` | Session inactivity timeout | `1800000` (30min) |
 | `BROWSER_IDLE_TIMEOUT_MS` | Kill browser when idle (0 = never) | `300000` (5min) |
 | `HANDLER_TIMEOUT_MS` | Max time for any handler | `30000` (30s) |
 | `MAX_CONCURRENT_PER_USER` | Concurrent request cap per user | `3` |
+| `TAB_ADMISSION_MAX_ACTIVE` | Max concurrent tab creations globally | `4` |
+| `TAB_ADMISSION_MAX_ACTIVE_PER_USER` | Max concurrent tab creations per user | `2` |
+| `TAB_ADMISSION_QUEUE_LIMIT` | Max queued tab-creation requests before HTTP 429 | `8` |
 | `MAX_OLD_SPACE_SIZE` | Node.js V8 heap limit (MB) | `128` |
 | `PROXY_STRATEGY` | Proxy mode: `backconnect` (rotating sticky sessions) or blank (single endpoint) | - |
 | `PROXY_PROVIDER` | Provider name for session format (e.g. `decodo`) | `decodo` |

--- a/lib/config.js
+++ b/lib/config.js
@@ -76,6 +76,12 @@ function camoufoxExecutablePath(env = process.env) {
   ).trim();
 }
 
+function parsePositiveInt(value, fallback) {
+  if (typeof value !== 'string' || !/^\d+$/.test(value.trim())) return fallback;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 function loadConfig({ configPath = CONFIG_PATH } = {}) {
   const externalCamoufoxExecutable = camoufoxExecutablePath();
   const browserIdleTimeoutMs = parseInt(process.env.BROWSER_IDLE_TIMEOUT_MS, 10);
@@ -99,14 +105,17 @@ function loadConfig({ configPath = CONFIG_PATH } = {}) {
     tracesDir: process.env.CAMOFOX_TRACES_DIR || join(os.homedir(), '.camofox', 'traces'),
     tracesMaxBytes: parseInt(process.env.CAMOFOX_TRACES_MAX_BYTES || String(50 * 1024 * 1024), 10),
     tracesTtlHours: parseInt(process.env.CAMOFOX_TRACES_TTL_HOURS || '24', 10),
-    handlerTimeoutMs: parseInt(process.env.HANDLER_TIMEOUT_MS) || 30000,
+    handlerTimeoutMs: parsePositiveInt(process.env.HANDLER_TIMEOUT_MS, 30000),
     newPageTimeoutMs,
-    maxConcurrentPerUser: parseInt(process.env.MAX_CONCURRENT_PER_USER) || 3,
-    sessionTimeoutMs: parseInt(process.env.SESSION_TIMEOUT_MS) || 600000,
-    tabInactivityMs: parseInt(process.env.TAB_INACTIVITY_MS) || 300000,
-    maxSessions: parseInt(process.env.MAX_SESSIONS) || 50,
-    maxTabsPerSession: parseInt(process.env.MAX_TABS_PER_SESSION) || 10,
-    maxTabsGlobal: parseInt(process.env.MAX_TABS_GLOBAL) || 50,
+    maxConcurrentPerUser: parsePositiveInt(process.env.MAX_CONCURRENT_PER_USER, 3),
+    sessionTimeoutMs: parsePositiveInt(process.env.SESSION_TIMEOUT_MS, 600000),
+    tabInactivityMs: parsePositiveInt(process.env.TAB_INACTIVITY_MS, 300000),
+    maxSessions: parsePositiveInt(process.env.MAX_SESSIONS, 50),
+    maxTabsPerSession: parsePositiveInt(process.env.MAX_TABS_PER_SESSION, 10),
+    maxTabsGlobal: parsePositiveInt(process.env.MAX_TABS_GLOBAL, 50),
+    tabAdmissionMaxActive: parsePositiveInt(process.env.TAB_ADMISSION_MAX_ACTIVE, 4),
+    tabAdmissionMaxActivePerUser: parsePositiveInt(process.env.TAB_ADMISSION_MAX_ACTIVE_PER_USER, 2),
+    tabAdmissionQueueLimit: parsePositiveInt(process.env.TAB_ADMISSION_QUEUE_LIMIT, 8),
     navigateTimeoutMs: parseInt(process.env.NAVIGATE_TIMEOUT_MS) || 25000,
     buildrefsTimeoutMs: parseInt(process.env.BUILDREFS_TIMEOUT_MS) || 12000,
     browserIdleTimeoutMs: Number.isFinite(browserIdleTimeoutMs) ? browserIdleTimeoutMs : 300000,
@@ -149,6 +158,13 @@ function loadConfig({ configPath = CONFIG_PATH } = {}) {
       CAMOFOX_TRACES_MAX_BYTES: process.env.CAMOFOX_TRACES_MAX_BYTES,
       CAMOFOX_TRACES_TTL_HOURS: process.env.CAMOFOX_TRACES_TTL_HOURS,
       CAMOFOX_DISABLE_DEFAULT_ADDONS: process.env.CAMOFOX_DISABLE_DEFAULT_ADDONS,
+      HANDLER_TIMEOUT_MS: process.env.HANDLER_TIMEOUT_MS,
+      MAX_CONCURRENT_PER_USER: process.env.MAX_CONCURRENT_PER_USER,
+      MAX_TABS_GLOBAL: process.env.MAX_TABS_GLOBAL,
+      MAX_TABS_PER_SESSION: process.env.MAX_TABS_PER_SESSION,
+      TAB_ADMISSION_MAX_ACTIVE: process.env.TAB_ADMISSION_MAX_ACTIVE,
+      TAB_ADMISSION_MAX_ACTIVE_PER_USER: process.env.TAB_ADMISSION_MAX_ACTIVE_PER_USER,
+      TAB_ADMISSION_QUEUE_LIMIT: process.env.TAB_ADMISSION_QUEUE_LIMIT,
       CAMOUFOX_EXECUTABLE: process.env.CAMOUFOX_EXECUTABLE,
       CAMOUFOX_EXECUTABLE_PATH: process.env.CAMOUFOX_EXECUTABLE_PATH,
       CAMOFOX_EXECUTABLE_PATH: process.env.CAMOFOX_EXECUTABLE_PATH,

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -22,6 +22,10 @@ function buildNoopMetrics() {
     sessionsExpiredTotal: noopCounter,
     tabsReapedTotal: noopCounter,
     tabsRecycledTotal: noopCounter,
+    tabAdmissionActiveGauge: noopGauge,
+    tabAdmissionPendingGauge: noopGauge,
+    tabAdmissionRejectedTotal: noopCounter,
+    tabAdmissionTimeoutsTotal: noopCounter,
     requestDuration: noopHistogram,
     pageLoadDuration: noopHistogram,
     snapshotBytes: noopHistogram,
@@ -79,6 +83,26 @@ async function buildRealMetrics() {
     tabsRecycledTotal: new client.Counter({
       name: 'camofox_tabs_recycled_total',
       help: 'Tabs recycled when tab limit reached',
+      registers: [_register],
+    }),
+    tabAdmissionActiveGauge: new client.Gauge({
+      name: 'camofox_tab_admission_active',
+      help: 'Current number of admitted tab creation requests',
+      registers: [_register],
+    }),
+    tabAdmissionPendingGauge: new client.Gauge({
+      name: 'camofox_tab_admission_pending',
+      help: 'Current number of queued tab creation requests',
+      registers: [_register],
+    }),
+    tabAdmissionRejectedTotal: new client.Counter({
+      name: 'camofox_tab_admission_rejected_total',
+      help: 'Rejected tab creation requests due to admission limits',
+      registers: [_register],
+    }),
+    tabAdmissionTimeoutsTotal: new client.Counter({
+      name: 'camofox_tab_admission_timeouts_total',
+      help: 'Tab creation requests that timed out while queued or executing',
       registers: [_register],
     }),
     requestDuration: new client.Histogram({

--- a/lib/new-page-recovery.js
+++ b/lib/new-page-recovery.js
@@ -10,9 +10,19 @@ export async function createPageWithSessionRecovery({
   destroySession,
   getSession,
   log,
+  reservePendingCreation = () => () => {},
 }) {
+  const createPage = (activeSession, label) => {
+    const releasePendingCreation = reservePendingCreation(activeSession);
+    const pagePromise = Promise.resolve().then(() => activeSession.context.newPage());
+    // A timeout does not necessarily settle the underlying newPage promise.
+    // Keep the reaper reservation until the real attempt resolves or rejects.
+    pagePromise.then(releasePendingCreation, releasePendingCreation);
+    return withTimeout(pagePromise, timeoutMs, label);
+  };
+
   try {
-    const page = await withTimeout(session.context.newPage(), timeoutMs, 'new page');
+    const page = await createPage(session, 'new page');
     return { session, page };
   } catch (err) {
     if (!isTimeoutError(err) && !isDeadContextError(err)) throw err;
@@ -29,7 +39,7 @@ export async function createPageWithSessionRecovery({
     }
 
     session = await getSession(userId, { trace });
-    const page = await withTimeout(session.context.newPage(), timeoutMs, 'new page retry');
+    const page = await createPage(session, 'new page retry');
     return { session, page };
   }
 }

--- a/lib/openapi.js
+++ b/lib/openapi.js
@@ -66,6 +66,15 @@ const swaggerDefinition = {
         required: ['error'],
         properties: { error: { type: 'string' } },
       },
+      TabAdmissionError: {
+        type: 'object',
+        required: ['error', 'code', 'retryAfter'],
+        properties: {
+          error: { type: 'string' },
+          code: { type: 'string', pattern: '^tab_admission_' },
+          retryAfter: { type: 'integer', minimum: 1 },
+        },
+      },
     },
   },
 };

--- a/lib/tab-admission.js
+++ b/lib/tab-admission.js
@@ -1,0 +1,274 @@
+export class TabAdmissionError extends Error {
+  constructor(message, { code, retryAfter, statusCode = 429 } = {}) {
+    super(message);
+    this.name = 'TabAdmissionError';
+    this.statusCode = statusCode;
+    this.code = code;
+    this.retryAfter = retryAfter;
+  }
+}
+
+function positiveInteger(value, fallback) {
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export class TabAdmissionController {
+  constructor({
+    maxActive,
+    maxActivePerUser,
+    maxPending,
+    waitTimeoutMs = 0,
+    operationTimeoutMs = 0,
+    retryAfterSeconds = 2,
+    onStateChange = () => {},
+    onRejected = () => {},
+    onTimeout = () => {},
+  }) {
+    this.maxActive = positiveInteger(maxActive, 1);
+    this.maxActivePerUser = positiveInteger(maxActivePerUser, 1);
+    this.maxPending = positiveInteger(maxPending, 1);
+    this.waitTimeoutMs = Number.isFinite(waitTimeoutMs) && waitTimeoutMs > 0 ? waitTimeoutMs : 0;
+    this.operationTimeoutMs = Number.isFinite(operationTimeoutMs) && operationTimeoutMs > 0 ? operationTimeoutMs : 0;
+    this.retryAfterSeconds = positiveInteger(retryAfterSeconds, 2);
+    this.onStateChange = onStateChange;
+    this.onRejected = onRejected;
+    this.onTimeout = onTimeout;
+    this.active = 0;
+    this.pending = 0;
+    this.activeByUser = new Map();
+    this.queue = [];
+  }
+
+  snapshot() {
+    return {
+      active: this.active,
+      pending: this.pending,
+      activeByUser: Object.fromEntries(this.activeByUser),
+    };
+  }
+
+  run(userKey, operation) {
+    const key = String(userKey);
+    const canStartNow = this.#canStart(key);
+    if (!canStartNow && this.pending >= this.maxPending) {
+      this.onRejected();
+      return Promise.reject(new TabAdmissionError('Tab admission queue is full', {
+        code: 'tab_admission_queue_full',
+        retryAfter: this.retryAfterSeconds,
+      }));
+    }
+
+    return new Promise((resolve, reject) => {
+      const entry = {
+        key,
+        operation,
+        resolve,
+        reject,
+        queued: true,
+        responded: false,
+        waitTimer: null,
+      };
+      this.queue.push(entry);
+      this.pending += 1;
+
+      if (this.waitTimeoutMs > 0) {
+        entry.waitTimer = setTimeout(() => this.#expireQueued(entry), this.waitTimeoutMs);
+      }
+
+      this.#stateChanged();
+      this.#pump();
+    });
+  }
+
+  #canStart(key) {
+    return this.active < this.maxActive && (this.activeByUser.get(key) || 0) < this.maxActivePerUser;
+  }
+
+  #expireQueued(entry) {
+    if (!entry.queued) return;
+    const index = this.queue.indexOf(entry);
+    if (index < 0) return;
+    this.queue.splice(index, 1);
+    entry.queued = false;
+    this.pending -= 1;
+    this.onTimeout('wait');
+    this.#stateChanged();
+    entry.responded = true;
+    entry.reject(new TabAdmissionError('Tab admission wait timed out', {
+      code: 'tab_admission_wait_timeout',
+      retryAfter: this.retryAfterSeconds,
+    }));
+    this.#pump();
+  }
+
+  #pump() {
+    while (this.active < this.maxActive) {
+      const index = this.queue.findIndex((entry) => this.#canStart(entry.key));
+      if (index < 0) return;
+      const [entry] = this.queue.splice(index, 1);
+      this.#start(entry);
+    }
+  }
+
+  #start(entry) {
+    entry.queued = false;
+    clearTimeout(entry.waitTimer);
+    this.pending -= 1;
+    this.active += 1;
+    this.activeByUser.set(entry.key, (this.activeByUser.get(entry.key) || 0) + 1);
+    this.#stateChanged();
+
+    const abortController = new AbortController();
+    let operationTimer = null;
+    if (this.operationTimeoutMs > 0) {
+      operationTimer = setTimeout(() => {
+        if (entry.responded) return;
+        const error = new TabAdmissionError('Tab creation timed out', {
+          code: 'tab_admission_operation_timeout',
+          retryAfter: this.retryAfterSeconds,
+        });
+        entry.responded = true;
+        this.onTimeout('operation');
+        abortController.abort(error);
+        entry.reject(error);
+      }, this.operationTimeoutMs);
+    }
+
+    Promise.resolve()
+      .then(() => entry.operation(abortController.signal))
+      .then(
+        (value) => {
+          if (entry.responded) return;
+          entry.responded = true;
+          entry.resolve(value);
+        },
+        (error) => {
+          if (entry.responded) return;
+          entry.responded = true;
+          entry.reject(error);
+        },
+      )
+      .finally(() => {
+        clearTimeout(operationTimer);
+        this.active -= 1;
+        const remaining = (this.activeByUser.get(entry.key) || 1) - 1;
+        if (remaining > 0) this.activeByUser.set(entry.key, remaining);
+        else this.activeByUser.delete(entry.key);
+        this.#stateChanged();
+        this.#pump();
+      });
+  }
+
+  #stateChanged() {
+    this.onStateChange(this.snapshot());
+  }
+}
+
+export class TabCapacityReservations {
+  constructor({
+    maxGlobal,
+    maxPerUser,
+    getGlobalCount,
+    getUserCount,
+    retryAfterSeconds = 2,
+    onRejected = () => {},
+  }) {
+    this.maxGlobal = positiveInteger(maxGlobal, 1);
+    this.maxPerUser = positiveInteger(maxPerUser, 1);
+    this.getGlobalCount = getGlobalCount;
+    this.getUserCount = getUserCount;
+    this.retryAfterSeconds = positiveInteger(retryAfterSeconds, 2);
+    this.onRejected = onRejected;
+    this.reservedGlobal = 0;
+    this.reservedByUser = new Map();
+  }
+
+  reserve(userKey) {
+    const key = String(userKey);
+    const userReserved = this.reservedByUser.get(key) || 0;
+    if (this.getUserCount(key) + userReserved >= this.maxPerUser) {
+      this.onRejected();
+      throw new TabAdmissionError('Maximum tabs per user reached', {
+        code: 'tab_admission_user_limit',
+        retryAfter: this.retryAfterSeconds,
+      });
+    }
+    if (this.getGlobalCount() + this.reservedGlobal >= this.maxGlobal) {
+      this.onRejected();
+      throw new TabAdmissionError('Maximum global tabs reached', {
+        code: 'tab_admission_global_limit',
+        retryAfter: this.retryAfterSeconds,
+      });
+    }
+
+    this.reservedGlobal += 1;
+    this.reservedByUser.set(key, userReserved + 1);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.reservedGlobal -= 1;
+      const remaining = (this.reservedByUser.get(key) || 1) - 1;
+      if (remaining > 0) this.reservedByUser.set(key, remaining);
+      else this.reservedByUser.delete(key);
+    };
+  }
+}
+
+export function sendTabAdmissionError(response, error, safeMessage = error?.message) {
+  if (error?.statusCode !== 429 || !error?.code?.startsWith('tab_admission_')) return false;
+  response.set('Retry-After', String(error.retryAfter));
+  response.status(429).json({
+    error: safeMessage,
+    code: error.code,
+    retryAfter: error.retryAfter,
+  });
+  return true;
+}
+
+export async function awaitAbortableResource(resourcePromise, signal, cleanup) {
+  const resource = await resourcePromise;
+  if (!signal?.aborted) return resource;
+  await cleanup(resource);
+  throw signal.reason instanceof Error ? signal.reason : new Error('Operation aborted');
+}
+
+export async function withAbortableResource({
+  create,
+  signal,
+  register,
+  unregister,
+  cleanup,
+  operation,
+}) {
+  let resource;
+  let registered = false;
+  let cleanupPromise = null;
+  const abortError = () => signal?.reason instanceof Error ? signal.reason : new Error('Operation aborted');
+  const cleanupOnce = () => {
+    if (!resource) return Promise.resolve();
+    if (!cleanupPromise) cleanupPromise = Promise.resolve(cleanup(resource));
+    return cleanupPromise;
+  };
+  const onAbort = () => { cleanupOnce().catch(() => {}); };
+
+  try {
+    resource = await awaitAbortableResource(Promise.resolve().then(create), signal, cleanup);
+    registered = true;
+    await register(resource);
+    if (signal?.aborted) throw abortError();
+    signal?.addEventListener('abort', onAbort, { once: true });
+    const result = await operation(resource);
+    if (signal?.aborted) throw abortError();
+    return result;
+  } catch (error) {
+    try {
+      if (registered) await unregister(resource);
+    } finally {
+      await cleanupOnce();
+    }
+    throw error;
+  } finally {
+    signal?.removeEventListener('abort', onAbort);
+  }
+}

--- a/lib/tab-admission.js
+++ b/lib/tab-admission.js
@@ -215,6 +215,20 @@ export class TabCapacityReservations {
   }
 }
 
+export function reservePendingTabCreation(session) {
+  session._pendingTabCreations = (session._pendingTabCreations || 0) + 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    session._pendingTabCreations = Math.max(0, (session._pendingTabCreations || 1) - 1);
+  };
+}
+
+export function canReapEmptySession(session) {
+  return session.tabGroups.size === 0 && (session._pendingTabCreations || 0) === 0;
+}
+
 export function sendTabAdmissionError(response, error, safeMessage = error?.message) {
   if (error?.statusCode !== 429 || !error?.code?.startsWith('tab_admission_')) return false;
   response.set('Retry-After', String(error.retryAfter));

--- a/openapi.json
+++ b/openapi.json
@@ -78,6 +78,27 @@
             "type": "string"
           }
         }
+      },
+      "TabAdmissionError": {
+        "type": "object",
+        "required": [
+          "error",
+          "code",
+          "retryAfter"
+        ],
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string",
+            "pattern": "^tab_admission_"
+          },
+          "retryAfter": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
       }
     }
   },
@@ -483,11 +504,19 @@
             }
           },
           "429": {
-            "description": "Tab limit reached.",
+            "description": "Tab admission queue or capacity limit reached.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/TabAdmissionError"
                 }
               }
             }

--- a/server.js
+++ b/server.js
@@ -918,8 +918,17 @@ async function _closeBrowserFullyImpl(reason) {
     }
   } catch { /* best effort */ }
 
-  // Reset native memory baseline so next browser measures from fresh
-  reporter.resetNativeMemBaseline();
+  // Reset native memory baseline so next browser measures from fresh.
+  // Guard this call because older/stale reporter objects from partial deploys
+  // have caused idle-shutdown restart failures here.
+  if (typeof reporter.resetNativeMemBaseline === 'function') {
+    reporter.resetNativeMemBaseline();
+  } else {
+    log('warn', 'reporter.resetNativeMemBaseline unavailable; continuing browser close', {
+      reason,
+      reporterKeys: reporter && typeof reporter === 'object' ? Object.keys(reporter).sort() : [],
+    });
+  }
   _nativeMemBaseline = null;
 
   // Verify cleanup: check FD/handle counts dropped (after force-kill completes)

--- a/server.js
+++ b/server.js
@@ -1379,7 +1379,7 @@ async function getSession(userId, { trace = false } = {}) {
   return session;
 }
 
-async function createPageWithRecoveryForUser(userId, session, { trace = false } = {}) {
+async function createPageWithRecoveryForUser(userId, session, { trace = false, reservePendingCreation } = {}) {
   const key = normalizeUserId(userId);
   return createPageWithSessionRecovery({
     userId: key,
@@ -1393,6 +1393,7 @@ async function createPageWithRecoveryForUser(userId, session, { trace = false } 
     destroySession,
     getSession,
     log,
+    reservePendingCreation,
   });
 }
 
@@ -2822,14 +2823,15 @@ app.post('/tabs', async (req, res) => {
           let effectiveSession = initialSession;
           let group;
           let tabState;
-          const releasePendingCreation = reservePendingTabCreation(effectiveSession);
-          try {
-            return await withAbortableResource({
-              create: async () => {
-                const createdPage = await createPageWithRecoveryForUser(userId, effectiveSession, { trace: !!trace });
-                effectiveSession = createdPage.session;
-                return createdPage.page;
-              },
+          return withAbortableResource({
+            create: async () => {
+              const createdPage = await createPageWithRecoveryForUser(userId, effectiveSession, {
+                trace: !!trace,
+                reservePendingCreation: reservePendingTabCreation,
+              });
+              effectiveSession = createdPage.session;
+              return createdPage.page;
+            },
             signal,
             register: async (page) => {
               group = getTabGroup(effectiveSession, resolvedSessionKey);
@@ -2857,10 +2859,7 @@ app.post('/tabs', async (req, res) => {
               log('info', 'tab created', { reqId: req.reqId, tabId, userId, sessionKey: resolvedSessionKey, url: page.url() });
               return { tabId, url: page.url() };
             },
-            });
-          } finally {
-            releasePendingCreation();
-          }
+          });
         };
 
         try {

--- a/server.js
+++ b/server.js
@@ -49,6 +49,8 @@ import {
 import {
   TabAdmissionController,
   TabCapacityReservations,
+  canReapEmptySession,
+  reservePendingTabCreation,
   sendTabAdmissionError,
   withAbortableResource,
 } from './lib/tab-admission.js';
@@ -1354,7 +1356,14 @@ async function getSession(userId, { trace = false } = {}) {
         }
       }
 
-      const created = { context, tabGroups: new Map(), lastAccess: Date.now(), proxySessionId: sessionProxy?.sessionId || null, tracePath };
+      const created = {
+        context,
+        tabGroups: new Map(),
+        lastAccess: Date.now(),
+        proxySessionId: sessionProxy?.sessionId || null,
+        tracePath,
+        _pendingTabCreations: 0,
+      };
       sessions.set(key, created);
       await pluginEvents.emitAsync('session:created', { userId: key, context });
       log('info', 'session created', {
@@ -2813,12 +2822,14 @@ app.post('/tabs', async (req, res) => {
           let effectiveSession = initialSession;
           let group;
           let tabState;
-          return withAbortableResource({
-            create: async () => {
-              const createdPage = await createPageWithRecoveryForUser(userId, effectiveSession, { trace: !!trace });
-              effectiveSession = createdPage.session;
-              return createdPage.page;
-            },
+          const releasePendingCreation = reservePendingTabCreation(effectiveSession);
+          try {
+            return await withAbortableResource({
+              create: async () => {
+                const createdPage = await createPageWithRecoveryForUser(userId, effectiveSession, { trace: !!trace });
+                effectiveSession = createdPage.session;
+                return createdPage.page;
+              },
             signal,
             register: async (page) => {
               group = getTabGroup(effectiveSession, resolvedSessionKey);
@@ -2846,7 +2857,10 @@ app.post('/tabs', async (req, res) => {
               log('info', 'tab created', { reqId: req.reqId, tabId, userId, sessionKey: resolvedSessionKey, url: page.url() });
               return { tabId, url: page.url() };
             },
-          });
+            });
+          } finally {
+            releasePendingCreation();
+          }
         };
 
         try {
@@ -5308,8 +5322,10 @@ setInterval(() => {
         session.tabGroups.delete(listItemId);
       }
     }
-    // Clean up sessions with zero tabs remaining -- free browser context memory
-    if (session.tabGroups.size === 0) {
+    // Clean up sessions with zero tabs remaining -- free browser context memory.
+    // A session may be temporarily empty while newPage() is still resolving;
+    // never let the reaper close its context during that creation window.
+    if (canReapEmptySession(session)) {
       session._closing = true;
       log('info', 'session empty after tab reaper, closing', { userId });
       closeSession(userId, session, { reason: 'tab_reaper_empty_session', clearDownloads: true, clearLocks: true }).catch(() => {});

--- a/server.js
+++ b/server.js
@@ -46,6 +46,12 @@ import {
   isTabLockQueueTimeout, isTabDestroyedError,
   browserErrorStatus, browserErrorCode, browserErrorRecovery, isRetryableBrowserError,
 } from './lib/browser-errors.js';
+import {
+  TabAdmissionController,
+  TabCapacityReservations,
+  sendTabAdmissionError,
+  withAbortableResource,
+} from './lib/tab-admission.js';
 
 const CONFIG = loadConfig();
 
@@ -94,10 +100,11 @@ const authMiddleware = () => requireAuth(CONFIG);
 
 const {
   requestsTotal, requestDuration, pageLoadDuration, snapshotBytes,
-  activeTabsGauge, tabLockQueueDepth,
+  activeTabsGauge, tabLockQueueDepth, tabAdmissionActiveGauge, tabAdmissionPendingGauge,
   tabLockTimeoutsTotal,
   failuresTotal, browserRestartsTotal, tabsDestroyedTotal,
   sessionsExpiredTotal, tabsReapedTotal, tabsRecycledTotal,
+  tabAdmissionRejectedTotal, tabAdmissionTimeoutsTotal,
 } = await initMetrics({ enabled: CONFIG.prometheusEnabled });
 
 // --- Structured logging ---
@@ -486,6 +493,9 @@ const MAX_TABS_GLOBAL = CONFIG.maxTabsGlobal;
 const HANDLER_TIMEOUT_MS = CONFIG.handlerTimeoutMs;
 const NEW_PAGE_TIMEOUT_MS = CONFIG.newPageTimeoutMs;
 const MAX_CONCURRENT_PER_USER = CONFIG.maxConcurrentPerUser;
+const TAB_ADMISSION_MAX_ACTIVE = CONFIG.tabAdmissionMaxActive;
+const TAB_ADMISSION_MAX_ACTIVE_PER_USER = CONFIG.tabAdmissionMaxActivePerUser;
+const TAB_ADMISSION_QUEUE_LIMIT = CONFIG.tabAdmissionQueueLimit;
 const PAGE_CLOSE_TIMEOUT_MS = 5000;
 const NAVIGATE_TIMEOUT_MS = CONFIG.navigateTimeoutMs;
 const BUILDREFS_TIMEOUT_MS = CONFIG.buildrefsTimeoutMs;
@@ -652,6 +662,42 @@ if (proxyPool) {
 } else {
   log('info', 'no proxy configured');
 }
+
+const tabAdmission = new TabAdmissionController({
+  maxActive: TAB_ADMISSION_MAX_ACTIVE,
+  maxActivePerUser: TAB_ADMISSION_MAX_ACTIVE_PER_USER,
+  maxPending: TAB_ADMISSION_QUEUE_LIMIT,
+  waitTimeoutMs: requestTimeoutMs(),
+  operationTimeoutMs: requestTimeoutMs(),
+  retryAfterSeconds: 2,
+  onStateChange: ({ active, pending }) => {
+    tabAdmissionActiveGauge.set(active);
+    tabAdmissionPendingGauge.set(pending);
+  },
+  onRejected: () => tabAdmissionRejectedTotal.inc(),
+  onTimeout: () => tabAdmissionTimeoutsTotal.inc(),
+});
+
+async function withTabAdmission(userId, operation) {
+  return tabAdmission.run(normalizeUserId(userId), operation);
+}
+
+function getUserTabCount(userKey) {
+  const session = sessions.get(userKey);
+  if (!session) return 0;
+  let total = 0;
+  for (const group of session.tabGroups.values()) total += group.size;
+  return total;
+}
+
+const tabCapacity = new TabCapacityReservations({
+  maxGlobal: MAX_TABS_GLOBAL,
+  maxPerUser: MAX_TABS_PER_SESSION,
+  getGlobalCount: getTotalTabCount,
+  getUserCount: getUserTabCount,
+  retryAfterSeconds: 2,
+  onRejected: () => tabAdmissionRejectedTotal.inc(),
+});
 
 const BROWSER_IDLE_TIMEOUT_MS = CONFIG.browserIdleTimeoutMs;
 let browserIdleTimer = null;
@@ -2696,11 +2742,16 @@ app.post('/pressure/cleanup', async (req, res) => {
  *             schema:
  *               $ref: '#/components/schemas/Error'
  *       429:
- *         description: Tab limit reached.
+ *         description: Tab admission queue or capacity limit reached.
+ *         headers:
+ *           Retry-After:
+ *             description: Seconds to wait before retrying.
+ *             schema:
+ *               type: integer
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/Error'
+ *               $ref: '#/components/schemas/TabAdmissionError'
  *       409:
  *         description: Cannot enable tracing on an existing session.
  *         content:
@@ -2733,7 +2784,7 @@ app.post('/tabs', async (req, res) => {
       }
     }
 
-    const result = await withTimeout((async () => {
+    const result = await withTabAdmission(userId, async (signal) => {
       const existing = sessions.get(normalizeUserId(userId));
       if (trace && existing && !existing.tracePath) {
         throw Object.assign(
@@ -2742,68 +2793,82 @@ app.post('/tabs', async (req, res) => {
         );
       }
       let session = await getSession(userId, { trace: !!trace });
-      
+
       let totalTabs = 0;
       for (const group of session.tabGroups.values()) totalTabs += group.size;
-      
-      // Recycle oldest tab when limits are reached instead of rejecting
+
+      // Preserve current recycling behavior while reserving the slot so
+      // concurrent creations cannot oversubscribe the configured limits.
       if (totalTabs >= MAX_TABS_PER_SESSION || getTotalTabCount() >= MAX_TABS_GLOBAL) {
         const recycled = await recycleOldestTab(session, req.reqId, userId);
         if (!recycled) {
           throw Object.assign(new Error('Maximum tabs per session reached'), { statusCode: 429 });
         }
       }
-      
-      const createdPage = await createPageWithRecoveryForUser(userId, session, { trace: !!trace });
-      session = createdPage.session;
-      const page = createdPage.page;
-      const group = getTabGroup(session, resolvedSessionKey);
 
-      const tabId = fly.makeTabId();
-      let tabState = createTabState(page);
-      attachDownloadListener(tabState, tabId, log, pluginEvents, userId);
-      group.set(tabId, tabState);
-      attachPopupHandler(page, userId, resolvedSessionKey);
-      refreshActiveTabsGauge();
-      
-      if (url) {
-        const urlErr = validateUrl(url);
-        if (urlErr) throw Object.assign(new Error(urlErr), { statusCode: 400 });
-        tabState.lastRequestedUrl = url;
+      const releaseCapacity = tabCapacity.reserve(normalizeUserId(userId));
+      try {
+        const tabId = fly.makeTabId();
+        const createAttempt = async (initialSession) => {
+          let effectiveSession = initialSession;
+          let group;
+          let tabState;
+          return withAbortableResource({
+            create: async () => {
+              const createdPage = await createPageWithRecoveryForUser(userId, effectiveSession, { trace: !!trace });
+              effectiveSession = createdPage.session;
+              return createdPage.page;
+            },
+            signal,
+            register: async (page) => {
+              group = getTabGroup(effectiveSession, resolvedSessionKey);
+              tabState = createTabState(page);
+              attachDownloadListener(tabState, tabId, log, pluginEvents, userId);
+              group.set(tabId, tabState);
+              attachPopupHandler(page, userId, resolvedSessionKey);
+              refreshActiveTabsGauge();
+            },
+            unregister: async () => {
+              if (group?.get(tabId) === tabState) group.delete(tabId);
+              if (group?.size === 0) effectiveSession.tabGroups.delete(resolvedSessionKey);
+              refreshActiveTabsGauge();
+            },
+            cleanup: safePageClose,
+            operation: async (page) => {
+              if (url) {
+                const urlErr = validateUrl(url);
+                if (urlErr) throw Object.assign(new Error(urlErr), { statusCode: 400 });
+                tabState.lastRequestedUrl = url;
+                await withPageLoadDuration('open_url', () => page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 }));
+                tabState.visitedUrls.add(url);
+              }
+              pluginEvents.emit('tab:created', { userId, tabId, page, url: page.url() });
+              log('info', 'tab created', { reqId: req.reqId, tabId, userId, sessionKey: resolvedSessionKey, url: page.url() });
+              return { tabId, url: page.url() };
+            },
+          });
+        };
+
         try {
-          await withPageLoadDuration('open_url', () => page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 }));
+          return await createAttempt(session);
         } catch (navErr) {
-          if ((isProxyError(navErr) || isTimeoutError(navErr)) && proxyPool?.canRotateSessions) {
-            log('warn', 'tab create navigate failed, retrying with fresh proxy', {
-              reqId: req.reqId, tabId, error: navErr.message,
-            });
-            browserRestartsTotal.labels('proxy_retry').inc();
-            const key = normalizeUserId(userId);
-            const oldSession = sessions.get(key);
-            if (oldSession) {
-              await closeSession(key, oldSession, { reason: 'proxy_retry_rotate', clearDownloads: true, clearLocks: true });
-            }
-            session = await getSession(userId, { trace: !!trace });
-            const retryGroup = getTabGroup(session, resolvedSessionKey);
-            const retryPage = await session.context.newPage();
-            tabState = createTabState(retryPage);
-            tabState.lastRequestedUrl = url;
-            attachDownloadListener(tabState, tabId, log, pluginEvents, userId);
-            retryGroup.set(tabId, tabState);
-            attachPopupHandler(retryPage, userId, resolvedSessionKey);
-            refreshActiveTabsGauge();
-            await withPageLoadDuration('open_url', () => retryPage.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 }));
-          } else {
-            throw navErr;
+          if (!(url && (isProxyError(navErr) || isTimeoutError(navErr)) && proxyPool?.canRotateSessions)) throw navErr;
+          log('warn', 'tab create navigate failed, retrying with fresh proxy', {
+            reqId: req.reqId, tabId, error: navErr.message,
+          });
+          browserRestartsTotal.labels('proxy_retry').inc();
+          const key = normalizeUserId(userId);
+          const oldSession = sessions.get(key);
+          if (oldSession) {
+            await closeSession(key, oldSession, { reason: 'proxy_retry_rotate', clearDownloads: true, clearLocks: true });
           }
+          session = await getSession(userId, { trace: !!trace });
+          return createAttempt(session);
         }
-        tabState.visitedUrls.add(url);
+      } finally {
+        releaseCapacity();
       }
-      
-      pluginEvents.emit('tab:created', { userId, tabId, page, url: page.url() });
-      log('info', 'tab created', { reqId: req.reqId, tabId, userId, sessionKey: resolvedSessionKey, url: page.url() });
-      return { tabId, url: page.url() };
-    })(), requestTimeoutMs(), 'tab create');
+    });
 
     res.json(result);
   } catch (err) {
@@ -2821,7 +2886,9 @@ app.post('/tabs', async (req, res) => {
         recoverable: false,
       });
     }
-    // Memory pressure / max sessions → bounce through LB to another machine
+    // Admission overflow/timeouts are explicitly retryable and machine-readable.
+    if (sendTabAdmissionError(res, err, safeError(err))) return;
+    // Memory pressure / max sessions → bounce through LB to another machine.
     if (FLY_MACHINE_ID && err.statusCode === 503) {
       res.set('fly-replay', `app=${CONFIG.flyAppName || 'camofox-browser'}`);
       return res.status(503).json({ error: safeError(err), code: err.code || 'admission_rejected' });

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -63,6 +63,55 @@ describe('loadConfig', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  test('rejects zero, negative, and malformed admission limits safely', () => {
+    process.env.HANDLER_TIMEOUT_MS = '0';
+    process.env.MAX_CONCURRENT_PER_USER = '3oops';
+    process.env.MAX_TABS_GLOBAL = '0';
+    process.env.MAX_TABS_PER_SESSION = '-5';
+    process.env.TAB_ADMISSION_MAX_ACTIVE = '0';
+    process.env.TAB_ADMISSION_MAX_ACTIVE_PER_USER = '-2';
+    process.env.TAB_ADMISSION_QUEUE_LIMIT = 'NaN';
+
+    const config = loadConfig();
+
+    expect(config.handlerTimeoutMs).toBe(30000);
+    expect(config.maxConcurrentPerUser).toBe(3);
+    expect(config.maxTabsGlobal).toBe(50);
+    expect(config.maxTabsPerSession).toBe(10);
+    expect(config.tabAdmissionMaxActive).toBe(4);
+    expect(config.tabAdmissionMaxActivePerUser).toBe(2);
+    expect(config.tabAdmissionQueueLimit).toBe(8);
+  });
+
+  test('accepts positive admission-control values', () => {
+    process.env.HANDLER_TIMEOUT_MS = '1500';
+    process.env.MAX_CONCURRENT_PER_USER = '4';
+    process.env.MAX_TABS_GLOBAL = '12';
+    process.env.MAX_TABS_PER_SESSION = '8';
+    process.env.TAB_ADMISSION_MAX_ACTIVE = '6';
+    process.env.TAB_ADMISSION_MAX_ACTIVE_PER_USER = '3';
+    process.env.TAB_ADMISSION_QUEUE_LIMIT = '5';
+
+    const config = loadConfig();
+
+    expect(config.handlerTimeoutMs).toBe(1500);
+    expect(config.maxConcurrentPerUser).toBe(4);
+    expect(config.maxTabsGlobal).toBe(12);
+    expect(config.maxTabsPerSession).toBe(8);
+    expect(config.tabAdmissionMaxActive).toBe(6);
+    expect(config.tabAdmissionMaxActivePerUser).toBe(3);
+    expect(config.tabAdmissionQueueLimit).toBe(5);
+    expect(config.serverEnv).toMatchObject({
+      HANDLER_TIMEOUT_MS: '1500',
+      MAX_CONCURRENT_PER_USER: '4',
+      MAX_TABS_GLOBAL: '12',
+      MAX_TABS_PER_SESSION: '8',
+      TAB_ADMISSION_MAX_ACTIVE: '6',
+      TAB_ADMISSION_MAX_ACTIVE_PER_USER: '3',
+      TAB_ADMISSION_QUEUE_LIMIT: '5',
+    });
+  });
+
   test('disables default addons when CAMOFOX_DISABLE_DEFAULT_ADDONS is set', () => {
     delete process.env.CAMOFOX_DISABLE_DEFAULT_ADDONS;
     expect(loadConfig().disableDefaultAddons).toBe(false);
@@ -78,5 +127,4 @@ describe('loadConfig', () => {
     expect(config.disableDefaultAddons).toBe(true);
     expect(config.serverEnv.CAMOFOX_DISABLE_DEFAULT_ADDONS).toBe('true');
   });
-
 });

--- a/tests/unit/newPageRecovery.test.js
+++ b/tests/unit/newPageRecovery.test.js
@@ -73,6 +73,33 @@ describe('createPageWithSessionRecovery', () => {
     expect(replacement.context.newPage).toHaveBeenCalledTimes(1);
   });
 
+  test('reserves each session while its new-page attempt is pending', async () => {
+    const timeoutError = Object.assign(new Error('new page timed out'), { code: 'timeout' });
+    const oldSession = { id: 'old', context: { newPage: jest.fn().mockRejectedValue(timeoutError) } };
+    const page = { id: 'fresh-page' };
+    const replacement = { id: 'replacement', context: { newPage: jest.fn().mockResolvedValue(page) } };
+    const releases = [];
+    const reservePendingCreation = jest.fn(() => {
+      const release = jest.fn();
+      releases.push(release);
+      return release;
+    });
+
+    const result = await createPageWithSessionRecovery(recoveryOptions({
+      session: oldSession,
+      currentSession: () => oldSession,
+      destroySession: async () => {},
+      getSession: async () => replacement,
+      reservePendingCreation,
+    }));
+
+    expect(result).toEqual({ session: replacement, page });
+    expect(reservePendingCreation.mock.calls.map(([session]) => session.id)).toEqual(['old', 'replacement']);
+    expect(releases).toHaveLength(2);
+    expect(releases[0]).toHaveBeenCalledTimes(1);
+    expect(releases[1]).toHaveBeenCalledTimes(1);
+  });
+
   test('does not recover unrelated failures', async () => {
     const error = new Error('programming error');
     const session = { context: { newPage: jest.fn().mockRejectedValue(error) } };

--- a/tests/unit/tabAdmission.test.js
+++ b/tests/unit/tabAdmission.test.js
@@ -3,6 +3,8 @@ import {
   TabAdmissionController,
   TabCapacityReservations,
   awaitAbortableResource,
+  canReapEmptySession,
+  reservePendingTabCreation,
   sendTabAdmissionError,
   withAbortableResource,
 } from '../../lib/tab-admission.js';
@@ -200,6 +202,30 @@ describe('TabCapacityReservations', () => {
 
     release();
     expect(() => capacity.reserve('u2')).not.toThrow();
+  });
+});
+
+describe('pending tab creation and empty-session reaping', () => {
+  test('blocks empty-session reaping until every pending creation settles', () => {
+    const session = { tabGroups: new Map() };
+    expect(canReapEmptySession(session)).toBe(true);
+
+    const releaseFirst = reservePendingTabCreation(session);
+    const releaseSecond = reservePendingTabCreation(session);
+    expect(canReapEmptySession(session)).toBe(false);
+
+    releaseFirst();
+    releaseFirst();
+    expect(canReapEmptySession(session)).toBe(false);
+
+    releaseSecond();
+    expect(canReapEmptySession(session)).toBe(true);
+    expect(session._pendingTabCreations).toBe(0);
+  });
+
+  test('never reaps a session that already contains a tab group', () => {
+    const session = { tabGroups: new Map([['group', new Map()]]) };
+    expect(canReapEmptySession(session)).toBe(false);
   });
 });
 

--- a/tests/unit/tabAdmission.test.js
+++ b/tests/unit/tabAdmission.test.js
@@ -1,0 +1,273 @@
+import { jest } from '@jest/globals';
+import {
+  TabAdmissionController,
+  TabCapacityReservations,
+  awaitAbortableResource,
+  sendTabAdmissionError,
+  withAbortableResource,
+} from '../../lib/tab-admission.js';
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('TabAdmissionController', () => {
+  test('enforces the global active limit and starts queued work after release', async () => {
+    const controller = new TabAdmissionController({ maxActive: 2, maxActivePerUser: 2, maxPending: 4 });
+    const gates = [deferred(), deferred(), deferred()];
+    const started = [];
+
+    const runs = gates.map((gate, index) => controller.run(`user-${index}`, async () => {
+      started.push(index);
+      return gate.promise;
+    }));
+    await flush();
+
+    expect(started).toEqual([0, 1]);
+    expect(controller.snapshot()).toMatchObject({ active: 2, pending: 1 });
+
+    gates[0].resolve('first');
+    await expect(runs[0]).resolves.toBe('first');
+    await flush();
+    expect(started).toEqual([0, 1, 2]);
+
+    gates[1].resolve('second');
+    gates[2].resolve('third');
+    await expect(Promise.all(runs.slice(1))).resolves.toEqual(['second', 'third']);
+    expect(controller.snapshot()).toMatchObject({ active: 0, pending: 0 });
+  });
+
+  test('enforces per-user active limit without head-of-line blocking another user', async () => {
+    const controller = new TabAdmissionController({ maxActive: 2, maxActivePerUser: 1, maxPending: 4 });
+    const first = deferred();
+    const second = deferred();
+    const other = deferred();
+    const started = [];
+
+    const run1 = controller.run('same-user', async () => { started.push('same-1'); return first.promise; });
+    const run2 = controller.run('same-user', async () => { started.push('same-2'); return second.promise; });
+    const run3 = controller.run('other-user', async () => { started.push('other'); return other.promise; });
+    await flush();
+
+    expect(started).toEqual(['same-1', 'other']);
+    first.resolve('one');
+    await expect(run1).resolves.toBe('one');
+    await flush();
+    expect(started).toEqual(['same-1', 'other', 'same-2']);
+
+    second.resolve('two');
+    other.resolve('other');
+    await expect(Promise.all([run2, run3])).resolves.toEqual(['two', 'other']);
+  });
+
+  test('bounds the pending queue and rejects overflow with 429 retry metadata', async () => {
+    const controller = new TabAdmissionController({
+      maxActive: 1,
+      maxActivePerUser: 1,
+      maxPending: 2,
+      retryAfterSeconds: 7,
+    });
+    const active = deferred();
+    const queued1 = deferred();
+    const queued2 = deferred();
+
+    const run1 = controller.run('u1', () => active.promise);
+    const run2 = controller.run('u2', () => queued1.promise);
+    const run3 = controller.run('u3', () => queued2.promise);
+    await flush();
+
+    await expect(controller.run('u4', async () => 'never')).rejects.toMatchObject({
+      statusCode: 429,
+      code: 'tab_admission_queue_full',
+      retryAfter: 7,
+    });
+
+    active.resolve('active');
+    await run1;
+    queued1.resolve('q1');
+    await run2;
+    queued2.resolve('q2');
+    await run3;
+  });
+
+  test.each([
+    ['success', async () => 'ok'],
+    ['error', async () => { throw new Error('boom'); }],
+  ])('releases capacity after operation %s', async (_label, operation) => {
+    const controller = new TabAdmissionController({ maxActive: 1, maxActivePerUser: 1, maxPending: 1 });
+    const first = controller.run('u1', operation);
+    const second = controller.run('u2', async () => 'next');
+
+    if (_label === 'success') await expect(first).resolves.toBe('ok');
+    else await expect(first).rejects.toThrow('boom');
+    await expect(second).resolves.toBe('next');
+    expect(controller.snapshot()).toMatchObject({ active: 0, pending: 0 });
+  });
+
+  test('times out active work, aborts it, and releases only after late settlement', async () => {
+    jest.useFakeTimers();
+    try {
+      const controller = new TabAdmissionController({
+        maxActive: 1,
+        maxActivePerUser: 1,
+        maxPending: 1,
+        operationTimeoutMs: 100,
+      });
+      const late = deferred();
+      let signal;
+      const first = controller.run('u1', async (operationSignal) => {
+        signal = operationSignal;
+        return late.promise;
+      });
+      const firstRejection = expect(first).rejects.toMatchObject({ code: 'tab_admission_operation_timeout' });
+      const second = controller.run('u2', async () => 'next');
+      await flush();
+
+      await jest.advanceTimersByTimeAsync(100);
+      await firstRejection;
+      expect(signal.aborted).toBe(true);
+      expect(controller.snapshot()).toMatchObject({ active: 1, pending: 1 });
+
+      late.resolve('ignored');
+      await flush();
+      await expect(second).resolves.toBe('next');
+      expect(controller.snapshot()).toMatchObject({ active: 0, pending: 0 });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('times out queued work and removes it fairly', async () => {
+    jest.useFakeTimers();
+    try {
+      const controller = new TabAdmissionController({
+        maxActive: 1,
+        maxActivePerUser: 1,
+        maxPending: 2,
+        waitTimeoutMs: 100,
+      });
+      const active = deferred();
+      const run1 = controller.run('u1', () => active.promise);
+      const queued = controller.run('u2', async () => 'never');
+      const queuedRejection = expect(queued).rejects.toMatchObject({
+        statusCode: 429,
+        code: 'tab_admission_wait_timeout',
+      });
+      await flush();
+
+      await jest.advanceTimersByTimeAsync(100);
+      await queuedRejection;
+      expect(controller.snapshot()).toMatchObject({ active: 1, pending: 0 });
+
+      active.resolve('done');
+      await expect(run1).resolves.toBe('done');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('TabCapacityReservations', () => {
+  test('atomically enforces resident global and per-user tab limits', () => {
+    let globalTabs = 1;
+    const userTabs = new Map([['u1', 1]]);
+    const capacity = new TabCapacityReservations({
+      maxGlobal: 2,
+      maxPerUser: 2,
+      getGlobalCount: () => globalTabs,
+      getUserCount: (user) => userTabs.get(user) || 0,
+      retryAfterSeconds: 3,
+    });
+
+    const release = capacity.reserve('u1');
+    expect(() => capacity.reserve('u2')).toThrow(expect.objectContaining({
+      statusCode: 429,
+      code: 'tab_admission_global_limit',
+      retryAfter: 3,
+    }));
+    expect(() => capacity.reserve('u1')).toThrow(expect.objectContaining({
+      statusCode: 429,
+      code: 'tab_admission_user_limit',
+    }));
+
+    release();
+    expect(() => capacity.reserve('u2')).not.toThrow();
+  });
+});
+
+describe('sendTabAdmissionError', () => {
+  test('writes HTTP 429 JSON and Retry-After for admission overflow', () => {
+    const response = {
+      headers: {},
+      statusCode: null,
+      body: null,
+      set(name, value) { this.headers[name] = value; return this; },
+      status(value) { this.statusCode = value; return this; },
+      json(value) { this.body = value; return this; },
+    };
+    const error = new Error('queue full');
+    Object.assign(error, {
+      statusCode: 429,
+      code: 'tab_admission_queue_full',
+      retryAfter: 5,
+    });
+
+    expect(sendTabAdmissionError(response, error, 'safe queue full')).toBe(true);
+    expect(response.headers['Retry-After']).toBe('5');
+    expect(response.statusCode).toBe(429);
+    expect(response.body).toEqual({
+      error: 'safe queue full',
+      code: 'tab_admission_queue_full',
+      retryAfter: 5,
+    });
+  });
+});
+
+describe('awaitAbortableResource', () => {
+  test('closes a resource that resolves after its operation was aborted', async () => {
+    const resource = deferred();
+    const abort = new AbortController();
+    const close = jest.fn(async () => {});
+    const result = awaitAbortableResource(resource.promise, abort.signal, close);
+
+    abort.abort(new Error('request timed out'));
+    resource.resolve({ id: 'late-page' });
+
+    await expect(result).rejects.toThrow('request timed out');
+    expect(close).toHaveBeenCalledWith({ id: 'late-page' });
+  });
+
+  test('unregisters and closes a managed resource when work is aborted', async () => {
+    const abort = new AbortController();
+    const work = deferred();
+    const registered = new Map();
+    const close = jest.fn(async () => {});
+    const resource = { id: 'tab-1' };
+
+    const result = withAbortableResource({
+      create: async () => resource,
+      signal: abort.signal,
+      register: async (value) => registered.set(value.id, value),
+      unregister: async (value) => registered.delete(value.id),
+      cleanup: close,
+      operation: async () => work.promise,
+    });
+    await new Promise(setImmediate);
+    expect(registered.has('tab-1')).toBe(true);
+
+    abort.abort(new Error('request timed out'));
+    work.reject(new Error('page closed'));
+
+    await expect(result).rejects.toThrow('page closed');
+    expect(registered.size).toBe(0);
+    expect(close).toHaveBeenCalledWith(resource);
+  });
+});


### PR DESCRIPTION
## Summary

This publishes the exact three-commit Camofox stack currently deployed and verified in production:

1. Preserve the deployed reporter compatibility behavior.
2. Add bounded tab-creation admission control.
3. Prevent the empty-session reaper from closing a session while `newPage()` is still resolving.

Admission defaults:

- global active creations: `4`
- per-user active creations: `2`
- pending queue: `8`

Queue overflow and admission timeout paths return machine-readable HTTP 429 responses with `Retry-After`. Capacity and pending-creation reservations are released on success, error, timeout, abort, and late settlement.

## Verification

- Admission/session-cleanup/config/OpenAPI: 52/52 passed.
- eBay client integration tests: 46/46 passed in its separate repository.
- Isolated Camoufox E2E with the real browser bundle: final full run 67/67 passed.
- Controlled six-create burst: one success, five bounded HTTP 429 responses, final active/pending/tabs all zero.
- Production canary after deployment: real navigation/snapshot passed; three concurrent creates passed; all four canary tabs and both canary sessions closed.
- 11-minute production soak: service active, zero restarts, zero tabs/sessions/failures, zero warning-or-higher journal entries.

## Runtime finding addressed

An isolated E2E run exposed a real race where the 60-second empty-session reaper could close a newly created session while `newPage()` was pending. The final commit adds an idempotent pending-creation reservation and tests that reaping remains blocked until every pending creation settles.

## Residual test behavior

The existing typing/click E2E can intermittently hit its 30-second click fallback timeout. Reverse-order A/B reproduced the exact same test identity and error class on both baseline and candidate. No click, typing, mouse fallback, or action-timeout code is changed here.

## Publication/rebase status

The exact reviewed production commit is preserved in the fork as `batumi/deployed-56b0a892` at `56b0a892e6f0c8b7a3d295b8be6af9af57feb5bf`.

This PR head rebases that production patch stack onto upstream `master` at `8b5b0959adfadadae38ecce9d7eed706ab102bf1`. Conflict resolution preserves newer upstream tab recycling and `createPageWithSessionRecovery` behavior. A focused TDD addition verifies that pending-creation reaper reservations follow both the original and replacement sessions during recovery. Opening this PR does not request or imply an upstream deployment.
