### PR TITLE
fix: add CAMOFOX_MAX_BODY_SIZE env var to control body parser limit

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -94,6 +94,7 @@ function loadConfig({ configPath = CONFIG_PATH } = {}) {
     adminKey: process.env.CAMOFOX_ADMIN_KEY || '',
     apiKey: process.env.CAMOFOX_API_KEY || '',
     accessKey: (process.env.CAMOFOX_ACCESS_KEY || '').trim(),
+    maxBodySize: process.env.CAMOFOX_MAX_BODY_SIZE || '100kb',
     cookiesDir: process.env.CAMOFOX_COOKIES_DIR || join(os.homedir(), '.camofox', 'cookies'),
     profileDir: process.env.CAMOFOX_PROFILE_DIR || join(os.homedir(), '.camofox', 'profiles'),
     tracesDir: process.env.CAMOFOX_TRACES_DIR || join(os.homedir(), '.camofox', 'traces'),

--- a/server.js
+++ b/server.js
@@ -117,7 +117,7 @@ function log(level, msg, fields = {}) {
 }
 
 const app = express();
-app.use(express.json({ limit: '100kb' }));
+app.use(express.json({ limit: CONFIG.maxBodySize }));
 
 // Request logging + metrics middleware
 app.use((req, res, next) => {
@@ -4569,7 +4569,7 @@ app.get('/tabs/:tabId/stats', async (req, res) => {
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-app.post('/tabs/:tabId/evaluate', express.json({ limit: '1mb' }), async (req, res) => {
+app.post('/tabs/:tabId/evaluate', express.json({ limit: CONFIG.maxBodySize }), async (req, res) => {
   try {
     const { userId, expression } = req.body;
     if (!userId) return res.status(400).json({ error: 'userId is required' });


### PR DESCRIPTION
## Problem

The `/tabs/:tabId/evaluate` endpoint has a 1MB body limit override, but it's **dead code** — the global `express.json({ limit: '100kb' })` middleware on line 120 runs first and rejects any body larger than 100KB before the evaluate-specific parser ever fires.

This makes it impossible to pass large expressions to evaluate, which is important for:
- Injecting base64-encoded binary data (e.g., file uploads via FormData + fetch)
- Passing large JSON payloads through evaluate

## Fix

Add `CAMOFOX_MAX_BODY_SIZE` env var (default: `'100kb'`) to `lib/config.js` — the centralized config module where all other env vars live. Then use `CONFIG.maxBodySize` in both places:

- `lib/config.js`: `maxBodySize: process.env.CAMOFOX_MAX_BODY_SIZE || '100kb'`
- Global parser: `express.json({ limit: CONFIG.maxBodySize })`
- Evaluate parser: `express.json({ limit: CONFIG.maxBodySize })`

The cookies endpoint (`512kb`) and extract endpoint (`256kb`) are intentionally unchanged — they have their own specific limits.

## Usage

```bash
# Default (100KB, backward compatible)
camofox-browser

# Increase to 10MB for large evaluate payloads
CAMOFOX_MAX_BODY_SIZE=10mb camofox-browser
```

Closes #8397