### PR TITLE
fix(evaluate): route errors through handleRouteError

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1845,6 +1845,26 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Page navigated while evaluating; caller should retry once the page settles.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Browser session expired; caller should retry to get a fresh session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }

--- a/server.js
+++ b/server.js
@@ -4568,6 +4568,18 @@ app.get('/tabs/:tabId/stats', async (req, res) => {
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/Error'
+ *       409:
+ *         description: Page navigated while evaluating; caller should retry once the page settles.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       503:
+ *         description: Browser session expired; caller should retry to get a fresh session.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 app.post('/tabs/:tabId/evaluate', express.json({ limit: '1mb' }), async (req, res) => {
   try {
@@ -4589,9 +4601,8 @@ app.post('/tabs/:tabId/evaluate', express.json({ limit: '1mb' }), async (req, re
     log('info', 'evaluate', { reqId: req.reqId, tabId: req.params.tabId, userId, resultType: typeof result });
     res.json({ ok: true, result });
   } catch (err) {
-    failuresTotal.labels(classifyError(err), 'evaluate').inc();
-    log('error', 'evaluate failed', { reqId: req.reqId, error: err.message });
-    res.status(500).json({ error: safeError(err) });
+    log('error', 'evaluate failed', { reqId: req.reqId, tabId: req.params.tabId, error: err.message });
+    handleRouteError(err, req, res);
   }
 });
 

--- a/tests/e2e/evaluateNavigationRace.test.js
+++ b/tests/e2e/evaluateNavigationRace.test.js
@@ -1,0 +1,55 @@
+import { createClient } from '../helpers/client.js';
+import { getSharedEnv } from './sharedEnv.js';
+
+describe('Evaluate during navigation', () => {
+  let serverUrl;
+  let testSiteUrl;
+
+  beforeAll(() => {
+    const env = getSharedEnv();
+    serverUrl = env.serverUrl;
+    testSiteUrl = env.testSiteUrl;
+  });
+
+  test('evaluate interrupted by a late redirect returns 409 navigation_race, then succeeds on retry', async () => {
+    const client = createClient(serverUrl);
+
+    try {
+      const { tabId } = await client.createTab(`${testSiteUrl}/lateRedirect`);
+
+      let raceError = null;
+      try {
+        await client.evaluate(tabId, 'new Promise(r => setTimeout(r, 5000))');
+      } catch (err) {
+        raceError = err;
+      }
+
+      expect(raceError).not.toBeNull();
+      expect(raceError.status).toBe(409);
+      expect(raceError.data.code).toBe('navigation_race');
+      expect(raceError.data.retryable).toBe(true);
+
+      await client.waitForUrl(tabId, '/pageA');
+      const retry = await client.evaluate(tabId, 'document.title');
+      expect(retry.ok).toBe(true);
+      expect(retry.result).toBe('Page A');
+    } finally {
+      await client.cleanup();
+    }
+  });
+
+  test('evaluate after the redirect settles succeeds without error', async () => {
+    const client = createClient(serverUrl);
+
+    try {
+      const { tabId } = await client.createTab(`${testSiteUrl}/lateRedirect`);
+      await client.waitForUrl(tabId, '/pageA');
+
+      const result = await client.evaluate(tabId, '1 + 1');
+      expect(result.ok).toBe(true);
+      expect(result.result).toBe(2);
+    } finally {
+      await client.cleanup();
+    }
+  });
+});

--- a/tests/helpers/client.js
+++ b/tests/helpers/client.js
@@ -99,6 +99,10 @@ class BrowserClient {
   async click(tabId, options) {
     return this.request('POST', `/tabs/${tabId}/click`, { userId: this.userId, ...options });
   }
+
+  async evaluate(tabId, expression) {
+    return this.request('POST', `/tabs/${tabId}/evaluate`, { userId: this.userId, expression });
+  }
   
   async type(tabId, options) {
     const { pressEnter, clear, ...typeOptions } = options;

--- a/tests/helpers/testSite.js
+++ b/tests/helpers/testSite.js
@@ -36,6 +36,18 @@ function createTestApp() {
     `);
   });
   
+  // Page that fires a client-side redirect shortly after DOMContentLoaded
+  app.get('/lateRedirect', (req, res) => {
+    res.send(`
+      <!DOCTYPE html>
+      <html><head><title>Late Redirect</title></head>
+      <body>
+        <h1>Redirecting soon</h1>
+        <script>setTimeout(() => { location.href = '/pageA'; }, 300);</script>
+      </body></html>
+    `);
+  });
+
   // Page with multiple links for links extraction test
   app.get('/links', (req, res) => {
     res.send(`

--- a/tests/unit/evaluateErrors.test.js
+++ b/tests/unit/evaluateErrors.test.js
@@ -1,0 +1,42 @@
+/**
+ * /tabs/:tabId/evaluate errors must flow through handleRouteError so
+ * clients get structured retryable codes instead of a bare 500.
+ */
+import { describe, test, expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import {
+  browserErrorStatus,
+  browserErrorCode,
+  browserErrorRecovery,
+  isRetryableBrowserError,
+} from '../../lib/browser-errors.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverSource = readFileSync(resolve(__dirname, '../../server.js'), 'utf8');
+
+describe('evaluate route error handling', () => {
+  test('evaluate errors are routed through handleRouteError', () => {
+    const start = serverSource.indexOf("app.post('/tabs/:tabId/evaluate'");
+    expect(start).toBeGreaterThan(-1);
+    const section = serverSource.slice(start, serverSource.indexOf('\napp.', start + 1));
+    expect(section).toContain('handleRouteError(err, req, res)');
+    expect(section).not.toContain('res.status(500)');
+  });
+
+  test('evaluate during a navigation normalizes to 409 navigation_race', () => {
+    const err = new Error('page.evaluate: Execution context was destroyed, most likely because of a navigation');
+    expect(browserErrorStatus(err)).toBe(409);
+    expect(browserErrorCode(err)).toBe('navigation_race');
+    expect(isRetryableBrowserError(err)).toBe(true);
+  });
+
+  test('evaluate on a dead target normalizes to 503 session_expired', () => {
+    const err = new Error('page.evaluate: Target page, context or browser has been closed');
+    expect(browserErrorStatus(err)).toBe(503);
+    expect(browserErrorCode(err)).toBe('session_expired');
+    expect(isRetryableBrowserError(err)).toBe(true);
+    expect(browserErrorRecovery(err)).toBe('retry');
+  });
+});


### PR DESCRIPTION
`/tabs/:tabId/evaluate` is the only tab route whose catch skips `handleRouteError` — every failure comes back as a bare 500 `{"error":"Internal server error"}`.

In production the two most common evaluate failures are:

- `Execution context was destroyed, most likely because of a navigation` — the page fires a client-side redirect right after `domcontentloaded`, so an evaluate issued straight after `POST /tabs` lands mid-navigation. ~1% of first evaluates in our workload, mostly on URN-resolver pages that redirect to the real document.
- `Target page, context or browser has been closed`

`lib/browser-errors.js` already normalizes both to structured retryable responses (409 `navigation_race`, 503 `session_expired`) — evaluate just never used it. This routes the catch through `handleRouteError`, adds `tabId` to the failure log, and documents 409/503 in the OpenAPI spec.

Tests:
- unit: evaluate error wiring + normalization of the two messages above
- e2e: new `/lateRedirect` fixture reproduces the race deterministically, asserts 409 `navigation_race` and a successful retry after the page settles. Fails on master (bare 500), passes with this patch.
