### PR TITLE
feat: add atomic session ownership and capability readback

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,26 @@ Override the directory with `CAMOFOX_PROFILE_DIR` or set `"profileDir"` in the p
 
 By default, storage state contains cookies and localStorage only. To also persist IndexedDB, set `"indexedDB": true` in the persistence plugin config. This captures all serializable IndexedDB records—not only authentication data—and may make snapshots significantly larger and checkpoints slower.
 
+### Exclusive Temporary Sessions
+
+Clients that must prove they created a previously absent session can atomically claim it while opening the first tab. Generate an opaque base64url-style owner token of 32–256 characters, send it in the initial claim body, and retain it until exact session cleanup. Never put owner tokens in query parameters; the server rejects that transport. Empty, non-scalar, `undefined`, and `null` user IDs are invalid, while IDs beginning with `__` are reserved for isolated server-internal sessions:
+
+```bash
+curl -X POST http://localhost:9377/tabs \
+  -H 'Authorization: Bearer YOUR_ACCESS_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{"userId":"unique-temporary-id","sessionKey":"task1","exclusiveSession":true,"sessionOwnerToken":"CALLER_GENERATED_OPAQUE_OWNER_TOKEN"}'
+
+curl -X DELETE http://localhost:9377/sessions/unique-temporary-id \
+  -H 'Authorization: Bearer YOUR_ACCESS_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{"sessionOwnerToken":"CALLER_GENERATED_OPAQUE_OWNER_TOKEN"}'
+```
+
+The claim fails with `409 session_ownership_conflict` if the session already exists, is being created, or is already claimed. Claimed sessions reject control requests without the matching token and are excluded from caller-triggered pressure cleanup. Send the token in the `X-Camofox-Session-Owner` header for subsequent requests; cleanup also accepts the request-body field shown above. The server stores only a SHA-256 digest of the token; abandoned claims are released only after their TTL has elapsed and the server confirms that no live session, in-flight creation, active control operation, or deletion reservation exists. Cleanup is serialized behind active control requests, blocks new requests while deletion runs, and rechecks live/in-flight state before releasing the claim. A disconnected client does not release its operation lease before the asynchronous handler completes. A browser context close error retains both the live session and claim unless the context independently proves it is already dead. Cleanup returns `409 session_creation_inflight` without releasing the claim when creation has not settled; retry after the active lifecycle operation finishes.
+
+`GET /capabilities` provides side-effect-free readback for `controlAccessKeyEnforced` and the atomic ownership contract. When `CAMOFOX_ACCESS_KEY` is configured, the global access-key middleware authenticates this route before it can report enforcement.
+
 ### Session Tracing
 
 Capture a Playwright trace of every action in a session: page screenshots, DOM snapshots, network requests, and console output. Output is a single `.zip` file you can open in Playwright's built-in Trace Viewer.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "camofox-browser",
-    "version": "1.6.0",
+    "version": "1.13.0",
     "description": "Anti-detection browser automation server for AI agents. Accessibility snapshots, element refs, session isolation, cookie import, proxy rotation, and structured logs.",
     "license": {
       "name": "MIT",
@@ -55,11 +55,36 @@
     }
   ],
   "components": {
+    "parameters": {
+      "SessionOwnerTokenHeader": {
+        "name": "X-Camofox-Session-Owner",
+        "in": "header",
+        "required": false,
+        "description": "Exact owner token required for every control request after a session has been claimed. Never send this token in a query string.",
+        "schema": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 256,
+          "pattern": "^[A-Za-z0-9_-]+$"
+        }
+      }
+    },
     "securitySchemes": {
       "BearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "Bearer token matching CAMOFOX_API_KEY."
+        "description": "Bearer token matching CAMOFOX_API_KEY (per-route auth for sensitive endpoints like cookie import and traces)."
+      },
+      "AdminKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-admin-key",
+        "description": "Administrative key matching CAMOFOX_ADMIN_KEY. Required by POST /stop."
+      },
+      "AccessKeyAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Bearer token matching CAMOFOX_ACCESS_KEY. When set, gates all routes except /health, cookie import, and /stop. Acts as a superkey -- also accepted by endpoints that normally require CAMOFOX_API_KEY."
       }
     },
     "schemas": {
@@ -77,6 +102,66 @@
     }
   },
   "paths": {
+    "/capabilities": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Read control-plane security capabilities",
+        "description": "Side-effect-free readback. When controlAccessKeyEnforced is true, this response was gated by CAMOFOX_ACCESS_KEY.",
+        "responses": {
+          "200": {
+            "description": "Control-plane capability state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "controlAccessKeyEnforced",
+                    "atomicSessionOwnership"
+                  ],
+                  "properties": {
+                    "controlAccessKeyEnforced": {
+                      "type": "boolean"
+                    },
+                    "atomicSessionOwnership": {
+                      "type": "object",
+                      "required": [
+                        "version",
+                        "ownerTokenRetained",
+                        "ownerTokenHeader"
+                      ],
+                      "properties": {
+                        "version": {
+                          "type": "integer"
+                        },
+                        "ownerTokenRetained": {
+                          "type": "boolean"
+                        },
+                        "ownerTokenHeader": {
+                          "type": "string",
+                          "example": "X-Camofox-Session-Owner"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/sessions/{userId}/cookies": {
       "post": {
         "tags": [
@@ -98,6 +183,9 @@
               "type": "string"
             },
             "description": "Session owner identifier."
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -192,6 +280,16 @@
           },
           "403": {
             "description": "Forbidden.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -296,6 +394,105 @@
         }
       }
     },
+    "/pressure/cleanup": {
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Proactive memory-pressure cleanup",
+        "description": "Closes tabs observed idle across multiple checks while preserving tabs\nwith active/queued operations. Never returns URLs, titles, cookies,\npage text, or user IDs. Defaults to dry-run mode.\n",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "dryRun": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "When true, returns candidates without closing them."
+                  },
+                  "minIdleMs": {
+                    "type": "number",
+                    "default": 600000,
+                    "description": "Minimum idle time (ms) before a tab is eligible."
+                  },
+                  "maxTabsToClose": {
+                    "type": "number",
+                    "default": 4,
+                    "description": "Maximum tabs to close per invocation."
+                  },
+                  "minTabsPerSession": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "Preserve at least this many tabs per session."
+                  },
+                  "closeEmptySessions": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Close sessions left with zero tabs after cleanup."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cleanup result with before/after counts and hashed metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "dryRun": {
+                      "type": "boolean"
+                    },
+                    "before": {
+                      "type": "object",
+                      "properties": {
+                        "sessions": {
+                          "type": "integer"
+                        },
+                        "tabs": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    "after": {
+                      "type": "object",
+                      "properties": {
+                        "sessions": {
+                          "type": "integer"
+                        },
+                        "tabs": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    "candidates": {
+                      "type": "integer"
+                    },
+                    "closed": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "preserved": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/tabs": {
       "post": {
         "tags": [
@@ -333,6 +530,19 @@
                   "trace": {
                     "type": "boolean",
                     "description": "Enable Playwright tracing for this session (screenshots, DOM snapshots, network). Must be set on first tab creation; cannot be added to an existing session."
+                  },
+                  "exclusiveSession": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Atomically claim a previously absent, non-inflight session. Requires sessionOwnerToken."
+                  },
+                  "sessionOwnerToken": {
+                    "type": "string",
+                    "minLength": 32,
+                    "maxLength": 256,
+                    "pattern": "^[A-Za-z0-9_-]+$",
+                    "writeOnly": true,
+                    "description": "Caller-generated opaque token used to authorize reuse and exact cleanup of an exclusively claimed session."
                   }
                 }
               }
@@ -352,6 +562,10 @@
                     },
                     "url": {
                       "type": "string"
+                    },
+                    "sessionOwned": {
+                      "type": "boolean",
+                      "description": "True when the session is protected by an active ownership claim."
                     }
                   }
                 }
@@ -359,7 +573,17 @@
             }
           },
           "400": {
-            "description": "Missing required fields.",
+            "description": "Missing or invalid request fields, including ownership inputs.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Session owner token mismatch.",
             "content": {
               "application/json": {
                 "schema": {
@@ -369,7 +593,7 @@
             }
           },
           "409": {
-            "description": "Cannot enable tracing on an existing session.",
+            "description": "Session ownership conflict, or tracing cannot be enabled on an existing session.",
             "content": {
               "application/json": {
                 "schema": {
@@ -388,7 +612,12 @@
               }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
+          }
+        ]
       },
       "get": {
         "tags": [
@@ -400,10 +629,14 @@
           {
             "name": "userId",
             "in": "query",
+            "required": true,
             "schema": {
               "type": "string"
             },
             "description": "Filter by session owner."
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -444,6 +677,36 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -463,6 +726,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -521,8 +787,28 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -588,6 +874,9 @@
                 "false"
               ]
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -624,8 +913,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -651,6 +970,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -694,8 +1016,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -722,6 +1074,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -785,8 +1140,28 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Page changed during the click; caller should take a fresh snapshot and retry with current refs.",
             "content": {
               "application/json": {
                 "schema": {
@@ -813,6 +1188,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -872,8 +1250,28 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Page changed or target became invalid; caller should take a fresh snapshot and retry.",
             "content": {
               "application/json": {
                 "schema": {
@@ -899,6 +1297,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -940,8 +1341,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -967,6 +1398,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -1011,8 +1445,146 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tabs/{tabId}/viewport": {
+      "post": {
+        "tags": [
+          "Interaction"
+        ],
+        "summary": "Set the page viewport size",
+        "description": "Physically resizes the page via Playwright's `page.setViewportSize`, triggering a real layout reflow. Use for responsive testing — `window.resizeTo()` is a no-op on non-popup windows.\n",
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId",
+                  "width",
+                  "height"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "width": {
+                    "type": "integer",
+                    "minimum": 100,
+                    "maximum": 4000
+                  },
+                  "height": {
+                    "type": "integer",
+                    "minimum": 100,
+                    "maximum": 4000
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Viewport set.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "width": {
+                      "type": "integer"
+                    },
+                    "height": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Width or height missing or out of range."
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1038,6 +1610,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -1077,8 +1652,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1104,6 +1709,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -1143,8 +1751,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1170,6 +1808,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -1209,8 +1850,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1244,6 +1915,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -1276,8 +1950,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1311,6 +2015,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -1343,8 +2050,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1378,6 +2115,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -1413,8 +2153,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1449,6 +2219,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -1475,8 +2248,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1511,6 +2314,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -1547,8 +2353,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1575,6 +2411,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -1627,8 +2466,28 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1655,6 +2514,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -1752,6 +2614,16 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
             "content": {
@@ -1838,6 +2710,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -1856,8 +2731,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1891,6 +2796,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -1912,8 +2820,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Session not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1946,6 +2884,9 @@
               "type": "string"
             },
             "description": "Session owner identifier."
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -1981,8 +2922,28 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "403": {
             "description": "Forbidden.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2034,6 +2995,9 @@
               "type": "string"
             },
             "description": "Trace zip filename."
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -2070,6 +3034,16 @@
           },
           "404": {
             "description": "Trace not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2119,6 +3093,9 @@
               "type": "string"
             },
             "description": "Trace zip filename."
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -2167,6 +3144,16 @@
               }
             }
           },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Server error.",
             "content": {
@@ -2195,8 +3182,31 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sessionOwnerToken": {
+                    "type": "string",
+                    "minLength": 32,
+                    "maxLength": 256,
+                    "pattern": "^[A-Za-z0-9_-]+$",
+                    "writeOnly": true,
+                    "description": "Required only when the target session has an active exclusive ownership claim."
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Session destroyed.",
@@ -2210,14 +3220,48 @@
                     },
                     "closed": {
                       "type": "integer"
+                    },
+                    "claimReleased": {
+                      "type": "boolean",
+                      "description": "True when an exclusive ownership claim was released."
                     }
                   }
                 }
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Session owner token mismatch.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Session not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session creation is still in flight or deletion is already in progress; retry after the active lifecycle operation settles.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2322,8 +3366,33 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
+          }
+        ]
       }
     },
     "/start": {
@@ -2374,7 +3443,7 @@
         "description": "Stops the browser and closes all sessions. Requires x-admin-key header.",
         "security": [
           {
-            "BearerAuth": []
+            "AdminKey": []
           }
         ],
         "responses": {
@@ -2466,6 +3535,16 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
             "content": {
@@ -2475,8 +3554,23 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
+          }
+        ]
       }
     },
     "/snapshot": {
@@ -2528,6 +3622,9 @@
                 "false"
               ]
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -2551,8 +3648,28 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2637,6 +3754,16 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
             "content": {
@@ -2646,6 +3773,197 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
+          }
+        ]
+      }
+    },
+    "/sessions/{userId}/storage_state": {
+      "delete": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Reset live and persisted session storage state",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Storage state reset completed."
+          },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Storage state reset failed."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Export the live session storage state",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current storage state."
+          },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found."
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Storage state export failed."
+          }
+        }
+      }
+    },
+    "/vnc/status": {
+      "get": {
+        "tags": [
+          "Browser"
+        ],
+        "summary": "Read VNC helper status",
+        "responses": {
+          "200": {
+            "description": "VNC helper status."
+          }
+        }
+      }
+    },
+    "/youtube/transcript": {
+      "post": {
+        "tags": [
+          "Content"
+        ],
+        "summary": "Extract a YouTube transcript",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "languages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Transcript extraction result."
+          },
+          "400": {
+            "description": "Invalid input URL."
+          },
+          "500": {
+            "description": "Transcript extraction failed."
           }
         }
       }

--- a/lib/browser-launch-lifecycle.js
+++ b/lib/browser-launch-lifecycle.js
@@ -1,0 +1,54 @@
+export function createBrowserLaunchGeneration() {
+  let current = 0;
+  return {
+    begin() {
+      current += 1;
+      return current;
+    },
+    invalidate() {
+      current += 1;
+    },
+    assertCurrent(generation) {
+      if (generation !== current) {
+        throw Object.assign(new Error('Browser launch was superseded before publication'), {
+          code: 'browser_launch_superseded',
+        });
+      }
+    },
+  };
+}
+
+export function waitForLaunchWithTimeout(task, timeoutMs) {
+  let timeout;
+  return Promise.race([
+    task,
+    new Promise((_, reject) => {
+      timeout = setTimeout(
+        () => reject(new Error(`Browser launch timeout (${Math.round(timeoutMs / 1000)}s)`)),
+        timeoutMs,
+      );
+    }),
+  ]).finally(() => clearTimeout(timeout));
+}
+
+export async function closeAndDrainBrowserLaunch(closeBrowser, launchTask) {
+  try {
+    await closeBrowser();
+  } finally {
+    await launchTask?.catch(() => {});
+  }
+}
+
+export async function runBackgroundBrowserOperation(operation, onError) {
+  try {
+    return await operation();
+  } catch (error) {
+    try {
+      onError(error);
+    } catch {
+      // A background timer must never surface a second unhandled rejection
+      // merely because diagnostics or retry scheduling failed.
+    }
+    return undefined;
+  }
+}

--- a/lib/openapi.js
+++ b/lib/openapi.js
@@ -18,6 +18,10 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_OPENAPI_APIS = [
+  join(__dirname, '..', 'server.js'),
+  join(__dirname, '..', 'plugins', '**', '*.js'),
+];
 
 let version = 'unknown';
 try {
@@ -48,11 +52,31 @@ const swaggerDefinition = {
     { name: 'Legacy', description: 'OpenClaw-compatible endpoints (deprecated).' },
   ],
   components: {
+    parameters: {
+      SessionOwnerTokenHeader: {
+        name: 'X-Camofox-Session-Owner',
+        in: 'header',
+        required: false,
+        description: 'Exact owner token required for every control request after a session has been claimed. Never send this token in a query string.',
+        schema: {
+          type: 'string',
+          minLength: 32,
+          maxLength: 256,
+          pattern: '^[A-Za-z0-9_-]+$',
+        },
+      },
+    },
     securitySchemes: {
       BearerAuth: {
         type: 'http',
         scheme: 'bearer',
         description: 'Bearer token matching CAMOFOX_API_KEY (per-route auth for sensitive endpoints like cookie import and traces).',
+      },
+      AdminKey: {
+        type: 'apiKey',
+        in: 'header',
+        name: 'x-admin-key',
+        description: 'Administrative key matching CAMOFOX_ADMIN_KEY. Required by POST /stop.',
       },
       AccessKeyAuth: {
         type: 'http',
@@ -70,21 +94,66 @@ const swaggerDefinition = {
   },
 };
 
+const USER_SCOPED_LEGACY_PATHS = new Set(['/navigate', '/snapshot', '/act']);
+
+function isUserScopedControlPath(path) {
+  return path === '/tabs' || path.startsWith('/tabs/') ||
+    path.startsWith('/sessions/{userId}') || USER_SCOPED_LEGACY_PATHS.has(path);
+}
+
+/** Add the ownership contract consistently to every user-scoped control operation. */
+export function applySessionOwnershipContract(spec) {
+  const ownershipParameter = { $ref: '#/components/parameters/SessionOwnerTokenHeader' };
+  const ownershipResponses = {
+    400: {
+      description: 'Invalid or conflicting session owner token or user identifier.',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } },
+    },
+    403: {
+      description: 'The claimed session requires its exact owner token.',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } },
+    },
+    409: {
+      description: 'Session ownership, creation, or deletion lifecycle conflict.',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } },
+    },
+  };
+  for (const [path, pathItem] of Object.entries(spec.paths || {})) {
+    if (!isUserScopedControlPath(path)) continue;
+    for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
+      const operation = pathItem[method];
+      if (!operation) continue;
+      operation.parameters ||= [];
+      if (!operation.parameters.some(parameter => parameter.$ref === ownershipParameter.$ref)) {
+        operation.parameters.push(ownershipParameter);
+      }
+      operation.responses ||= {};
+      for (const [status, response] of Object.entries(ownershipResponses)) {
+        operation.responses[status] ||= response;
+      }
+    }
+  }
+  return spec;
+}
+
+export function buildOpenApiSpec(apis = DEFAULT_OPENAPI_APIS) {
+  return applySessionOwnershipContract(swaggerJsdoc({
+    definition: swaggerDefinition,
+    apis,
+  }));
+}
+
 /**
  * Mount GET /openapi.json and GET /docs on the Express app.
  * Call AFTER all routes are registered so swagger-jsdoc can scan them.
  *
  * @param {import('express').Application} app
  * @param {Object} [opts]
- * @param {string[]} [opts.apis] - Glob patterns for files with @openapi JSDoc (default: ['./server.js'])
+ * @param {string[]} [opts.apis] - Glob patterns for files with @openapi JSDoc
  */
 export function mountDocs(app, opts = {}) {
-  const apis = opts.apis || ['./server.js'];
-
-  const spec = swaggerJsdoc({
-    definition: swaggerDefinition,
-    apis,
-  });
+  const apis = opts.apis || DEFAULT_OPENAPI_APIS;
+  const spec = buildOpenApiSpec(apis);
 
   app.get('/openapi.json', (_req, res) => {
     res.json(spec);

--- a/lib/pressure-cleanup.js
+++ b/lib/pressure-cleanup.js
@@ -1,0 +1,10 @@
+export function isPressureTabStillEligible(tabState, {
+  selectedToolCalls,
+  minIdleMs,
+  now = Date.now(),
+}) {
+  if (!tabState || tabState.toolCalls !== selectedToolCalls) return false;
+  if (!Number.isFinite(tabState.pressureObservedAt)) return false;
+  if (tabState.pressureObservedToolCalls !== tabState.toolCalls) return false;
+  return now - tabState.pressureObservedAt >= minIdleMs;
+}

--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -47,11 +47,17 @@ export function captureException(error, context = {}) {
   } catch {}
 }
 
+export function sanitizeRequestPath(req) {
+  if (typeof req?.path === 'string') return req.path;
+  if (typeof req?.originalUrl === 'string') return req.originalUrl.split('?', 1)[0];
+  return undefined;
+}
+
 export function setupExpressErrorHandler(app) {
   if (!app) return;
   app.use((err, req, res, next) => {
     captureException(err, {
-      path: req?.originalUrl,
+      path: sanitizeRequestPath(req),
       method: req?.method,
       userId: req?.query?.userId || req?.body?.userId,
       reqId: req?.reqId,

--- a/lib/session-operations.js
+++ b/lib/session-operations.js
@@ -1,0 +1,131 @@
+function lifecycleConflict() {
+  return Object.assign(new Error('Session deletion is already in flight'), {
+    statusCode: 409,
+    code: 'session_deletion_inflight',
+  });
+}
+
+export function attachOperationCompletion(response, finish) {
+  let completed = false;
+  const complete = () => {
+    if (completed) return;
+    completed = true;
+    finish();
+  };
+  if (response.destroyed || response.writableEnded) {
+    complete();
+    return false;
+  }
+  const originalEnd = response.end;
+  response.end = function operationAwareEnd(...args) {
+    const result = originalEnd.apply(this, args);
+    complete();
+    return result;
+  };
+  if (typeof response.destroy === 'function') {
+    const originalDestroy = response.destroy;
+    response.destroy = function operationAwareDestroy(...args) {
+      const result = originalDestroy.apply(this, args);
+      complete();
+      return result;
+    };
+  }
+  return true;
+}
+
+export function trackOperationPromise(coordinator, userId, promise) {
+  const finish = coordinator.extend(userId);
+  return Promise.resolve(promise).finally(finish);
+}
+
+export async function runCoordinatedDeletion(coordinator, userId, operation) {
+  const finishDelete = await coordinator.beginDelete(userId);
+  try {
+    return await operation();
+  } finally {
+    finishDelete();
+  }
+}
+
+export function createSessionOperationCoordinator() {
+  const states = new Map();
+
+  function stateFor(userId) {
+    let state = states.get(userId);
+    if (!state) {
+      state = { active: 0, deleting: false, idleWaiters: [] };
+      states.set(userId, state);
+    }
+    return state;
+  }
+
+  function cleanup(userId, state) {
+    if (state.active === 0 && !state.deleting && state.idleWaiters.length === 0) {
+      states.delete(userId);
+    }
+  }
+
+  function enter(userId) {
+    const state = stateFor(userId);
+    if (state.deleting) {
+      cleanup(userId, state);
+      throw lifecycleConflict();
+    }
+    state.active += 1;
+    let finished = false;
+    return () => {
+      if (finished) return;
+      finished = true;
+      state.active -= 1;
+      if (state.active === 0) {
+        const waiters = state.idleWaiters.splice(0);
+        for (const resolve of waiters) resolve();
+      }
+      cleanup(userId, state);
+    };
+  }
+
+  function extend(userId) {
+    const state = states.get(userId);
+    if (!state || state.active === 0) throw lifecycleConflict();
+    state.active += 1;
+    let finished = false;
+    return () => {
+      if (finished) return;
+      finished = true;
+      state.active -= 1;
+      if (state.active === 0) {
+        const waiters = state.idleWaiters.splice(0);
+        for (const resolve of waiters) resolve();
+      }
+      cleanup(userId, state);
+    };
+  }
+
+  async function beginDelete(userId) {
+    const state = stateFor(userId);
+    if (state.deleting) throw lifecycleConflict();
+    state.deleting = true;
+    if (state.active > 0) {
+      await new Promise(resolve => state.idleWaiters.push(resolve));
+    }
+    let finished = false;
+    return () => {
+      if (finished) return;
+      finished = true;
+      state.deleting = false;
+      cleanup(userId, state);
+    };
+  }
+
+  return {
+    enter,
+    extend,
+    beginDelete,
+    isActive: userId => {
+      const state = states.get(userId);
+      return !!state && (state.active > 0 || state.deleting);
+    },
+    size: () => states.size,
+  };
+}

--- a/lib/session-ownership.js
+++ b/lib/session-ownership.js
@@ -1,0 +1,112 @@
+import crypto from 'crypto';
+import { performance } from 'perf_hooks';
+
+const OWNER_TOKEN_PATTERN = /^[A-Za-z0-9_-]{32,256}$/;
+const DEFAULT_TTL_MS = 30 * 60 * 1000;
+const DEFAULT_MAX_CLAIMS = 1000;
+
+function ownershipError(message, statusCode, code) {
+  return Object.assign(new Error(message), { statusCode, code });
+}
+
+function tokenDigest(token) {
+  return crypto.createHash('sha256').update(token, 'utf8').digest();
+}
+
+function validOwnerToken(token) {
+  return typeof token === 'string' && OWNER_TOKEN_PATTERN.test(token);
+}
+
+function sameToken(claim, token) {
+  if (!validOwnerToken(token)) return false;
+  return crypto.timingSafeEqual(claim.digest, tokenDigest(token));
+}
+
+export function createSessionOwnershipRegistry({
+  ttlMs = DEFAULT_TTL_MS,
+  maxClaims = DEFAULT_MAX_CLAIMS,
+  now = () => performance.now(),
+} = {}) {
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+    throw new TypeError('ttlMs must be positive');
+  }
+  if (!Number.isSafeInteger(maxClaims) || maxClaims <= 0) {
+    throw new TypeError('maxClaims must be a positive safe integer');
+  }
+
+  const claims = new Map();
+
+  function purgeExpired(canRelease) {
+    if (typeof canRelease !== 'function') {
+      throw new TypeError('canRelease must be a function');
+    }
+    const current = now();
+    let released = 0;
+    for (const [userId, claim] of claims) {
+      if (claim.expiresAt <= current && canRelease(userId)) {
+        claims.delete(userId);
+        released += 1;
+      }
+    }
+    return released;
+  }
+
+  function claim(userId, ownerToken, { sessionExists, creationInflight }) {
+    if (!validOwnerToken(ownerToken)) {
+      throw ownershipError('Invalid session owner token', 400, 'invalid_session_owner_token');
+    }
+    const current = now();
+    if (sessionExists || creationInflight || claims.has(userId)) {
+      throw ownershipError('Session is not available for exclusive ownership', 409, 'session_ownership_conflict');
+    }
+    if (claims.size >= maxClaims) {
+      throw ownershipError('Session ownership capacity reached', 503, 'session_ownership_capacity');
+    }
+    claims.set(userId, {
+      digest: tokenDigest(ownerToken),
+      expiresAt: current + ttlMs,
+    });
+  }
+
+  function authorize(userId, ownerToken) {
+    if (ownerToken !== undefined && !validOwnerToken(ownerToken)) {
+      throw ownershipError('Invalid session owner token', 400, 'invalid_session_owner_token');
+    }
+    const current = now();
+    const existing = claims.get(userId);
+    if (!existing) return false;
+    if (!sameToken(existing, ownerToken)) {
+      throw ownershipError('Session owner token mismatch', 403, 'session_owner_mismatch');
+    }
+    existing.expiresAt = current + ttlMs;
+    return true;
+  }
+
+  function release(userId, ownerToken) {
+    const existing = claims.get(userId);
+    if (!existing) return false;
+    if (!sameToken(existing, ownerToken)) {
+      throw ownershipError('Session owner token mismatch', 403, 'session_owner_mismatch');
+    }
+    claims.delete(userId);
+    return true;
+  }
+
+  function prepareRelease(userId, ownerToken, { creationInflight }) {
+    const owned = authorize(userId, ownerToken);
+    if (creationInflight) {
+      throw ownershipError(
+        'Session creation is still in flight',
+        409,
+        'session_creation_inflight',
+      );
+    }
+    return owned;
+  }
+
+  function hasClaim(userId) {
+    return claims.has(userId);
+  }
+
+  return Object.freeze({ authorize, claim, hasClaim, prepareRelease, purgeExpired, release });
+}

--- a/lib/verified-context-close.js
+++ b/lib/verified-context-close.js
@@ -1,0 +1,22 @@
+export async function closeContextVerified(context) {
+  try {
+    await context.close();
+  } catch (error) {
+    try {
+      context.pages();
+    } catch {
+      return;
+    }
+    throw error;
+  }
+}
+
+export function deleteSessionIfCurrent(registry, key, session) {
+  if (registry.get(key) !== session) {
+    throw Object.assign(new Error('Session changed while its prior context was closing'), {
+      statusCode: 409,
+      code: 'session_replaced_during_close',
+    });
+  }
+  registry.delete(key);
+}

--- a/openapi.json
+++ b/openapi.json
@@ -55,11 +55,31 @@
     }
   ],
   "components": {
+    "parameters": {
+      "SessionOwnerTokenHeader": {
+        "name": "X-Camofox-Session-Owner",
+        "in": "header",
+        "required": false,
+        "description": "Exact owner token required for every control request after a session has been claimed. Never send this token in a query string.",
+        "schema": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 256,
+          "pattern": "^[A-Za-z0-9_-]+$"
+        }
+      }
+    },
     "securitySchemes": {
       "BearerAuth": {
         "type": "http",
         "scheme": "bearer",
         "description": "Bearer token matching CAMOFOX_API_KEY (per-route auth for sensitive endpoints like cookie import and traces)."
+      },
+      "AdminKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-admin-key",
+        "description": "Administrative key matching CAMOFOX_ADMIN_KEY. Required by POST /stop."
       },
       "AccessKeyAuth": {
         "type": "http",
@@ -82,6 +102,66 @@
     }
   },
   "paths": {
+    "/capabilities": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Read control-plane security capabilities",
+        "description": "Side-effect-free readback. When controlAccessKeyEnforced is true, this response was gated by CAMOFOX_ACCESS_KEY.",
+        "responses": {
+          "200": {
+            "description": "Control-plane capability state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "controlAccessKeyEnforced",
+                    "atomicSessionOwnership"
+                  ],
+                  "properties": {
+                    "controlAccessKeyEnforced": {
+                      "type": "boolean"
+                    },
+                    "atomicSessionOwnership": {
+                      "type": "object",
+                      "required": [
+                        "version",
+                        "ownerTokenRetained",
+                        "ownerTokenHeader"
+                      ],
+                      "properties": {
+                        "version": {
+                          "type": "integer"
+                        },
+                        "ownerTokenRetained": {
+                          "type": "boolean"
+                        },
+                        "ownerTokenHeader": {
+                          "type": "string",
+                          "example": "X-Camofox-Session-Owner"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/sessions/{userId}/cookies": {
       "post": {
         "tags": [
@@ -103,6 +183,9 @@
               "type": "string"
             },
             "description": "Session owner identifier."
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -197,6 +280,16 @@
           },
           "403": {
             "description": "Forbidden.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -437,6 +530,19 @@
                   "trace": {
                     "type": "boolean",
                     "description": "Enable Playwright tracing for this session (screenshots, DOM snapshots, network). Must be set on first tab creation; cannot be added to an existing session."
+                  },
+                  "exclusiveSession": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Atomically claim a previously absent, non-inflight session. Requires sessionOwnerToken."
+                  },
+                  "sessionOwnerToken": {
+                    "type": "string",
+                    "minLength": 32,
+                    "maxLength": 256,
+                    "pattern": "^[A-Za-z0-9_-]+$",
+                    "writeOnly": true,
+                    "description": "Caller-generated opaque token used to authorize reuse and exact cleanup of an exclusively claimed session."
                   }
                 }
               }
@@ -456,6 +562,10 @@
                     },
                     "url": {
                       "type": "string"
+                    },
+                    "sessionOwned": {
+                      "type": "boolean",
+                      "description": "True when the session is protected by an active ownership claim."
                     }
                   }
                 }
@@ -463,7 +573,17 @@
             }
           },
           "400": {
-            "description": "Missing required fields.",
+            "description": "Missing or invalid request fields, including ownership inputs.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Session owner token mismatch.",
             "content": {
               "application/json": {
                 "schema": {
@@ -473,7 +593,7 @@
             }
           },
           "409": {
-            "description": "Cannot enable tracing on an existing session.",
+            "description": "Session ownership conflict, or tracing cannot be enabled on an existing session.",
             "content": {
               "application/json": {
                 "schema": {
@@ -492,7 +612,12 @@
               }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
+          }
+        ]
       },
       "get": {
         "tags": [
@@ -504,10 +629,14 @@
           {
             "name": "userId",
             "in": "query",
+            "required": true,
             "schema": {
               "type": "string"
             },
             "description": "Filter by session owner."
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -548,6 +677,36 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -567,6 +726,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -625,8 +787,28 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -692,6 +874,9 @@
                 "false"
               ]
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -728,8 +913,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -755,6 +970,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -798,8 +1016,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -826,6 +1074,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -889,6 +1140,16 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
             "content": {
@@ -927,6 +1188,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -986,6 +1250,16 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
             "content": {
@@ -1023,6 +1297,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -1064,8 +1341,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1091,6 +1398,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -1135,8 +1445,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1163,6 +1503,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -1220,8 +1563,28 @@
           "400": {
             "description": "Width or height missing or out of range."
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1247,6 +1610,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -1286,8 +1652,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1313,6 +1709,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -1352,8 +1751,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1379,6 +1808,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -1418,8 +1850,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1453,6 +1915,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -1485,8 +1950,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1520,6 +2015,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -1552,8 +2050,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1587,6 +2115,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -1622,8 +2153,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1658,6 +2219,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -1684,8 +2248,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1720,6 +2314,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -1756,8 +2353,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1784,6 +2411,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -1836,8 +2466,28 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1864,6 +2514,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "requestBody": {
@@ -1961,6 +2614,16 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
             "content": {
@@ -2047,6 +2710,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -2065,8 +2731,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2100,6 +2796,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -2121,8 +2820,38 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Session not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2155,6 +2884,9 @@
               "type": "string"
             },
             "description": "Session owner identifier."
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -2190,8 +2922,28 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "403": {
             "description": "Forbidden.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2243,6 +2995,9 @@
               "type": "string"
             },
             "description": "Trace zip filename."
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -2279,6 +3034,16 @@
           },
           "404": {
             "description": "Trace not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2328,6 +3093,9 @@
               "type": "string"
             },
             "description": "Trace zip filename."
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -2376,6 +3144,16 @@
               }
             }
           },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Server error.",
             "content": {
@@ -2404,8 +3182,31 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sessionOwnerToken": {
+                    "type": "string",
+                    "minLength": 32,
+                    "maxLength": 256,
+                    "pattern": "^[A-Za-z0-9_-]+$",
+                    "writeOnly": true,
+                    "description": "Required only when the target session has an active exclusive ownership claim."
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Session destroyed.",
@@ -2419,14 +3220,48 @@
                     },
                     "closed": {
                       "type": "integer"
+                    },
+                    "claimReleased": {
+                      "type": "boolean",
+                      "description": "True when an exclusive ownership claim was released."
                     }
                   }
                 }
               }
             }
           },
+          "400": {
+            "description": "Invalid or conflicting session owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Session owner token mismatch.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Session not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session creation is still in flight or deletion is already in progress; retry after the active lifecycle operation settles.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2531,8 +3366,33 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
+          }
+        ]
       }
     },
     "/start": {
@@ -2583,7 +3443,7 @@
         "description": "Stops the browser and closes all sessions. Requires x-admin-key header.",
         "security": [
           {
-            "BearerAuth": []
+            "AdminKey": []
           }
         ],
         "responses": {
@@ -2675,6 +3535,16 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
             "content": {
@@ -2684,8 +3554,23 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
+          }
+        ]
       }
     },
     "/snapshot": {
@@ -2737,6 +3622,9 @@
                 "false"
               ]
             }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
           }
         ],
         "responses": {
@@ -2760,8 +3648,28 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2846,6 +3754,16 @@
               }
             }
           },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Tab not found.",
             "content": {
@@ -2855,6 +3773,197 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
+          }
+        ]
+      }
+    },
+    "/sessions/{userId}/storage_state": {
+      "delete": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Reset live and persisted session storage state",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Storage state reset completed."
+          },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Storage state reset failed."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Export the live session storage state",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/SessionOwnerTokenHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current storage state."
+          },
+          "400": {
+            "description": "Invalid or conflicting session owner token or user identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The claimed session requires its exact owner token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found."
+          },
+          "409": {
+            "description": "Session ownership, creation, or deletion lifecycle conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Storage state export failed."
+          }
+        }
+      }
+    },
+    "/vnc/status": {
+      "get": {
+        "tags": [
+          "Browser"
+        ],
+        "summary": "Read VNC helper status",
+        "responses": {
+          "200": {
+            "description": "VNC helper status."
+          }
+        }
+      }
+    },
+    "/youtube/transcript": {
+      "post": {
+        "tags": [
+          "Content"
+        ],
+        "summary": "Extract a YouTube transcript",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "languages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Transcript extraction result."
+          },
+          "400": {
+            "description": "Invalid input URL."
+          },
+          "500": {
+            "description": "Transcript extraction failed."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "files": [
     "server.js",
     "lib/",
+    "docs/",
     "plugins/",
     "camofox.config.json",
     "plugin.ts",

--- a/plugins/persistence/index.js
+++ b/plugins/persistence/index.js
@@ -152,19 +152,21 @@ export async function register(app, ctx, pluginConfig = {}) {
   });
 
   // On session destroying (pre-close): checkpoint while context is still alive
-  events.on('session:destroying', async ({ userId, reason }) => {
-    const context = activeSessions.get(userId);
-    if (context) {
+  events.on('session:destroying', async ({ userId, reason, context }) => {
+    const trackedContext = activeSessions.get(userId);
+    if (context && trackedContext === context) {
       if (reason !== 'storage_reset') {
         await checkpoint(userId, context, reason).catch(() => {});
       }
-      activeSessions.delete(userId);
     }
   });
 
-  // On session destroyed (post-close): cleanup tracking if not already done
-  events.on('session:destroyed', async ({ userId }) => {
-    activeSessions.delete(userId);
+  // Keep tracking through verified close so a failed close can be retried and
+  // subsequent checkpoints still refer to the retained live context.
+  events.on('session:destroyed', async ({ userId, context }) => {
+    if (context && activeSessions.get(userId) === context) {
+      activeSessions.delete(userId);
+    }
   });
 
   // On shutdown: checkpoint all remaining sessions
@@ -175,6 +177,23 @@ export async function register(app, ctx, pluginConfig = {}) {
     activeSessions.clear();
   });
 
+  /**
+   * @openapi
+   * /sessions/{userId}/storage_state:
+   *   delete:
+   *     tags: [Sessions]
+   *     summary: Reset live and persisted session storage state
+   *     parameters:
+   *       - in: path
+   *         name: userId
+   *         required: true
+   *         schema: { type: string }
+   *     responses:
+   *       200:
+   *         description: Storage state reset completed.
+   *       500:
+   *         description: Storage state reset failed.
+   */
   app.delete('/sessions/:userId/storage_state', ctx.auth(), async (req, res) => {
     const userId = ctx.normalizeUserId(req.params.userId);
     if (resettingUsers.has(userId)) {

--- a/plugins/persistence/plugin.test.js
+++ b/plugins/persistence/plugin.test.js
@@ -11,6 +11,8 @@ describe('persistence plugin', () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'camofox-persist-plugin-'));
     events = createPluginEvents();
+    const sessionContexts = new Map();
+    events.on('session:created', ({ userId, context }) => sessionContexts.set(userId, context));
     mockApp = { delete: jest.fn() };
     ctx = {
       events,
@@ -20,8 +22,11 @@ describe('persistence plugin', () => {
       normalizeUserId: (u) => String(u),
       safeError: (err) => err.message,
       destroySession: jest.fn(async (userId, { reason } = {}) => {
-        await events.emitAsync('session:destroying', { userId: String(userId), reason });
-        await events.emitAsync('session:destroyed', { userId: String(userId), reason });
+        const key = String(userId);
+        const context = sessionContexts.get(key);
+        await events.emitAsync('session:destroying', { userId: key, reason, context });
+        await events.emitAsync('session:destroyed', { userId: key, reason, context });
+        sessionContexts.delete(key);
         return true;
       }),
     };
@@ -104,7 +109,9 @@ describe('persistence plugin', () => {
     };
 
     await events.emitAsync('session:created', { userId: 'user-3', context: mockContext });
-    await events.emitAsync('session:destroying', { userId: 'user-3', reason: 'test' });
+    await events.emitAsync('session:destroying', {
+      userId: 'user-3', reason: 'test', context: mockContext,
+    });
 
     expect(mockContext.storageState).toHaveBeenCalled();
   });
@@ -224,7 +231,9 @@ describe('persistence plugin', () => {
       }),
     };
     await events.emitAsync('session:created', { userId: 'user-no-idb', context: mockContext });
-    await events.emitAsync('session:destroying', { userId: 'user-no-idb', reason: 'test' });
+    await events.emitAsync('session:destroying', {
+      userId: 'user-no-idb', reason: 'test', context: mockContext,
+    });
 
     expect(ctx.log).toHaveBeenCalledWith(
       'info',
@@ -246,7 +255,9 @@ describe('persistence plugin', () => {
       }),
     };
     await events.emitAsync('session:created', { userId: 'user-idb', context: mockContext });
-    await events.emitAsync('session:destroying', { userId: 'user-idb', reason: 'test' });
+    await events.emitAsync('session:destroying', {
+      userId: 'user-idb', reason: 'test', context: mockContext,
+    });
 
     expect(ctx.log).toHaveBeenCalledWith(
       'info',

--- a/plugins/vnc/index.js
+++ b/plugins/vnc/index.js
@@ -105,6 +105,16 @@ export async function register(app, ctx, pluginConfig = {}) {
   });
 
   // --- HTTP endpoint: GET /vnc/status ---
+  /**
+   * @openapi
+   * /vnc/status:
+   *   get:
+   *     tags: [Browser]
+   *     summary: Read VNC helper status
+   *     responses:
+   *       200:
+   *         description: VNC helper status.
+   */
   app.get('/vnc/status', (_req, res) => {
     const watcherRunning = watcher.exitCode === null && !watcher.killed;
     const vncStatus = watcher.getVncStatus();
@@ -122,6 +132,25 @@ export async function register(app, ctx, pluginConfig = {}) {
   // --- HTTP endpoint: GET /sessions/:userId/storage_state ---
   const authMiddleware = requireAuth(config);
 
+  /**
+   * @openapi
+   * /sessions/{userId}/storage_state:
+   *   get:
+   *     tags: [Sessions]
+   *     summary: Export the live session storage state
+   *     parameters:
+   *       - in: path
+   *         name: userId
+   *         required: true
+   *         schema: { type: string }
+   *     responses:
+   *       200:
+   *         description: Current storage state.
+   *       404:
+   *         description: Session not found.
+   *       500:
+   *         description: Storage state export failed.
+   */
   app.get('/sessions/:userId/storage_state', authMiddleware, async (req, res) => {
     try {
       const userId = req.params.userId;

--- a/plugins/youtube/index.js
+++ b/plugins/youtube/index.js
@@ -9,8 +9,9 @@ import { detectYtDlp, hasYtDlp, ensureYtDlp, ytDlpTranscript, parseJson3, parseV
 import { classifyError } from '../../lib/request-utils.js';
 
 export async function register(app, ctx, pluginConfig = {}) {
-  const { log, config, sessions, ensureBrowser, getSession,
-          withUserLimit, safePageClose, normalizeUserId,
+  const { log, config, ensureBrowser, getSession,
+          destroySessionCoordinated, enterInternalSessionOperation,
+          withUserLimit, safePageClose,
           validateUrl, safeError, buildProxyUrl, proxyPool,
           failuresTotal } = ctx;
 
@@ -23,6 +24,32 @@ export async function register(app, ctx, pluginConfig = {}) {
   // Auth off by default -- matches pre-plugin behavior. Set { "auth": true } to require auth.
   const middleware = pluginConfig.auth === true ? ctx.auth() : (_req, _res, next) => next();
 
+  /**
+   * @openapi
+   * /youtube/transcript:
+   *   post:
+   *     tags: [Content]
+   *     summary: Extract a YouTube transcript
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [url]
+   *             properties:
+   *               url: { type: string, format: uri }
+   *               languages:
+   *                 type: array
+   *                 items: { type: string }
+   *     responses:
+   *       200:
+   *         description: Transcript extraction result.
+   *       400:
+   *         description: Invalid input URL.
+   *       500:
+   *         description: Transcript extraction failed.
+   */
   app.post('/youtube/transcript', middleware, async (req, res) => {
     const reqId = req.reqId;
     try {
@@ -76,11 +103,14 @@ export async function register(app, ctx, pluginConfig = {}) {
   // Browser fallback -- play video, intercept timedtext network response
   async function browserTranscript(reqId, url, videoId, lang) {
     return await withUserLimit('__yt_transcript__', async () => {
-      await ensureBrowser();
-      const session = await getSession('__yt_transcript__');
-      const page = await session.context.newPage();
-
+      const ytKey = '__yt_transcript__';
+      const finishOperation = enterInternalSessionOperation(ytKey);
+      let session = null;
+      let page = null;
       try {
+        await ensureBrowser();
+        session = await getSession(ytKey);
+        page = await session.context.newPage();
         await page.addInitScript(() => {
           const origPlay = HTMLMediaElement.prototype.play;
           HTMLMediaElement.prototype.play = function() { this.volume = 0; this.muted = true; return origPlay.call(this); };
@@ -184,20 +214,29 @@ export async function register(app, ctx, pluginConfig = {}) {
           available_languages: meta.languages,
         };
       } finally {
-        await safePageClose(page);
-        // Clean up transcript session if no live pages remain
-        const ytKey = normalizeUserId('__yt_transcript__');
-        const ytSession = sessions.get(ytKey);
-        if (ytSession && !ytSession._closing) {
+        try {
+          if (page) await safePageClose(page);
+        } finally {
+          finishOperation();
+        }
+        if (session) {
           try {
-            const remainingPages = ytSession.context.pages();
-            if (remainingPages.length === 0) {
-              ytSession._closing = true;
-              ytSession.context.close().catch(() => {});
-              sessions.delete(ytKey);
+            await destroySessionCoordinated(ytKey, 'youtube_transcript_cleanup', {
+              expectedSession: session,
+              shouldDestroy: current => {
+                try {
+                  return current.context.pages().length === 0;
+                } catch {
+                  return true;
+                }
+              },
+            });
+          } catch (closeError) {
+            if (closeError?.code !== 'session_deletion_inflight') {
+              log('warn', 'youtube transcript session cleanup failed', {
+                error: closeError.message,
+              });
             }
-          } catch {
-            sessions.delete(ytKey);
           }
         }
       }

--- a/scripts/generate-openapi.js
+++ b/scripts/generate-openapi.js
@@ -8,17 +8,14 @@
 import { writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import swaggerJsdoc from 'swagger-jsdoc';
-import { swaggerDefinition } from '../lib/openapi.js';
+import { buildOpenApiSpec } from '../lib/openapi.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
+const spec = buildOpenApiSpec();
 
-const spec = swaggerJsdoc({
-  definition: swaggerDefinition,
-  apis: [join(root, 'server.js')],
-});
-
-const out = join(root, 'openapi.json');
-writeFileSync(out, JSON.stringify(spec, null, 2) + '\n');
-console.log(`Wrote ${Object.keys(spec.paths).length} paths to openapi.json`);
+const serialized = JSON.stringify(spec, null, 2) + '\n';
+for (const out of [join(root, 'openapi.json'), join(root, 'docs', 'openapi.json')]) {
+  writeFileSync(out, serialized);
+}
+console.log(`Wrote ${Object.keys(spec.paths).length} paths to root and docs OpenAPI files`);

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ import express from 'express';
 import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { expandMacro } from './lib/macros.js';
 import { loadConfig } from './lib/config.js';
 import { normalizePlaywrightProxy, createProxyPool, buildProxyUrl } from './lib/proxy.js';
@@ -33,7 +34,22 @@ import {
 import { actionFromReq, classifyError } from './lib/request-utils.js';
 import { cleanupOrphanedTempFiles, cleanupStaleFirefoxProfiles } from './lib/tmp-cleanup.js';
 import { coalesceInflight } from './lib/inflight.js';
+import { createSessionOwnershipRegistry } from './lib/session-ownership.js';
+import {
+  attachOperationCompletion,
+  createSessionOperationCoordinator,
+  runCoordinatedDeletion,
+  trackOperationPromise,
+} from './lib/session-operations.js';
 import { createPageWithSessionRecovery } from './lib/new-page-recovery.js';
+import { closeContextVerified, deleteSessionIfCurrent } from './lib/verified-context-close.js';
+import { isPressureTabStillEligible } from './lib/pressure-cleanup.js';
+import {
+  closeAndDrainBrowserLaunch,
+  createBrowserLaunchGeneration,
+  runBackgroundBrowserOperation,
+  waitForLaunchWithTimeout,
+} from './lib/browser-launch-lifecycle.js';
 import { createReporter, createTabHealthTracker, collectResourceSnapshot, classifyProxyError, browserProcessTreeRssMb, browserProcessNameRssMb } from './lib/reporter.js';
 import { mountDocs } from './lib/openapi.js';
 import { initSentry, captureException as sentryCaptureException, setupExpressErrorHandler as setupSentryErrorHandler, flush as sentryFlush } from './lib/sentry.js';
@@ -163,6 +179,163 @@ app.use('/tabs/:tabId', fly.replayMiddleware(log));
 // dedicated keys (cookie import -> CAMOFOX_API_KEY, /stop -> CAMOFOX_ADMIN_KEY)
 // so each key gates a distinct surface. When unset, behavior is unchanged.
 app.use(accessKeyMiddleware(CONFIG));
+
+let sessionOwnership;
+const sessionOperations = createSessionOperationCoordinator();
+const sessionOperationContext = new AsyncLocalStorage();
+
+function readSessionOwnerToken(req) {
+  if (Object.prototype.hasOwnProperty.call(req.query || {}, 'sessionOwnerToken')) {
+    throw Object.assign(new Error('Session owner tokens are not accepted in query parameters'), {
+      statusCode: 400,
+      code: 'invalid_session_owner_token',
+    });
+  }
+  const bodyToken = req.body?.sessionOwnerToken;
+  const headerValue = req.headers['x-camofox-session-owner'];
+  const headerToken = Array.isArray(headerValue) ? undefined : headerValue;
+  if (Array.isArray(headerValue) || (bodyToken !== undefined && headerToken !== undefined && bodyToken !== headerToken)) {
+    throw Object.assign(new Error('Conflicting or invalid session owner token'), {
+      statusCode: 400,
+      code: 'invalid_session_owner_token',
+    });
+  }
+  return bodyToken ?? headerToken;
+}
+
+function authorizeSessionOwner(req, userId) {
+  return sessionOwnership.authorize(normalizeUserId(userId), readSessionOwnerToken(req));
+}
+
+function readRequestUserId(req) {
+  if (Object.prototype.hasOwnProperty.call(req.query || {}, 'sessionOwnerToken')) {
+    throw Object.assign(new Error('Session owner tokens are not accepted in query parameters'), {
+      statusCode: 400,
+      code: 'invalid_session_owner_token',
+    });
+  }
+  const candidates = [];
+  if (req.body?.userId !== undefined) candidates.push(req.body.userId);
+  if (req.query?.userId !== undefined) candidates.push(req.query.userId);
+  const sessionPath = req.path.match(/^\/sessions\/([^/]+)/);
+  if (sessionPath) {
+    try {
+      candidates.push(decodeURIComponent(sessionPath[1]));
+    } catch {
+      candidates.push(sessionPath[1]);
+    }
+  }
+  if (candidates.length === 0) return undefined;
+  if (candidates.some(value => (
+    (typeof value !== 'string' && typeof value !== 'number')
+    || (typeof value === 'number' && !Number.isFinite(value))
+  ))) {
+    throw Object.assign(new Error('Invalid session user identifier'), {
+      statusCode: 400,
+      code: 'invalid_session_user_id',
+    });
+  }
+  const normalized = candidates.map(normalizeUserId);
+  if (new Set(normalized).size !== 1) {
+    throw Object.assign(new Error('Conflicting session user identifiers'), {
+      statusCode: 400,
+      code: 'conflicting_session_user_id',
+    });
+  }
+  if (normalized[0].length === 0 || normalized[0] === 'undefined' || normalized[0] === 'null') {
+    throw Object.assign(new Error('Invalid session user identifier'), {
+      statusCode: 400,
+      code: 'invalid_session_user_id',
+    });
+  }
+  if (normalized[0].startsWith('__')) {
+    throw Object.assign(new Error('Reserved internal session user identifier'), {
+      statusCode: 400,
+      code: 'reserved_session_user_id',
+    });
+  }
+  return normalized[0];
+}
+
+function requiresSessionUserId(req) {
+  return /^\/tabs(?:\/|$)/.test(req.path)
+    || req.path === '/navigate'
+    || req.path === '/snapshot'
+    || req.path === '/act';
+}
+
+app.use(async (req, res, next) => {
+  try {
+    const userId = readRequestUserId(req);
+    if (userId === undefined) {
+      if (!requiresSessionUserId(req)) return next();
+      throw Object.assign(new Error('A scalar userId is required'), {
+        statusCode: 400,
+        code: 'invalid_session_user_id',
+      });
+    }
+    const normalizedUserId = normalizeUserId(userId);
+    const isExclusiveClaim = req.method === 'POST' && req.path === '/tabs' && req.body?.exclusiveSession === true;
+    const isSessionDelete = req.method === 'DELETE'
+      && /^\/sessions\/[^/]+(?:\/storage_state)?$/.test(req.path);
+    if (!isExclusiveClaim) authorizeSessionOwner(req, normalizedUserId);
+    const finishOperation = isSessionDelete
+      ? await sessionOperations.beginDelete(normalizedUserId)
+      : sessionOperations.enter(normalizedUserId);
+    if (!attachOperationCompletion(res, finishOperation)) return;
+    req.completeSessionOperation = finishOperation;
+    sessionOperationContext.run({ userId: normalizedUserId }, next);
+  } catch (err) {
+    handleRouteError(err, req, res);
+  }
+});
+
+/**
+ * @openapi
+ * /capabilities:
+ *   get:
+ *     tags: [System]
+ *     summary: Read control-plane security capabilities
+ *     description: Side-effect-free readback. When controlAccessKeyEnforced is true, this response was gated by CAMOFOX_ACCESS_KEY.
+ *     responses:
+ *       200:
+ *         description: Control-plane capability state.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [controlAccessKeyEnforced, atomicSessionOwnership]
+ *               properties:
+ *                 controlAccessKeyEnforced:
+ *                   type: boolean
+ *                 atomicSessionOwnership:
+ *                   type: object
+ *                   required: [version, ownerTokenRetained, ownerTokenHeader]
+ *                   properties:
+ *                     version:
+ *                       type: integer
+ *                     ownerTokenRetained:
+ *                       type: boolean
+ *                     ownerTokenHeader:
+ *                       type: string
+ *                       example: X-Camofox-Session-Owner
+ *       401:
+ *         description: Access key missing or invalid.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+app.get('/capabilities', (_req, res) => {
+  res.json({
+    controlAccessKeyEnforced: Boolean(CONFIG.accessKey),
+    atomicSessionOwnership: {
+      version: 1,
+      ownerTokenRetained: false,
+      ownerTokenHeader: 'X-Camofox-Session-Owner',
+    },
+  });
+});
 
 const ALLOWED_URL_SCHEMES = ['http:', 'https:'];
 
@@ -568,12 +741,17 @@ async function withTabLock(tabId, operation, timeoutMs = HANDLER_TIMEOUT_MS) {
 }
 
 function withTimeout(promise, ms, label) {
+  const operationUserId = sessionOperationContext.getStore()?.userId;
+  const trackedPromise = operationUserId
+    ? trackOperationPromise(sessionOperations, operationUserId, promise)
+    : promise;
+  let timer;
   return Promise.race([
-    promise,
-    new Promise((_, reject) =>
-      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
-    )
-  ]);
+    trackedPromise,
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    }),
+  ]).finally(() => clearTimeout(timer));
 }
 
 function requestTimeoutMs(baseMs = HANDLER_TIMEOUT_MS) {
@@ -656,6 +834,7 @@ if (proxyPool) {
 const BROWSER_IDLE_TIMEOUT_MS = CONFIG.browserIdleTimeoutMs;
 let browserIdleTimer = null;
 let browserLaunchPromise = null;
+const browserLaunchGeneration = createBrowserLaunchGeneration();
 let browserWarmRetryTimer = null;
 
 // Tracks why the browser was last stopped. Intentional reasons (idle_shutdown, admin_stop)
@@ -667,9 +846,15 @@ function scheduleBrowserIdleShutdown() {
   if (browserIdleTimer || sessions.size > 0 || !browser) return;
   browserIdleTimer = setTimeout(async () => {
     browserIdleTimer = null;
-    if (sessions.size === 0 && browser) {
-      log('info', 'browser idle shutdown (no sessions)');
-      await closeBrowserFully('idle_shutdown');
+    if (sessions.size === 0 && browser?.isConnected()) {
+      log('info', 'browser idle timeout reached, shutting down');
+      await runBackgroundBrowserOperation(
+        () => closeBrowserFully('idle_shutdown'),
+        (error) => {
+          log('error', 'browser idle shutdown failed', { error: safeError(error) });
+          if (sessions.size === 0 && browser?.isConnected()) scheduleBrowserIdleShutdown();
+        },
+      );
     }
   }, BROWSER_IDLE_TIMEOUT_MS);
 }
@@ -752,7 +937,6 @@ async function restartBrowser(reason) {
     await closeAllSessions(`browser_restart:${reason}`, { clearDownloads: true, clearLocks: true });
     await closeBrowserFully(`browser_restart:${reason}`);
     pluginEvents.emit('browser:closed', { reason });
-    browserLaunchPromise = null;
     await ensureBrowser();
     healthState.consecutiveNavFailures = 0;
     healthState.lastSuccessfulNav = Date.now();
@@ -862,7 +1046,12 @@ function attachBrowserCleanup(candidateBrowser, localVirtualDisplay) {
  */
 async function closeBrowserFully(reason) {
   if (_browserClosePromise) return _browserClosePromise;
-  _browserClosePromise = _closeBrowserFullyImpl(reason);
+  const launchToDrain = browserLaunchPromise;
+  browserLaunchGeneration.invalidate();
+  _browserClosePromise = closeAndDrainBrowserLaunch(
+    () => _closeBrowserFullyImpl(reason),
+    launchToDrain,
+  );
   try {
     return await _browserClosePromise;
   } finally {
@@ -1001,7 +1190,7 @@ function _countActiveHandles() {
   try { return process._getActiveHandles().length; } catch { return null; }
 }
 
-async function launchBrowserInstance() {
+async function launchBrowserInstance(generation) {
   const hostOS = getHostOS();
   const maxAttempts = proxyPool?.launchRetries ?? 1;
   let lastError = null;
@@ -1094,6 +1283,7 @@ async function launchBrowserInstance() {
         }
       }
 
+      browserLaunchGeneration.assertCurrent(generation);
       virtualDisplay = localVirtualDisplay;
       browserLaunchProxy = launchProxy;
       _lastBrowserPid = candidateBrowser.process?.()?.pid ?? null;
@@ -1122,6 +1312,7 @@ async function launchBrowserInstance() {
       });
       await candidateBrowser?.close().catch(() => {});
       if (localVirtualDisplay) localVirtualDisplay.kill();
+      if (err.code === 'browser_launch_superseded') throw err;
     }
   }
 
@@ -1142,13 +1333,17 @@ async function ensureBrowser() {
     await closeBrowserFully('browser_disconnected');
   }
   if (browser) return browser;
-  if (browserLaunchPromise) return browserLaunchPromise;
   const launchTimeoutMs = proxyPool?.launchTimeoutMs ?? 60000;
-  browserLaunchPromise = Promise.race([
-    launchBrowserInstance(),
-    new Promise((_, reject) => setTimeout(() => reject(new Error(`Browser launch timeout (${Math.round(launchTimeoutMs / 1000)}s)`)), launchTimeoutMs)),
-  ]).finally(() => { browserLaunchPromise = null; });
-  return browserLaunchPromise;
+  if (!browserLaunchPromise) {
+    const generation = browserLaunchGeneration.begin();
+    const task = launchBrowserInstance(generation);
+    browserLaunchPromise = task;
+    const clear = () => {
+      if (browserLaunchPromise === task) browserLaunchPromise = null;
+    };
+    task.then(clear, clear);
+  }
+  return waitForLaunchWithTimeout(browserLaunchPromise, launchTimeoutMs);
 }
 
 // Helper to normalize userId to string (JSON body may parse as number)
@@ -1157,6 +1352,11 @@ function normalizeUserId(userId) {
 }
 
 const sessionCreations = new Map();
+const scheduledSessionDestroys = new Map();
+sessionOwnership = createSessionOwnershipRegistry({
+  ttlMs: SESSION_TIMEOUT_MS,
+  maxClaims: MAX_SESSIONS,
+});
 
 function clearSessionLocks(session) {
   if (!session?.tabGroups) return;
@@ -1180,6 +1380,7 @@ async function closeSession(userId, session, {
   if (!session) return;
 
   const key = normalizeUserId(userId);
+  session._closing = true;
 
   // Drain locks BEFORE closing context — queued operations get clean "Tab destroyed"
   // (410) instead of messy "Target page closed" (500) errors.
@@ -1191,19 +1392,33 @@ async function closeSession(userId, session, {
     await clearSessionDownloads(session).catch(() => {});
   }
 
-  await pluginEvents.emitAsync('session:destroying', { userId: key, reason });
-  if (session.tracePath) {
-    try {
-      await session.context.tracing.stop({ path: session.tracePath });
-      log('info', 'tracing saved', { userId: key, path: session.tracePath });
-    } catch (err) {
-      log('warn', 'tracing.stop failed', { userId: key, error: err.message });
+  try {
+    await pluginEvents.emitAsync('session:destroying', {
+      userId: key,
+      reason,
+      session,
+      context: session.context,
+    });
+    if (session.tracePath) {
+      try {
+        await session.context.tracing.stop({ path: session.tracePath });
+        log('info', 'tracing saved', { userId: key, path: session.tracePath });
+      } catch (err) {
+        log('warn', 'tracing.stop failed', { userId: key, error: err.message });
+      }
     }
+    await closeContextVerified(session.context);
+  } catch (error) {
+    session._closing = false;
+    throw error;
   }
-
-  await session.context.close().catch(() => {});
-  sessions.delete(key);
-  await pluginEvents.emitAsync('session:destroyed', { userId: key, reason });
+  deleteSessionIfCurrent(sessions, key, session);
+  await pluginEvents.emitAsync('session:destroyed', {
+    userId: key,
+    reason,
+    session,
+    context: session.context,
+  });
 
   refreshActiveTabsGauge();
 }
@@ -1222,8 +1437,10 @@ async function getSession(userId, { trace = false } = {}) {
   // Check if existing session's context is still alive
   if (session) {
     if (session._closing) {
-      // Session is being torn down by reaper/expiry -- treat as dead
-      session = null;
+      throw Object.assign(new Error('Session deletion is already in flight'), {
+        statusCode: 409,
+        code: 'session_deletion_inflight',
+      });
     } else {
       try {
         // Lightweight probe: pages() is synchronous-ish and throws if context is dead
@@ -1364,7 +1581,7 @@ function handleRouteError(err, req, res, extraFields = {}) {
   const pageUrl = safePageUrl(foundForContext?.tabState?.page);
   const sentryContext = {
     route: req.route?.path,
-    path: req.originalUrl,
+    path: req.path,
     method: req.method,
     action,
     reqId: req.reqId,
@@ -1388,7 +1605,7 @@ function handleRouteError(err, req, res, extraFields = {}) {
     return res.status(410).json({ error: 'Page crashed. Open a new tab.', code: 'page_crashed', retryable: true, recovery: 'create_new_tab', ...extraFields });
   }
   if (userId && isDeadContextError(err)) {
-    destroySession(userId).catch(() => {});
+    scheduleSessionDestroy(userId, 'dead_context_error');
   }
   // Proxy errors mean the session is dead -- rotate at context level.
   // Destroy the user's session so the next request gets a fresh context with a new proxy.
@@ -1397,7 +1614,7 @@ function handleRouteError(err, req, res, extraFields = {}) {
       action, userId, error: err.message,
     });
     browserRestartsTotal.labels('proxy_error').inc();
-    destroySession(userId).catch(() => {});
+    scheduleSessionDestroy(userId, 'proxy_error');
   }
   // Navigation-related timeouts can poison the proxy session (e.g., Cloudflare holding
   // the connection open for 30s). The browser context shares a single proxy session, so
@@ -1409,7 +1626,7 @@ function handleRouteError(err, req, res, extraFields = {}) {
       action, userId, error: err.message,
     });
     browserRestartsTotal.labels('navigation_timeout').inc();
-    destroySession(userId).catch(() => {});
+    scheduleSessionDestroy(userId, 'navigation_timeout');
   }
   // Track consecutive timeouts per tab and auto-destroy stuck tabs
   // (for non-navigation timeouts like type, scroll that don't poison the proxy)
@@ -1547,9 +1764,40 @@ async function destroySession(userId, { reason = 'destroy_session' } = {}) {
   const session = sessions.get(key);
   if (!session) return false;
   log('warn', 'destroying session', { userId: key, reason });
-  sessions.delete(key);
+  session._closing = true;
   await closeSession(key, session, { reason, clearDownloads: true, clearLocks: true });
   return true;
+}
+
+async function destroySessionCoordinated(userId, reason, {
+  expectedSession = null,
+  shouldDestroy = null,
+} = {}) {
+  const key = normalizeUserId(userId);
+  return runCoordinatedDeletion(sessionOperations, key, async () => {
+    const current = sessions.get(key);
+    if (!current) return false;
+    if (expectedSession && current !== expectedSession) return false;
+    if (shouldDestroy && !shouldDestroy(current)) return false;
+    return await destroySession(key, { reason });
+  });
+}
+
+function scheduleSessionDestroy(userId, reason, options = {}) {
+  const key = normalizeUserId(userId);
+  if (scheduledSessionDestroys.has(key)) return;
+  const pending = destroySessionCoordinated(key, reason, options)
+    .catch(error => log('warn', 'scheduled session destroy failed', {
+      userId: key,
+      reason,
+      error: error.message,
+    }))
+    .finally(() => {
+      if (scheduledSessionDestroys.get(key) === pending) {
+        scheduledSessionDestroys.delete(key);
+      }
+    });
+  scheduledSessionDestroys.set(key, pending);
 }
 
 function findTab(session, tabId) {
@@ -1661,6 +1909,8 @@ async function camofoxPressureCleanup(options = {}) {
     sessionTabCounts.set(userId, count);
   }
   const preserved = {
+    claimed: 0,
+    active_operations: 0,
     locked: 0,
     session_minimum: 0,
     first_observation: 0,
@@ -1670,6 +1920,14 @@ async function camofoxPressureCleanup(options = {}) {
   const candidates = [];
 
   for (const [userId, session] of sessions) {
+    if (sessionOwnership.hasClaim(userId)) {
+      preserved.claimed += sessionTabCounts.get(userId) || 1;
+      continue;
+    }
+    if (sessionOperations.isActive(userId)) {
+      preserved.active_operations += sessionTabCounts.get(userId) || 1;
+      continue;
+    }
     for (const [listItemId, group] of session.tabGroups) {
       for (const [tabId, tabState] of group) {
         const lockState = pressureLockState(tabId);
@@ -1730,35 +1988,61 @@ async function camofoxPressureCleanup(options = {}) {
 
   if (!dryRun) {
     for (const item of selected) {
-      if (!item.group.has(item.tabId)) continue;
-      if ((sessionTabCounts.get(item.userId) || 0) <= minTabsPerSession) continue;
-      const lockState = pressureLockState(item.tabId);
-      if (lockState.active || lockState.queued > 0) continue;
-      if (item.tabState.navigateAbort) item.tabState.navigateAbort.abort();
-      await clearTabDownloads(item.tabState).catch(() => {});
-      await safePageClose(item.tabState.page);
-      item.group.delete(item.tabId);
-      sessionTabCounts.set(item.userId, Math.max(0, (sessionTabCounts.get(item.userId) || 0) - 1));
-      const lock = tabLocks.get(item.tabId);
-      if (lock) {
-        lock.drain();
-        tabLocks.delete(item.tabId);
+      let closedItem;
+      try {
+        closedItem = await runCoordinatedDeletion(sessionOperations, item.userId, async () => {
+          const current = sessions.get(item.userId);
+          if (current !== item.session || sessionOwnership.hasClaim(item.userId)) return null;
+          const currentGroup = current.tabGroups.get(item.listItemId);
+          if (currentGroup !== item.group || currentGroup.get(item.tabId) !== item.tabState) return null;
+          const currentTabCount = Array.from(current.tabGroups.values())
+            .reduce((count, group) => count + group.size, 0);
+          if (currentTabCount <= minTabsPerSession) return null;
+          if (!isPressureTabStillEligible(item.tabState, {
+            selectedToolCalls: item.toolCalls,
+            minIdleMs,
+          })) return null;
+          const lockState = pressureLockState(item.tabId);
+          if (lockState.active || lockState.queued > 0) return null;
+          if (item.tabState.navigateAbort) item.tabState.navigateAbort.abort();
+          await clearTabDownloads(item.tabState).catch(() => {});
+          await safePageClose(item.tabState.page);
+          currentGroup.delete(item.tabId);
+          sessionTabCounts.set(item.userId, Math.max(0, currentTabCount - 1));
+          const lock = tabLocks.get(item.tabId);
+          if (lock) {
+            lock.drain();
+            tabLocks.delete(item.tabId);
+          }
+          tabsReapedTotal.inc();
+          pluginEvents.emit('tab:reaped', { userId: item.userId, tabId: item.tabId, listItemId: item.listItemId, reason: 'pressure_cleanup', idleMs: item.idleMs });
+          log('info', 'tab reaped (pressure cleanup)', { userId: item.userId, tabId: item.tabId, listItemId: item.listItemId, idleMs: item.idleMs, toolCalls: item.toolCalls });
+          return { session: pressureHash(item.userId), tab: pressureHash(item.tabId), group: pressureHash(item.listItemId), idleMs: item.idleMs, toolCalls: item.toolCalls };
+        });
+      } catch (error) {
+        if (error?.code !== 'session_deletion_inflight') throw error;
+        preserved.active_operations += 1;
+        continue;
       }
-      tabsReapedTotal.inc();
-      pluginEvents.emit('tab:reaped', { userId: item.userId, tabId: item.tabId, listItemId: item.listItemId, reason: 'pressure_cleanup', idleMs: item.idleMs });
-      log('info', 'tab reaped (pressure cleanup)', { userId: item.userId, tabId: item.tabId, listItemId: item.listItemId, idleMs: item.idleMs, toolCalls: item.toolCalls });
-      closed.push({ session: pressureHash(item.userId), tab: pressureHash(item.tabId), group: pressureHash(item.listItemId), idleMs: item.idleMs, toolCalls: item.toolCalls });
+      if (closedItem) closed.push(closedItem);
     }
 
     for (const [userId, session] of Array.from(sessions.entries())) {
+      if (sessionOwnership.hasClaim(userId)) continue;
       for (const [listItemId, group] of Array.from(session.tabGroups.entries())) {
         if (group.size === 0) session.tabGroups.delete(listItemId);
       }
       if (closeEmptySessions && session.tabGroups.size === 0) {
-        session._closing = true;
-        await closeSession(userId, session, { reason: 'pressure_cleanup_empty_session', clearDownloads: true, clearLocks: true });
-        sessionsExpiredTotal.inc();
-        log('info', 'session closed (pressure cleanup empty)', { userId });
+        if (sessionOperations.isActive(userId)) continue;
+        const destroyed = await destroySessionCoordinated(
+          userId,
+          'pressure_cleanup_empty_session',
+          { expectedSession: session, shouldDestroy: current => current.tabGroups.size === 0 },
+        );
+        if (destroyed) {
+          sessionsExpiredTotal.inc();
+          log('info', 'session closed (pressure cleanup empty)', { userId });
+        }
       }
     }
 
@@ -2668,6 +2952,17 @@ app.post('/pressure/cleanup', async (req, res) => {
  *               trace:
  *                 type: boolean
  *                 description: Enable Playwright tracing for this session (screenshots, DOM snapshots, network). Must be set on first tab creation; cannot be added to an existing session.
+ *               exclusiveSession:
+ *                 type: boolean
+ *                 default: false
+ *                 description: Atomically claim a previously absent, non-inflight session. Requires sessionOwnerToken.
+ *               sessionOwnerToken:
+ *                 type: string
+ *                 minLength: 32
+ *                 maxLength: 256
+ *                 pattern: '^[A-Za-z0-9_-]+$'
+ *                 writeOnly: true
+ *                 description: Caller-generated opaque token used to authorize reuse and exact cleanup of an exclusively claimed session.
  *     responses:
  *       200:
  *         description: Tab created.
@@ -2680,8 +2975,17 @@ app.post('/pressure/cleanup', async (req, res) => {
  *                   type: string
  *                 url:
  *                   type: string
+ *                 sessionOwned:
+ *                   type: boolean
+ *                   description: True when the session is protected by an active ownership claim.
  *       400:
- *         description: Missing required fields.
+ *         description: Missing or invalid request fields, including ownership inputs.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       403:
+ *         description: Session owner token mismatch.
  *         content:
  *           application/json:
  *             schema:
@@ -2693,7 +2997,7 @@ app.post('/pressure/cleanup', async (req, res) => {
  *             schema:
  *               $ref: '#/components/schemas/Error'
  *       409:
- *         description: Cannot enable tracing on an existing session.
+ *         description: Session ownership conflict, or tracing cannot be enabled on an existing session.
  *         content:
  *           application/json:
  *             schema:
@@ -2701,11 +3005,21 @@ app.post('/pressure/cleanup', async (req, res) => {
  */
 app.post('/tabs', async (req, res) => {
   try {
-    const { userId, sessionKey, listItemId, url, trace } = req.body;
+    const {
+      userId, sessionKey, listItemId, url, trace,
+      exclusiveSession = false,
+    } = req.body;
+    const sessionOwnerToken = readSessionOwnerToken(req);
     // Accept both sessionKey (preferred) and listItemId (legacy) for backward compatibility
     const resolvedSessionKey = sessionKey || listItemId;
     if (!userId || !resolvedSessionKey) {
       return res.status(400).json({ error: 'userId and sessionKey required' });
+    }
+    if (typeof exclusiveSession !== 'boolean') {
+      throw Object.assign(new Error('exclusiveSession must be a boolean'), {
+        statusCode: 400,
+        code: 'invalid_exclusive_session',
+      });
     }
 
     // Session overflow redirect (Fly.io only) — if this machine is above its
@@ -2725,7 +3039,16 @@ app.post('/tabs', async (req, res) => {
     }
 
     const result = await withTimeout((async () => {
-      const existing = sessions.get(normalizeUserId(userId));
+      const normalizedUserId = normalizeUserId(userId);
+      if (exclusiveSession) {
+        sessionOwnership.claim(normalizedUserId, sessionOwnerToken, {
+          sessionExists: sessions.has(normalizedUserId),
+          creationInflight: sessionCreations.has(normalizedUserId),
+        });
+      } else {
+        sessionOwnership.authorize(normalizedUserId, sessionOwnerToken);
+      }
+      const existing = sessions.get(normalizedUserId);
       if (trace && existing && !existing.tracePath) {
         throw Object.assign(
           new Error('trace must be set on session creation. DELETE /sessions/:userId first to restart with tracing.'),
@@ -2793,7 +3116,11 @@ app.post('/tabs', async (req, res) => {
       
       pluginEvents.emit('tab:created', { userId, tabId, page, url: page.url() });
       log('info', 'tab created', { reqId: req.reqId, tabId, userId, sessionKey: resolvedSessionKey, url: page.url() });
-      return { tabId, url: page.url() };
+      return {
+        tabId,
+        url: page.url(),
+        sessionOwned: sessionOwnership.hasClaim(normalizedUserId),
+      };
     })(), requestTimeoutMs(), 'tab create');
 
     res.json(result);
@@ -4999,6 +5326,7 @@ app.get('/sessions/:userId/traces/:filename', authMiddleware(), async (req, res)
     res.setHeader('Content-Type', 'application/zip');
     res.setHeader('Content-Length', String(st.size));
     const stream = fs.createReadStream(full);
+    stream.once('close', () => req.completeSessionOperation?.());
     stream.on('error', (err) => {
       if (!res.headersSent) res.status(404).json({ error: 'not found' });
       else res.destroy();
@@ -5100,6 +5428,20 @@ app.delete('/sessions/:userId/traces/:filename', authMiddleware(), async (req, r
  *         required: true
  *         schema:
  *           type: string
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               sessionOwnerToken:
+ *                 type: string
+ *                 minLength: 32
+ *                 maxLength: 256
+ *                 pattern: '^[A-Za-z0-9_-]+$'
+ *                 writeOnly: true
+ *                 description: Required only when the target session has an active exclusive ownership claim.
  *     responses:
  *       200:
  *         description: Session destroyed.
@@ -5112,8 +5454,29 @@ app.delete('/sessions/:userId/traces/:filename', authMiddleware(), async (req, r
  *                   type: boolean
  *                 closed:
  *                   type: integer
+ *                 claimReleased:
+ *                   type: boolean
+ *                   description: True when an exclusive ownership claim was released.
+ *       400:
+ *         description: Invalid or conflicting session owner token.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       403:
+ *         description: Session owner token mismatch.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  *       404:
  *         description: Session not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       409:
+ *         description: Session creation is still in flight or deletion is already in progress; retry after the active lifecycle operation settles.
  *         content:
  *           application/json:
  *             schema:
@@ -5122,13 +5485,28 @@ app.delete('/sessions/:userId/traces/:filename', authMiddleware(), async (req, r
 app.delete('/sessions/:userId', async (req, res) => {
   try {
     const userId = normalizeUserId(req.params.userId);
+    const ownerToken = readSessionOwnerToken(req);
+    const hadClaim = sessionOwnership.prepareRelease(
+      userId,
+      ownerToken,
+      { creationInflight: sessionCreations.has(userId) },
+    );
     const session = sessions.get(userId);
     if (session) {
       await closeSession(userId, session, { reason: 'api_delete_session', clearDownloads: true, clearLocks: true });
       log('info', 'session closed', { userId });
     }
+    if (sessionCreations.has(userId) || sessions.has(userId)) {
+      throw Object.assign(new Error('Session creation is still in flight'), {
+        statusCode: 409,
+        code: 'session_creation_inflight',
+      });
+    }
+    const claimReleased = hadClaim
+      ? sessionOwnership.release(userId, ownerToken)
+      : false;
     if (sessions.size === 0) scheduleBrowserIdleShutdown();
-    res.json({ ok: true });
+    res.json({ ok: true, claimReleased });
   } catch (err) {
     log('error', 'session close failed', { error: err.message });
     handleRouteError(err, req, res);
@@ -5139,14 +5517,24 @@ app.delete('/sessions/:userId', async (req, res) => {
 setInterval(() => {
   const now = Date.now();
   for (const [userId, session] of Array.from(sessions.entries())) {
+    if (sessionOwnership.hasClaim(userId)) continue;
     if (now - session.lastAccess > SESSION_TIMEOUT_MS) {
-      session._closing = true;
       const idleMs = now - session.lastAccess;
       sessionsExpiredTotal.inc();
       pluginEvents.emit('session:expired', { userId, idleMs });
-      closeSession(userId, session, { reason: 'session_timeout', clearDownloads: true, clearLocks: true }).catch(() => {});
+      scheduleSessionDestroy(userId, 'session_timeout', {
+        expectedSession: session,
+        shouldDestroy: current => Date.now() - current.lastAccess > SESSION_TIMEOUT_MS,
+      });
       log('info', 'session expired', { userId });
     }
+  }
+  const releasedClaims = sessionOwnership.purgeExpired(
+    userId => !sessions.has(userId) && !sessionCreations.has(userId)
+      && !sessionOperations.isActive(userId),
+  );
+  if (releasedClaims > 0) {
+    log('info', 'abandoned session ownership claims released', { count: releasedClaims });
   }
   // When all sessions gone, start idle timer to kill browser
   if (sessions.size === 0) {
@@ -5172,7 +5560,9 @@ if (FLY_MACHINE_ID) {
       let oldestKey = null;
       let oldestAccess = Infinity;
       for (const [key, session] of sessions) {
+        if (sessionOwnership.hasClaim(key)) continue;
         if (session._closing) continue;
+        if (scheduledSessionDestroys.has(key)) continue;
         if (session.lastAccess < oldestAccess) {
           oldestAccess = session.lastAccess;
           oldestKey = key;
@@ -5188,11 +5578,8 @@ if (FLY_MACHINE_ID) {
         idleMs,
         sessions: sessions.size,
       });
-      session._closing = true;
       sessionsExpiredTotal.inc();
-      closeSession(oldestKey, session, {
-        reason: 'memory_pressure', clearDownloads: true, clearLocks: true,
-      }).catch(() => {});
+      scheduleSessionDestroy(oldestKey, 'memory_pressure', { expectedSession: session });
       evicted++;
       // Re-check after marking session for closure
       freeMem = os.freemem();
@@ -5205,6 +5592,8 @@ if (FLY_MACHINE_ID) {
 setInterval(() => {
   const now = Date.now();
   for (const [userId, session] of sessions) {
+    if (sessionOwnership.hasClaim(userId)) continue;
+    if (sessionOperations.isActive(userId)) continue;
     for (const [listItemId, group] of session.tabGroups) {
       for (const [tabId, tabState] of group) {
         if (!tabState._lastReaperCheck) {
@@ -5234,9 +5623,11 @@ setInterval(() => {
     }
     // Clean up sessions with zero tabs remaining -- free browser context memory
     if (session.tabGroups.size === 0) {
-      session._closing = true;
       log('info', 'session empty after tab reaper, closing', { userId });
-      closeSession(userId, session, { reason: 'tab_reaper_empty_session', clearDownloads: true, clearLocks: true }).catch(() => {});
+      scheduleSessionDestroy(userId, 'tab_reaper_empty_session', {
+        expectedSession: session,
+        shouldDestroy: current => current.tabGroups.size === 0,
+      });
       sessionsExpiredTotal.inc();
     }
   }
@@ -5248,8 +5639,10 @@ setInterval(() => {
 // pages starve Firefox of DOM threads and eventually block new tab creation.
 setInterval(() => {
   let reaped = 0;
-  for (const session of sessions.values()) {
+  for (const [userId, session] of sessions) {
+    if (sessionOwnership.hasClaim(userId)) continue;
     if (session._closing) continue;
+    if (sessionOperations.isActive(userId)) continue;
     let contextPages;
     try {
       contextPages = session.context.pages();
@@ -5369,6 +5762,7 @@ app.get('/', (req, res) => {
  *     parameters:
  *       - name: userId
  *         in: query
+ *         required: true
  *         schema:
  *           type: string
  *         description: Filter by session owner.
@@ -5400,8 +5794,14 @@ app.get('/', (req, res) => {
  */
 app.get('/tabs', async (req, res) => {
   try {
-    const userId = req.query.userId;
-    const session = sessions.get(normalizeUserId(userId));
+    const userId = readRequestUserId(req);
+    if (userId === undefined) {
+      throw Object.assign(new Error('A scalar userId is required'), {
+        statusCode: 400,
+        code: 'invalid_session_user_id',
+      });
+    }
+    const session = sessions.get(userId);
     
     if (!session) {
       return res.json({ running: true, tabs: [] });
@@ -5586,7 +5986,7 @@ app.post('/start', async (req, res) => {
  *     summary: Stop browser
  *     description: Stops the browser and closes all sessions. Requires x-admin-key header.
  *     security:
- *       - BearerAuth: []
+ *       - AdminKey: []
  *     responses:
  *       200:
  *         description: Browser stopped.
@@ -6229,6 +6629,8 @@ const pluginCtx = {
   ensureBrowser,
   getSession,
   destroySession,
+  destroySessionCoordinated,
+  enterInternalSessionOperation: userId => sessionOperations.enter(normalizeUserId(userId)),
   closeSession,
   withUserLimit,
   safePageClose,

--- a/tests/e2e/capabilities.test.js
+++ b/tests/e2e/capabilities.test.js
@@ -1,0 +1,44 @@
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+
+const ACCESS_KEY = 'access_0123456789abcdefghijklmnopqrstuvwxyz';
+
+async function getCapabilities(serverUrl, token) {
+  const response = await fetch(`${serverUrl}/capabilities`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    redirect: 'manual',
+  });
+  const body = await response.json();
+  return { status: response.status, body };
+}
+
+describe('control capability readback', () => {
+  let serverUrl;
+
+  beforeAll(async () => {
+    await startServer(0, { CAMOFOX_ACCESS_KEY: ACCESS_KEY });
+    serverUrl = getServerUrl();
+  }, 120000);
+
+  afterAll(async () => {
+    await stopServer();
+  }, 30000);
+
+  test('proves access-key enforcement only after successful authentication', async () => {
+    await expect(getCapabilities(serverUrl)).resolves.toMatchObject({ status: 401 });
+    await expect(getCapabilities(serverUrl, `${ACCESS_KEY}x`)).resolves.toMatchObject({ status: 401 });
+
+    const result = await getCapabilities(serverUrl, ACCESS_KEY);
+    expect(result).toEqual({
+      status: 200,
+      body: {
+        controlAccessKeyEnforced: true,
+        atomicSessionOwnership: {
+          version: 1,
+          ownerTokenRetained: false,
+          ownerTokenHeader: 'X-Camofox-Session-Owner',
+        },
+      },
+    });
+    expect(JSON.stringify(result.body)).not.toContain(ACCESS_KEY);
+  });
+});

--- a/tests/e2e/sessionOwnership.test.js
+++ b/tests/e2e/sessionOwnership.test.js
@@ -1,0 +1,481 @@
+import { startServer, stopServer, getServerUrl } from '../helpers/startServer.js';
+import { startTestSite, stopTestSite, getTestSiteUrl } from '../helpers/testSite.js';
+import { createClient } from '../helpers/client.js';
+
+const OWNER_A = 'owner_A-0123456789abcdefghijklmnopqrstuvwxyz';
+const OWNER_B = 'owner_B-0123456789abcdefghijklmnopqrstuvwxyz';
+
+describe('exclusive session ownership API', () => {
+  let serverUrl;
+  let testSiteUrl;
+
+  beforeAll(async () => {
+    await startServer(0, { SESSION_TIMEOUT_MS: '30000' });
+    serverUrl = getServerUrl();
+    await startTestSite();
+    testSiteUrl = getTestSiteUrl();
+  }, 120000);
+
+  afterAll(async () => {
+    await stopTestSite();
+    await stopServer();
+  }, 30000);
+
+  test('claims an absent session atomically and protects reuse and cleanup', async () => {
+    const client = createClient(serverUrl);
+    let claimed = false;
+    try {
+      const first = await client.request('POST', '/tabs', {
+        userId: client.userId,
+        sessionKey: client.sessionKey,
+        url: `${testSiteUrl}/pageA`,
+        exclusiveSession: true,
+        sessionOwnerToken: OWNER_A,
+      });
+      claimed = true;
+
+      expect(first.tabId).toBeDefined();
+      expect(first.sessionOwned).toBe(true);
+
+      await expect(client.request(
+        'GET',
+        `/tabs/${first.tabId}/snapshot?userId=${client.userId}`,
+      )).rejects.toMatchObject({
+        status: 403,
+        data: { code: 'session_owner_mismatch' },
+      });
+      const ownedSnapshot = await client.request(
+        'GET',
+        `/tabs/${first.tabId}/snapshot?userId=${client.userId}`,
+        null,
+        { headers: { 'X-Camofox-Session-Owner': OWNER_A } },
+      );
+      expect(ownedSnapshot.url).toBe(`${testSiteUrl}/pageA`);
+
+      await expect(client.request(
+        'DELETE',
+        `/tabs/${first.tabId}?userId=${client.userId}`,
+        { userId: 'unclaimed-decoy-user' },
+      )).rejects.toMatchObject({
+        status: 400,
+        data: { code: 'conflicting_session_user_id' },
+      });
+      const snapshotAfterRejectedDelete = await client.request(
+        'GET',
+        `/tabs/${first.tabId}/snapshot?userId=${client.userId}`,
+        null,
+        { headers: { 'X-Camofox-Session-Owner': OWNER_A } },
+      );
+      expect(snapshotAfterRejectedDelete.url).toBe(`${testSiteUrl}/pageA`);
+
+      await expect(client.request(
+        'GET',
+        `/sessions/${client.userId}/traces`,
+      )).rejects.toMatchObject({
+        status: 403,
+        data: { code: 'session_owner_mismatch' },
+      });
+      await expect(client.request(
+        'DELETE',
+        `/sessions/${client.userId}/storage_state`,
+      )).rejects.toMatchObject({
+        status: 403,
+        data: { code: 'session_owner_mismatch' },
+      });
+      await expect(client.request(
+        'GET',
+        `/sessions/${client.userId}/traces`,
+        null,
+        { headers: { 'X-Camofox-Session-Owner': OWNER_A } },
+      )).resolves.toBeDefined();
+
+      await expect(client.request('POST', '/tabs', {
+        userId: client.userId,
+        sessionKey: 'competing-group',
+        exclusiveSession: true,
+        sessionOwnerToken: OWNER_B,
+      })).rejects.toMatchObject({
+        status: 409,
+        data: { code: 'session_ownership_conflict' },
+      });
+
+      await expect(client.request('POST', '/tabs', {
+        userId: client.userId,
+        sessionKey: 'competing-group',
+      })).rejects.toMatchObject({
+        status: 403,
+        data: { code: 'session_owner_mismatch' },
+      });
+
+      await expect(client.request('POST', '/tabs/open', {
+        userId: client.userId,
+        listItemId: 'legacy-competing-group',
+        url: `${testSiteUrl}/pageA`,
+      })).rejects.toMatchObject({
+        status: 403,
+        data: { code: 'session_owner_mismatch' },
+      });
+
+      const legacyOwned = await client.request('POST', '/tabs/open', {
+        userId: client.userId,
+        listItemId: 'legacy-owned-group',
+        url: `${testSiteUrl}/pageA`,
+      }, {
+        headers: { 'X-Camofox-Session-Owner': OWNER_A },
+      });
+      expect(legacyOwned.tabId).toBeDefined();
+
+      const second = await client.request('POST', '/tabs', {
+        userId: client.userId,
+        sessionKey: 'owned-group',
+        sessionOwnerToken: OWNER_A,
+      });
+      expect(second.sessionOwned).toBe(true);
+
+      await expect(client.request('DELETE', `/sessions/${client.userId}`, {
+        sessionOwnerToken: OWNER_B,
+      })).rejects.toMatchObject({
+        status: 403,
+        data: { code: 'session_owner_mismatch' },
+      });
+
+      const activeOperation = client.request('POST', `/tabs/${first.tabId}/evaluate`, {
+        userId: client.userId,
+        expression: 'new Promise(resolve => setTimeout(() => resolve("operation-finished"), 300))',
+      }, {
+        headers: { 'X-Camofox-Session-Owner': OWNER_A },
+      });
+      await new Promise(resolve => setTimeout(resolve, 50));
+      let deletionSettled = false;
+      const serializedDelete = client.request(
+        'DELETE',
+        `/sessions/${client.userId}`,
+        null,
+        { headers: { 'X-Camofox-Session-Owner': OWNER_A } },
+      ).then(result => {
+        deletionSettled = true;
+        return result;
+      });
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(deletionSettled).toBe(false);
+      await expect(client.request(
+        'GET',
+        `/tabs/${first.tabId}/snapshot?userId=${client.userId}`,
+        null,
+        { headers: { 'X-Camofox-Session-Owner': OWNER_A } },
+      )).rejects.toMatchObject({
+        status: 409,
+        data: { code: 'session_deletion_inflight' },
+      });
+      await expect(activeOperation).resolves.toMatchObject({
+        ok: true,
+        result: 'operation-finished',
+      });
+      await expect(serializedDelete).resolves.toMatchObject({
+        ok: true,
+        claimReleased: true,
+      });
+      claimed = false;
+    } finally {
+      if (claimed) {
+        await client.request('DELETE', `/sessions/${client.userId}`, {
+          sessionOwnerToken: OWNER_A,
+        }).catch(() => {});
+      }
+    }
+  }, 120000);
+
+  test('rejects ambiguous exclusive-session and owner-token inputs', async () => {
+    const client = createClient(serverUrl);
+    for (const invalidUserId of ['undefined', 'null', '', ['array'], { object: true }]) {
+      await expect(client.request('POST', '/tabs', {
+        userId: invalidUserId,
+        sessionKey: 'invalid-user',
+        exclusiveSession: true,
+        sessionOwnerToken: OWNER_A,
+      })).rejects.toMatchObject({
+        status: 400,
+        data: { code: 'invalid_session_user_id' },
+      });
+    }
+
+    await expect(client.request('POST', '/tabs', {
+      userId: client.userId,
+      sessionKey: client.sessionKey,
+      exclusiveSession: 'true',
+      sessionOwnerToken: OWNER_A,
+    })).rejects.toMatchObject({
+      status: 400,
+      data: { code: 'invalid_exclusive_session' },
+    });
+
+    await expect(client.request('POST', '/tabs', {
+      userId: client.userId,
+      sessionKey: client.sessionKey,
+      sessionOwnerToken: 'short',
+    })).rejects.toMatchObject({
+      status: 400,
+      data: { code: 'invalid_session_owner_token' },
+    });
+
+    await expect(client.request('DELETE', `/sessions/${client.userId}`, {
+      sessionOwnerToken: 'short',
+    })).rejects.toMatchObject({
+      status: 400,
+      data: { code: 'invalid_session_owner_token' },
+    });
+
+    await expect(client.request(
+      'GET',
+      `/tabs?userId=${client.userId}&sessionOwnerToken=${OWNER_A}`,
+    )).rejects.toMatchObject({
+      status: 400,
+      data: { code: 'invalid_session_owner_token' },
+    });
+
+    await expect(client.request('POST', '/tabs', {
+      userId: client.userId,
+      sessionKey: client.sessionKey,
+      sessionOwnerToken: OWNER_A,
+    }, {
+      headers: { 'X-Camofox-Session-Owner': OWNER_B },
+    })).rejects.toMatchObject({
+      status: 400,
+      data: { code: 'invalid_session_owner_token' },
+    });
+
+    await expect(client.request('POST', '/tabs', {
+      userId: '__yt_transcript__',
+      sessionKey: 'reserved-internal-session',
+      exclusiveSession: true,
+      sessionOwnerToken: OWNER_A,
+    })).rejects.toMatchObject({
+      status: 400,
+      data: { code: 'reserved_session_user_id' },
+    });
+  });
+
+  test('rejects missing identities on every user-scoped tab control', async () => {
+    const client = createClient(serverUrl);
+    for (const [method, path] of [
+      ['GET', '/tabs'],
+      ['POST', '/tabs/missing/wait'],
+      ['POST', '/tabs/missing/type'],
+      ['POST', '/tabs/missing/press'],
+      ['POST', '/tabs/missing/scroll'],
+      ['POST', '/tabs/missing/back'],
+      ['POST', '/tabs/missing/forward'],
+      ['POST', '/tabs/missing/refresh'],
+      ['GET', '/tabs/missing/snapshot'],
+      ['GET', '/tabs/missing/links'],
+      ['GET', '/tabs/missing/downloads'],
+      ['GET', '/tabs/missing/images'],
+      ['GET', '/tabs/missing/screenshot'],
+      ['GET', '/tabs/missing/stats'],
+      ['POST', '/navigate'],
+      ['GET', '/snapshot'],
+      ['POST', '/act'],
+    ]) {
+      const body = method === 'GET' ? undefined : {};
+      await expect(client.request(method, path, body)).rejects.toMatchObject({
+        status: 400,
+        data: { code: 'invalid_session_user_id' },
+      });
+    }
+  });
+
+  test('rejects malformed identities on GET /tabs', async () => {
+    const client = createClient(serverUrl);
+    for (const path of [
+      '/tabs?userId=',
+      '/tabs?userId=undefined',
+      '/tabs?userId=null',
+      '/tabs?userId=first&userId=second',
+    ]) {
+      await expect(client.request('GET', path)).rejects.toMatchObject({
+        status: 400,
+        data: { code: 'invalid_session_user_id' },
+      });
+    }
+  });
+
+  test('retains the operation lease after a client disconnects', async () => {
+    const client = createClient(serverUrl);
+    let claimed = false;
+    try {
+      const created = await client.request('POST', '/tabs', {
+        userId: client.userId,
+        sessionKey: 'disconnect-lease',
+        url: `${testSiteUrl}/pageA`,
+        exclusiveSession: true,
+        sessionOwnerToken: OWNER_A,
+      });
+      claimed = true;
+
+      await expect(client.request(
+        'POST',
+        `/tabs/${created.tabId}/evaluate`,
+        {
+          userId: client.userId,
+          expression: 'new Promise(resolve => setTimeout(() => resolve("late-finish"), 400))',
+        },
+        {
+          timeout: 100,
+          headers: { 'X-Camofox-Session-Owner': OWNER_A },
+        },
+      )).rejects.toThrow('Request timeout');
+
+      let deletionSettled = false;
+      const deletion = client.request(
+        'DELETE',
+        `/sessions/${client.userId}`,
+        null,
+        { headers: { 'X-Camofox-Session-Owner': OWNER_A } },
+      ).then(result => {
+        deletionSettled = true;
+        return result;
+      });
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(deletionSettled).toBe(false);
+      await expect(deletion).resolves.toMatchObject({ ok: true, claimReleased: true });
+      claimed = false;
+    } finally {
+      if (claimed) {
+        await client.request(
+          'DELETE',
+          `/sessions/${client.userId}`,
+          null,
+          { headers: { 'X-Camofox-Session-Owner': OWNER_A } },
+        ).catch(() => {});
+      }
+    }
+  });
+
+  test('excludes claimed sessions from global pressure cleanup', async () => {
+    const client = createClient(serverUrl);
+    let claimed = false;
+    try {
+      const created = await client.request('POST', '/tabs', {
+        userId: client.userId,
+        sessionKey: 'pressure-protected',
+        url: `${testSiteUrl}/pageA`,
+        exclusiveSession: true,
+        sessionOwnerToken: OWNER_A,
+      });
+      claimed = true;
+      const cleanup = await client.request('POST', '/pressure/cleanup', {
+        dryRun: false,
+        minIdleMs: 0,
+        minTabsPerSession: 0,
+        maxTabsToClose: 100,
+        closeEmptySessions: true,
+      });
+      expect(cleanup.closed).toEqual([]);
+      expect(cleanup.preserved.claimed).toBeGreaterThanOrEqual(1);
+      await expect(client.request(
+        'GET',
+        `/tabs/${created.tabId}/snapshot?userId=${client.userId}`,
+        null,
+        { headers: { 'X-Camofox-Session-Owner': OWNER_A } },
+      )).resolves.toMatchObject({ url: `${testSiteUrl}/pageA` });
+    } finally {
+      if (claimed) {
+        await client.request(
+          'DELETE',
+          `/sessions/${client.userId}`,
+          null,
+          { headers: { 'X-Camofox-Session-Owner': OWNER_A } },
+        ).catch(() => {});
+      }
+    }
+  });
+
+  test('clears a deletion reservation when its waiting client disconnects', async () => {
+    const client = createClient(serverUrl);
+    let claimed = false;
+    try {
+      const created = await client.request('POST', '/tabs', {
+        userId: client.userId,
+        sessionKey: 'disconnect-delete',
+        url: `${testSiteUrl}/pageA`,
+        exclusiveSession: true,
+        sessionOwnerToken: OWNER_A,
+      });
+      claimed = true;
+      const activeOperation = client.request(
+        'POST',
+        `/tabs/${created.tabId}/evaluate`,
+        {
+          userId: client.userId,
+          expression: 'new Promise(resolve => setTimeout(() => resolve("operation-finished"), 400))',
+        },
+        { headers: { 'X-Camofox-Session-Owner': OWNER_A } },
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      await expect(client.request(
+        'DELETE',
+        `/sessions/${client.userId}`,
+        null,
+        {
+          timeout: 100,
+          headers: { 'X-Camofox-Session-Owner': OWNER_A },
+        },
+      )).rejects.toThrow('Request timeout');
+      await expect(activeOperation).resolves.toMatchObject({ result: 'operation-finished' });
+
+      await expect(client.request(
+        'GET',
+        `/tabs/${created.tabId}/snapshot?userId=${client.userId}`,
+        null,
+        { headers: { 'X-Camofox-Session-Owner': OWNER_A } },
+      )).resolves.toMatchObject({ url: `${testSiteUrl}/pageA` });
+      await expect(client.request(
+        'DELETE',
+        `/sessions/${client.userId}`,
+        null,
+        { headers: { 'X-Camofox-Session-Owner': OWNER_A } },
+      )).resolves.toMatchObject({ ok: true, claimReleased: true });
+      claimed = false;
+    } finally {
+      if (claimed) {
+        await client.request(
+          'DELETE',
+          `/sessions/${client.userId}`,
+          null,
+          { headers: { 'X-Camofox-Session-Owner': OWNER_A } },
+        ).catch(() => {});
+      }
+    }
+  });
+
+  test('allows exactly one winner for concurrent exclusive claims', async () => {
+    const client = createClient(serverUrl);
+    const bodies = [OWNER_A, OWNER_B].map((sessionOwnerToken) => ({
+      userId: client.userId,
+      sessionKey: client.sessionKey,
+      exclusiveSession: true,
+      sessionOwnerToken,
+    }));
+
+    const settled = await Promise.allSettled(
+      bodies.map((body) => client.request('POST', '/tabs', body)),
+    );
+    const winners = settled
+      .map((result, index) => ({ result, index }))
+      .filter(({ result }) => result.status === 'fulfilled');
+    const losers = settled.filter((result) => result.status === 'rejected');
+
+    expect(winners).toHaveLength(1);
+    expect(losers).toHaveLength(1);
+    expect(losers[0].reason).toMatchObject({
+      status: 409,
+      data: { code: 'session_ownership_conflict' },
+    });
+
+    const winningToken = bodies[winners[0].index].sessionOwnerToken;
+    await client.request('DELETE', `/sessions/${client.userId}`, {
+      sessionOwnerToken: winningToken,
+    });
+  }, 120000);
+});

--- a/tests/helpers/client.js
+++ b/tests/helpers/client.js
@@ -19,7 +19,7 @@ class BrowserClient {
     try {
       const fetchOptions = {
         method,
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
         signal: controller.signal
       };
       

--- a/tests/unit/browserLaunchLifecycle.test.js
+++ b/tests/unit/browserLaunchLifecycle.test.js
@@ -1,0 +1,81 @@
+import { jest } from '@jest/globals';
+import {
+  createBrowserLaunchGeneration,
+  closeAndDrainBrowserLaunch,
+  waitForLaunchWithTimeout,
+  runBackgroundBrowserOperation,
+} from '../../lib/browser-launch-lifecycle.js';
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('browser launch lifecycle', () => {
+  test('a timeout does not cancel or forget the underlying launch task', async () => {
+    jest.useFakeTimers();
+    const launch = deferred();
+    const caller = waitForLaunchWithTimeout(launch.promise, 10);
+    jest.advanceTimersByTime(10);
+    await expect(caller).rejects.toThrow('Browser launch timeout');
+
+    launch.resolve('browser');
+    await expect(launch.promise).resolves.toBe('browser');
+    jest.useRealTimers();
+  });
+
+  test('an invalidated launch cannot publish after stop or replacement', async () => {
+    const generation = createBrowserLaunchGeneration();
+    const first = generation.begin();
+    generation.invalidate();
+
+    expect(() => generation.assertCurrent(first)).toThrow(expect.objectContaining({
+      code: 'browser_launch_superseded',
+    }));
+
+    const replacement = generation.begin();
+    expect(() => generation.assertCurrent(replacement)).not.toThrow();
+    expect(() => generation.assertCurrent(first)).toThrow(expect.objectContaining({
+      code: 'browser_launch_superseded',
+    }));
+  });
+
+  test('drains an in-flight launch even when browser cleanup rejects', async () => {
+    const launch = deferred();
+    const closeError = new Error('process snapshot failed');
+    let settled = false;
+    const closing = closeAndDrainBrowserLaunch(
+      async () => { throw closeError; },
+      launch.promise,
+    ).finally(() => { settled = true; });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    launch.resolve('stale candidate disposed');
+    await expect(closing).rejects.toBe(closeError);
+    expect(settled).toBe(true);
+  });
+
+  test('background cleanup reports close failure without rejecting', async () => {
+    const error = new Error('process snapshot failed');
+    const onError = jest.fn();
+
+    await expect(runBackgroundBrowserOperation(
+      async () => { throw error; },
+      onError,
+    )).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+
+  test('background cleanup remains settled if failure reporting also throws', async () => {
+    await expect(runBackgroundBrowserOperation(
+      async () => { throw new Error('close failed'); },
+      () => { throw new Error('logger failed'); },
+    )).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/openapi.test.js
+++ b/tests/unit/openapi.test.js
@@ -13,19 +13,20 @@
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import swaggerJsdoc from 'swagger-jsdoc';
-import { swaggerDefinition } from '../../lib/openapi.js';
+import { buildOpenApiSpec } from '../../lib/openapi.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const serverPath = join(__dirname, '..', '..', 'server.js');
 const serverSrc = readFileSync(serverPath, 'utf8');
+const pluginSources = [
+  join(__dirname, '..', '..', 'plugins', 'persistence', 'index.js'),
+  join(__dirname, '..', '..', 'plugins', 'vnc', 'index.js'),
+  join(__dirname, '..', '..', 'plugins', 'youtube', 'index.js'),
+].map(path => readFileSync(path, 'utf8'));
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf8'));
 
-// Build spec from JSDoc in server.js
-const spec = swaggerJsdoc({
-  definition: swaggerDefinition,
-  apis: [serverPath],
-});
+// Build the same server + plugin route contract mounted at runtime.
+const spec = buildOpenApiSpec();
 
 /**
  * Extract all app.get/post/delete routes from server.js source.
@@ -42,6 +43,10 @@ function parseServerRoutes(source) {
 }
 
 const serverRoutes = parseServerRoutes(serverSrc);
+const runtimeRoutes = new Set([
+  ...serverRoutes,
+  ...pluginSources.flatMap(source => [...parseServerRoutes(source)]),
+]);
 
 describe('OpenAPI spec', () => {
   test('is valid OpenAPI 3.0.x shape', () => {
@@ -57,9 +62,9 @@ describe('OpenAPI spec', () => {
     expect(spec.info.version).toBe(pkg.version);
   });
 
-  test('every server.js route appears in the spec', () => {
+  test('every server and plugin route appears in the spec', () => {
     const missing = [];
-    for (const route of serverRoutes) {
+    for (const route of runtimeRoutes) {
       const [method, expressPath] = route.split(' ');
       const oaPath = expressPath.replace(/:(\w+)/g, '{$1}');
       const pathObj = spec.paths[oaPath];
@@ -70,14 +75,14 @@ describe('OpenAPI spec', () => {
     expect(missing).toEqual([]);
   });
 
-  test('no stale routes in spec that are not in server.js', () => {
+  test('no stale routes in spec that are not registered by server or plugins', () => {
     const stale = [];
     for (const [oaPath, methods] of Object.entries(spec.paths)) {
       for (const method of Object.keys(methods)) {
         if (method.startsWith('x-')) continue; // skip extensions
         const expressPath = oaPath.replace(/\{(\w+)\}/g, ':$1');
         const key = `${method.toUpperCase()} ${expressPath}`;
-        if (!serverRoutes.has(key)) {
+        if (!runtimeRoutes.has(key)) {
           stale.push(key);
         }
       }
@@ -85,16 +90,16 @@ describe('OpenAPI spec', () => {
     expect(stale).toEqual([]);
   });
 
-  test('spec covers at least 30 routes from server.js', () => {
-    expect(serverRoutes.size).toBeGreaterThanOrEqual(30);
+  test('spec covers at least 30 runtime routes', () => {
+    expect(runtimeRoutes.size).toBeGreaterThanOrEqual(30);
 
     let covered = 0;
-    for (const route of serverRoutes) {
+    for (const route of runtimeRoutes) {
       const [method, expressPath] = route.split(' ');
       const oaPath = expressPath.replace(/:(\w+)/g, '{$1}');
       if (spec.paths[oaPath]?.[method.toLowerCase()]) covered++;
     }
-    expect(covered).toBe(serverRoutes.size);
+    expect(covered).toBe(runtimeRoutes.size);
   });
 
   test('every operation has at least one response', () => {
@@ -137,6 +142,36 @@ describe('OpenAPI spec', () => {
     expect(createTab.requestBody.content['application/json']).toBeDefined();
   });
 
+  test('session ownership fields are documented for create and cleanup', () => {
+    const createSchema = spec.paths['/tabs'].post
+      .requestBody.content['application/json'].schema;
+    expect(createSchema.properties.exclusiveSession).toMatchObject({ type: 'boolean' });
+    expect(createSchema.properties.sessionOwnerToken).toMatchObject({
+      type: 'string',
+      minLength: 32,
+      maxLength: 256,
+      writeOnly: true,
+    });
+    expect(spec.paths['/capabilities'].get.responses['200']
+      .content['application/json'].schema.properties.atomicSessionOwnership
+      .properties.ownerTokenHeader).toMatchObject({
+      type: 'string',
+      example: 'X-Camofox-Session-Owner',
+    });
+    expect(spec.paths['/tabs'].post.responses['200']
+      .content['application/json'].schema.properties.sessionOwned).toMatchObject({
+      type: 'boolean',
+    });
+
+    const deleteOperation = spec.paths['/sessions/{userId}'].delete;
+    expect(deleteOperation.requestBody.content['application/json']
+      .schema.properties.sessionOwnerToken.writeOnly).toBe(true);
+    expect(deleteOperation.responses['200'].content['application/json']
+      .schema.properties.claimReleased).toMatchObject({ type: 'boolean' });
+    expect(deleteOperation.responses['400'].description).toContain('Invalid or conflicting');
+    expect(deleteOperation.responses['409'].description).toContain('creation is still in flight');
+  });
+
   test('legacy routes are marked deprecated', () => {
     const legacyPaths = {
       '/act': 'post',
@@ -169,10 +204,52 @@ describe('OpenAPI spec', () => {
     expect(spec.components.securitySchemes.BearerAuth.scheme).toBe('bearer');
   });
 
+  test('POST /stop documents its runtime x-admin-key authentication', () => {
+    const scheme = spec.components.securitySchemes.AdminKey;
+    expect(scheme).toMatchObject({ type: 'apiKey', in: 'header', name: 'x-admin-key' });
+    expect(spec.paths['/stop']?.post?.security).toEqual([{ AdminKey: [] }]);
+  });
+
+  test('user-scoped control operations document owner header and ownership errors', () => {
+    expect(spec.components.parameters.SessionOwnerTokenHeader).toMatchObject({
+      name: 'X-Camofox-Session-Owner',
+      in: 'header',
+      required: false,
+      schema: { type: 'string', minLength: 32, maxLength: 256 },
+    });
+    const operations = [
+      spec.paths['/tabs'].post,
+      spec.paths['/tabs/{tabId}/snapshot'].get,
+      spec.paths['/tabs/open'].post,
+      spec.paths['/sessions/{userId}/cookies'].post,
+      spec.paths['/sessions/{userId}/traces'].get,
+      spec.paths['/sessions/{userId}/storage_state'].get,
+      spec.paths['/sessions/{userId}/storage_state'].delete,
+      spec.paths['/sessions/{userId}'].delete,
+      spec.paths['/navigate'].post,
+      spec.paths['/snapshot'].get,
+      spec.paths['/act'].post,
+    ];
+    for (const operation of operations) {
+      expect(operation.parameters).toContainEqual({
+        $ref: '#/components/parameters/SessionOwnerTokenHeader',
+      });
+      expect(operation.responses['400']).toBeDefined();
+      expect(operation.responses['403']).toBeDefined();
+      expect(operation.responses['409']).toBeDefined();
+    }
+  });
+
   test('cookie import route has security requirement', () => {
     const op = spec.paths['/sessions/{userId}/cookies']?.post;
     expect(op).toBeDefined();
     expect(op.security).toEqual([{ BearerAuth: [] }]);
+  });
+
+  test('GET /tabs documents its required session identity', () => {
+    const parameter = spec.paths['/tabs'].get.parameters
+      .find(item => item.name === 'userId' && item.in === 'query');
+    expect(parameter).toMatchObject({ required: true, schema: { type: 'string' } });
   });
 
   test('$ref references resolve to existing component schemas', () => {
@@ -190,13 +267,15 @@ describe('OpenAPI spec', () => {
     expect(unresolved).toEqual([]);
   });
 
-  test('openapi.json in repo root is up to date', () => {
-    let committed;
-    try {
-      committed = JSON.parse(readFileSync(join(__dirname, '..', '..', 'openapi.json'), 'utf8'));
-    } catch {
-      throw new Error('openapi.json not found -- run: npm run generate-openapi');
+  test('root and docs OpenAPI snapshots are up to date', () => {
+    for (const relativePath of ['openapi.json', join('docs', 'openapi.json')]) {
+      let committed;
+      try {
+        committed = JSON.parse(readFileSync(join(__dirname, '..', '..', relativePath), 'utf8'));
+      } catch {
+        throw new Error(`${relativePath} not found -- run: npm run generate-openapi`);
+      }
+      expect(committed).toEqual(spec);
     }
-    expect(committed).toEqual(spec);
   });
 });

--- a/tests/unit/pressureCleanup.test.js
+++ b/tests/unit/pressureCleanup.test.js
@@ -1,0 +1,50 @@
+import { isPressureTabStillEligible } from '../../lib/pressure-cleanup.js';
+
+describe('pressure cleanup eligibility revalidation', () => {
+  const selected = {
+    toolCalls: 4,
+    pressureObservedToolCalls: 4,
+    pressureObservedAt: 1_000,
+  };
+
+  test('keeps an unchanged idle candidate eligible', () => {
+    expect(isPressureTabStillEligible(selected, {
+      selectedToolCalls: 4,
+      minIdleMs: 500,
+      now: 1_500,
+    })).toBe(true);
+  });
+
+  test('rejects a stale candidate used while destructive cleanup waited', () => {
+    const usedAfterSelection = {
+      ...selected,
+      toolCalls: 5,
+      pressureObservedToolCalls: 5,
+      pressureObservedAt: 1_400,
+    };
+    expect(isPressureTabStillEligible(usedAfterSelection, {
+      selectedToolCalls: 4,
+      minIdleMs: 500,
+      now: 1_500,
+    })).toBe(false);
+  });
+
+  test('rejects refreshed activity and candidates no longer idle enough', () => {
+    expect(isPressureTabStillEligible({
+      ...selected,
+      pressureObservedToolCalls: 3,
+    }, {
+      selectedToolCalls: 4,
+      minIdleMs: 500,
+      now: 1_500,
+    })).toBe(false);
+    expect(isPressureTabStillEligible({
+      ...selected,
+      pressureObservedAt: 1_250,
+    }, {
+      selectedToolCalls: 4,
+      minIdleMs: 500,
+      now: 1_500,
+    })).toBe(false);
+  });
+});

--- a/tests/unit/sentry.test.js
+++ b/tests/unit/sentry.test.js
@@ -1,0 +1,14 @@
+import { sanitizeRequestPath } from '../../lib/sentry.js';
+
+describe('sanitizeRequestPath', () => {
+  test('drops query strings before telemetry capture', () => {
+    expect(sanitizeRequestPath({
+      path: '/tabs',
+      originalUrl: '/tabs?sessionOwnerToken=must-not-leak&userId=example',
+    })).toBe('/tabs');
+  });
+
+  test('falls back to an original URL pathname without query data', () => {
+    expect(sanitizeRequestPath({ originalUrl: '/broken?secret=must-not-leak' })).toBe('/broken');
+  });
+});

--- a/tests/unit/sessionCleanup.test.js
+++ b/tests/unit/sessionCleanup.test.js
@@ -3,7 +3,7 @@
  *
  * Covers:
  * 1. Tab reaper → empty session cleanup (with _closing flag)
- * 2. getSession() skips sessions marked _closing
+ * 2. getSession() refuses replacement while a session is _closing
  * 3. YT transcript cleanup uses context.pages() instead of tabGroups
  * 4. Session expiry sets _closing before teardown
  */
@@ -176,7 +176,9 @@ describe('getSession _closing flag handling', () => {
 
     if (session) {
       if (session._closing) {
-        session = null;
+        throw Object.assign(new Error('Session deletion is already in flight'), {
+          code: 'session_deletion_inflight',
+        });
       } else {
         try {
           session.context.pages();
@@ -205,19 +207,14 @@ describe('getSession _closing flag handling', () => {
     expect(result.context).toBe(existingContext);
   });
 
-  test('skips session with _closing flag and creates new one', () => {
+  test('rejects replacement while the existing session is closing', () => {
     const sessions = new Map();
     const oldContext = { pages: () => [] };
     sessions.set('user-1', { context: oldContext, tabGroups: new Map(), lastAccess: 0, _closing: true });
 
-    const newContext = { pages: () => [] };
-    const result = getSession(sessions, 'user-1', () => newContext);
-
-    expect(result.context).toBe(newContext);
-    expect(result.context).not.toBe(oldContext);
-    expect(result._closing).toBeUndefined();
-    // Old entry is replaced in the map
-    expect(sessions.get('user-1').context).toBe(newContext);
+    expect(() => getSession(sessions, 'user-1', () => { throw new Error('must not create'); }))
+      .toThrow(expect.objectContaining({ code: 'session_deletion_inflight' }));
+    expect(sessions.get('user-1').context).toBe(oldContext);
   });
 
   test('recreates session when context.pages() throws', () => {

--- a/tests/unit/sessionDestroyingEvent.test.js
+++ b/tests/unit/sessionDestroyingEvent.test.js
@@ -26,9 +26,9 @@ describe('session:destroying event ordering', () => {
    *   3. pluginEvents.emitAsync('session:destroyed', ...)
    */
   async function simulateCloseSession(pluginEvents, session, userId, reason) {
-    await pluginEvents.emitAsync('session:destroying', { userId, reason });
+    await pluginEvents.emitAsync('session:destroying', { userId, reason, context: session.context });
     await session.context.close();
-    await pluginEvents.emitAsync('session:destroyed', { userId, reason });
+    await pluginEvents.emitAsync('session:destroyed', { userId, reason, context: session.context });
   }
 
   function makeMockContext() {
@@ -192,16 +192,14 @@ describe('persistence plugin with session:destroying', () => {
       activeSessions.set(userId, context);
     });
 
-    events.on('session:destroying', async ({ userId, reason }) => {
-      const context = activeSessions.get(userId);
-      if (context) {
+    events.on('session:destroying', async ({ userId, reason, context }) => {
+      if (context && activeSessions.get(userId) === context) {
         await checkpoint(userId, context, reason).catch(() => {});
-        activeSessions.delete(userId);
       }
     });
 
-    events.on('session:destroyed', async ({ userId }) => {
-      activeSessions.delete(userId);
+    events.on('session:destroyed', async ({ userId, context }) => {
+      if (context && activeSessions.get(userId) === context) activeSessions.delete(userId);
     });
 
     return { activeSessions, checkpointCalls };
@@ -220,9 +218,9 @@ describe('persistence plugin with session:destroying', () => {
   }
 
   async function simulateCloseSession(pluginEvents, session, userId, reason) {
-    await pluginEvents.emitAsync('session:destroying', { userId, reason });
+    await pluginEvents.emitAsync('session:destroying', { userId, reason, context: session.context });
     await session.context.close();
-    await pluginEvents.emitAsync('session:destroyed', { userId, reason });
+    await pluginEvents.emitAsync('session:destroyed', { userId, reason, context: session.context });
   }
 
   test('checkpoints successfully during destroying (context alive)', async () => {
@@ -242,19 +240,19 @@ describe('persistence plugin with session:destroying', () => {
     expect(activeSessions.has('user-1')).toBe(false);
   });
 
-  test('activeSessions cleaned up even if checkpoint was already done in destroying', async () => {
+  test('activeSessions remains retryable until verified destruction completes', async () => {
     const events = createPluginEvents();
     const context = makeMockContext();
     const { activeSessions } = setupPersistencePlugin(events);
 
     await events.emitAsync('session:created', { userId: 'user-1', context });
 
-    // destroying removes from activeSessions
-    await events.emitAsync('session:destroying', { userId: 'user-1', reason: 'test' });
-    expect(activeSessions.has('user-1')).toBe(false);
+    // Pre-close checkpointing must not forget a context whose close can fail.
+    await events.emitAsync('session:destroying', { userId: 'user-1', reason: 'test', context });
+    expect(activeSessions.has('user-1')).toBe(true);
 
-    // destroyed is a no-op (already removed) but doesn't error
-    await events.emitAsync('session:destroyed', { userId: 'user-1', reason: 'test' });
+    // Only verified post-close completion removes lifecycle tracking.
+    await events.emitAsync('session:destroyed', { userId: 'user-1', reason: 'test', context });
     expect(activeSessions.has('user-1')).toBe(false);
   });
 
@@ -267,7 +265,7 @@ describe('persistence plugin with session:destroying', () => {
     expect(activeSessions.has('user-1')).toBe(true);
 
     // Skip destroying, go straight to destroyed (backward compat scenario)
-    await events.emitAsync('session:destroyed', { userId: 'user-1', reason: 'test' });
+    await events.emitAsync('session:destroyed', { userId: 'user-1', reason: 'test', context });
     expect(activeSessions.has('user-1')).toBe(false);
   });
 
@@ -290,6 +288,25 @@ describe('persistence plugin with session:destroying', () => {
     expect(checkpointCalls).toEqual([]); // checkpoint failed, nothing recorded
     expect(activeSessions.has('user-1')).toBe(false); // but cleanup still happened
     expect(failingContext.close).toHaveBeenCalled(); // context still closed
+  });
+
+  test('stale lifecycle events cannot checkpoint or remove a replacement context', async () => {
+    const events = createPluginEvents();
+    const original = makeMockContext();
+    const replacement = makeMockContext();
+    const { activeSessions, checkpointCalls } = setupPersistencePlugin(events);
+
+    await events.emitAsync('session:created', { userId: 'user-1', context: original });
+    await events.emitAsync('session:created', { userId: 'user-1', context: replacement });
+    await events.emitAsync('session:destroying', {
+      userId: 'user-1', reason: 'stale_close', context: original,
+    });
+    await events.emitAsync('session:destroyed', {
+      userId: 'user-1', reason: 'stale_close', context: original,
+    });
+
+    expect(checkpointCalls).toEqual([]);
+    expect(activeSessions.get('user-1')).toBe(replacement);
   });
 
   test('multiple sessions checkpoint independently', async () => {

--- a/tests/unit/sessionOperations.test.js
+++ b/tests/unit/sessionOperations.test.js
@@ -1,0 +1,165 @@
+import { EventEmitter } from 'events';
+import { jest } from '@jest/globals';
+import {
+  attachOperationCompletion,
+  createSessionOperationCoordinator,
+  runCoordinatedDeletion,
+  trackOperationPromise,
+} from '../../lib/session-operations.js';
+
+function nextTurn() {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
+describe('session operation coordinator', () => {
+  test('deletion waits for active operations and blocks later operations until cleanup ends', async () => {
+    const coordinator = createSessionOperationCoordinator();
+    const finishOperation = coordinator.enter('user-a');
+    expect(coordinator.isActive('user-a')).toBe(true);
+
+    let deletionReady = false;
+    const deletion = coordinator.beginDelete('user-a').then(finishDelete => {
+      deletionReady = true;
+      return finishDelete;
+    });
+
+    await nextTurn();
+    expect(deletionReady).toBe(false);
+    expect(() => coordinator.enter('user-a')).toThrow(expect.objectContaining({
+      statusCode: 409,
+      code: 'session_deletion_inflight',
+    }));
+
+    finishOperation();
+    const finishDelete = await deletion;
+    expect(deletionReady).toBe(true);
+    expect(() => coordinator.enter('user-a')).toThrow(expect.objectContaining({
+      statusCode: 409,
+      code: 'session_deletion_inflight',
+    }));
+
+    finishDelete();
+    const finishNextOperation = coordinator.enter('user-a');
+    finishNextOperation();
+    expect(coordinator.size()).toBe(0);
+    expect(coordinator.isActive('user-a')).toBe(false);
+  });
+
+  test('rejects concurrent deletion and makes completion callbacks idempotent', async () => {
+    const coordinator = createSessionOperationCoordinator();
+    const finishDelete = await coordinator.beginDelete('user-a');
+
+    await expect(coordinator.beginDelete('user-a')).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'session_deletion_inflight',
+    });
+
+    finishDelete();
+    finishDelete();
+    expect(coordinator.size()).toBe(0);
+  });
+
+  test('tracks handler completion rather than client socket close', () => {
+    const response = new EventEmitter();
+    response.destroyed = false;
+    response.writableEnded = false;
+    response.end = jest.fn(() => {
+      response.writableEnded = true;
+    });
+    const finish = jest.fn();
+
+    expect(attachOperationCompletion(response, finish)).toBe(true);
+    response.emit('close');
+    expect(finish).not.toHaveBeenCalled();
+
+    response.end('done');
+    response.end('duplicate');
+    expect(finish).toHaveBeenCalledTimes(1);
+  });
+
+  test('completes after an explicit response destroy settles', () => {
+    const response = new EventEmitter();
+    response.destroyed = false;
+    response.writableEnded = false;
+    response.end = jest.fn();
+    response.destroy = jest.fn(() => {
+      response.destroyed = true;
+    });
+    const finish = jest.fn();
+
+    expect(attachOperationCompletion(response, finish)).toBe(true);
+    response.destroy();
+    expect(response.destroyed).toBe(true);
+    expect(finish).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not complete when response end or destroy throws', () => {
+    for (const method of ['end', 'destroy']) {
+      const response = new EventEmitter();
+      response.destroyed = false;
+      response.writableEnded = false;
+      response.end = jest.fn();
+      response.destroy = jest.fn();
+      response[method].mockImplementation(() => { throw new Error(`${method} failed`); });
+      const finish = jest.fn();
+
+      expect(attachOperationCompletion(response, finish)).toBe(true);
+      expect(() => response[method]()).toThrow(`${method} failed`);
+      expect(finish).not.toHaveBeenCalled();
+    }
+  });
+
+  test('keeps deletion blocked until a timed-out underlying promise settles', async () => {
+    const coordinator = createSessionOperationCoordinator();
+    const finishRequest = coordinator.enter('user-a');
+    let settleUnderlying;
+    const underlying = new Promise(resolve => { settleUnderlying = resolve; });
+    const tracked = trackOperationPromise(coordinator, 'user-a', underlying);
+    finishRequest();
+
+    let deleteStarted = false;
+    const deleting = coordinator.beginDelete('user-a').then(finish => {
+      deleteStarted = true;
+      finish();
+    });
+    await Promise.resolve();
+    expect(deleteStarted).toBe(false);
+
+    settleUnderlying('done');
+    await expect(tracked).resolves.toBe('done');
+    await deleting;
+    expect(deleteStarted).toBe(true);
+    expect(coordinator.size()).toBe(0);
+  });
+
+  test('background destruction waits for an active tab publication operation', async () => {
+    const coordinator = createSessionOperationCoordinator();
+    const finishTabPublication = coordinator.enter('user-a');
+    const destroy = jest.fn(async () => 'destroyed');
+    const destruction = runCoordinatedDeletion(coordinator, 'user-a', destroy);
+
+    await nextTurn();
+    expect(destroy).not.toHaveBeenCalled();
+    expect(() => coordinator.enter('user-a')).toThrow(expect.objectContaining({
+      code: 'session_deletion_inflight',
+    }));
+
+    finishTabPublication();
+    await expect(destruction).resolves.toBe('destroyed');
+    expect(destroy).toHaveBeenCalledTimes(1);
+    const finishNext = coordinator.enter('user-a');
+    finishNext();
+  });
+
+  test('cancels a pending deletion reservation when its response already closed', () => {
+    const response = new EventEmitter();
+    response.destroyed = true;
+    response.writableEnded = false;
+    response.end = jest.fn();
+    const finish = jest.fn();
+
+    expect(attachOperationCompletion(response, finish)).toBe(false);
+    expect(finish).toHaveBeenCalledTimes(1);
+    expect(response.end).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/sessionOwnership.test.js
+++ b/tests/unit/sessionOwnership.test.js
@@ -1,0 +1,175 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { createSessionOwnershipRegistry } from '../../lib/session-ownership.js';
+
+const OWNER_A = 'owner_A-0123456789abcdefghijklmnopqrstuvwxyz';
+const OWNER_B = 'owner_B-0123456789abcdefghijklmnopqrstuvwxyz';
+
+function expectOwnershipError(action, statusCode, code) {
+  try {
+    action();
+    throw new Error('expected ownership error');
+  } catch (error) {
+    expect(error.statusCode).toBe(statusCode);
+    expect(error.code).toBe(code);
+    return error;
+  }
+}
+
+describe('session ownership registry', () => {
+  test('atomically claims only an absent non-inflight session', () => {
+    const registry = createSessionOwnershipRegistry();
+
+    registry.claim('temporary-user', OWNER_A, {
+      sessionExists: false,
+      creationInflight: false,
+    });
+
+    expect(registry.hasClaim('temporary-user')).toBe(true);
+    expectOwnershipError(
+      () => registry.claim('temporary-user', OWNER_B, {
+        sessionExists: false,
+        creationInflight: false,
+      }),
+      409,
+      'session_ownership_conflict',
+    );
+    expectOwnershipError(
+      () => registry.claim('existing-user', OWNER_A, {
+        sessionExists: true,
+        creationInflight: false,
+      }),
+      409,
+      'session_ownership_conflict',
+    );
+    expectOwnershipError(
+      () => registry.claim('inflight-user', OWNER_A, {
+        sessionExists: false,
+        creationInflight: true,
+      }),
+      409,
+      'session_ownership_conflict',
+    );
+  });
+
+  test('requires a high-entropy opaque owner token', () => {
+    const registry = createSessionOwnershipRegistry();
+
+    expectOwnershipError(
+      () => registry.claim('temporary-user', 'short', {
+        sessionExists: false,
+        creationInflight: false,
+      }),
+      400,
+      'invalid_session_owner_token',
+    );
+    expectOwnershipError(
+      () => registry.claim('temporary-user', `${OWNER_A}.invalid`, {
+        sessionExists: false,
+        creationInflight: false,
+      }),
+      400,
+      'invalid_session_owner_token',
+    );
+  });
+
+  test('gates claimed sessions while preserving unclaimed compatibility', () => {
+    const registry = createSessionOwnershipRegistry();
+
+    expect(registry.authorize('legacy-user', undefined)).toBe(false);
+    expectOwnershipError(
+      () => registry.authorize('legacy-user', 'short'),
+      400,
+      'invalid_session_owner_token',
+    );
+    registry.claim('temporary-user', OWNER_A, {
+      sessionExists: false,
+      creationInflight: false,
+    });
+
+    expect(registry.authorize('temporary-user', OWNER_A)).toBe(true);
+    expectOwnershipError(
+      () => registry.authorize('temporary-user', OWNER_B),
+      403,
+      'session_owner_mismatch',
+    );
+    expectOwnershipError(
+      () => registry.authorize('temporary-user', undefined),
+      403,
+      'session_owner_mismatch',
+    );
+  });
+
+  test('releases only the exact owned claim', () => {
+    const registry = createSessionOwnershipRegistry();
+    registry.claim('temporary-user', OWNER_A, {
+      sessionExists: false,
+      creationInflight: false,
+    });
+
+    expectOwnershipError(
+      () => registry.release('temporary-user', OWNER_B),
+      403,
+      'session_owner_mismatch',
+    );
+    expect(registry.hasClaim('temporary-user')).toBe(true);
+    expect(registry.release('temporary-user', OWNER_A)).toBe(true);
+    expect(registry.hasClaim('temporary-user')).toBe(false);
+    expect(registry.release('temporary-user', OWNER_A)).toBe(false);
+  });
+
+  test('does not release ownership while session creation is in flight', () => {
+    const registry = createSessionOwnershipRegistry();
+    registry.claim('temporary-user', OWNER_A, {
+      sessionExists: false,
+      creationInflight: false,
+    });
+
+    expectOwnershipError(
+      () => registry.prepareRelease('temporary-user', OWNER_A, { creationInflight: true }),
+      409,
+      'session_creation_inflight',
+    );
+    expectOwnershipError(
+      () => registry.authorize('temporary-user'),
+      403,
+      'session_owner_mismatch',
+    );
+
+    expect(registry.prepareRelease('temporary-user', OWNER_A, { creationInflight: false })).toBe(true);
+    expect(registry.release('temporary-user', OWNER_A)).toBe(true);
+  });
+
+  test('stores only a digest, never the raw owner token', () => {
+    const registry = createSessionOwnershipRegistry();
+    registry.claim('temporary-user', OWNER_A, {
+      sessionExists: false,
+      creationInflight: false,
+    });
+
+    expect(JSON.stringify(registry)).not.toContain(OWNER_A);
+    expect(String(registry)).not.toContain(OWNER_A);
+  });
+
+  test('expires only abandoned claims when the server proves release is safe', () => {
+    let now = 10;
+    const registry = createSessionOwnershipRegistry({
+      ttlMs: 100,
+      now: () => now,
+    });
+    registry.claim('temporary-user', OWNER_A, {
+      sessionExists: false,
+      creationInflight: false,
+    });
+
+    now = 109;
+    expect(registry.authorize('temporary-user', OWNER_A)).toBe(true);
+    now = 210;
+    expect(registry.hasClaim('temporary-user')).toBe(true);
+    expect(registry.purgeExpired(() => false)).toBe(0);
+    expect(registry.hasClaim('temporary-user')).toBe(true);
+    expect(registry.purgeExpired(userId => userId === 'temporary-user')).toBe(1);
+    expect(registry.hasClaim('temporary-user')).toBe(false);
+    expect(registry.authorize('temporary-user', undefined)).toBe(false);
+  });
+});

--- a/tests/unit/verifiedContextClose.test.js
+++ b/tests/unit/verifiedContextClose.test.js
@@ -1,0 +1,46 @@
+import { jest } from '@jest/globals';
+import { closeContextVerified, deleteSessionIfCurrent } from '../../lib/verified-context-close.js';
+
+describe('closeContextVerified', () => {
+  test('returns after a successful close', async () => {
+    const context = { close: jest.fn().mockResolvedValue(), pages: jest.fn() };
+    await expect(closeContextVerified(context)).resolves.toBeUndefined();
+    expect(context.pages).not.toHaveBeenCalled();
+  });
+
+  test('accepts a close error only when the context proves dead', async () => {
+    const closeError = new Error('transport closed');
+    const context = {
+      close: jest.fn().mockRejectedValue(closeError),
+      pages: jest.fn(() => { throw new Error('context closed'); }),
+    };
+    await expect(closeContextVerified(context)).resolves.toBeUndefined();
+  });
+
+  test('fails closed when close throws and the context remains live', async () => {
+    const closeError = new Error('close failed');
+    const context = {
+      close: jest.fn().mockRejectedValue(closeError),
+      pages: jest.fn(() => []),
+    };
+    await expect(closeContextVerified(context)).rejects.toBe(closeError);
+  });
+});
+
+describe('deleteSessionIfCurrent', () => {
+  test('deletes only the exact session that was verified closed', () => {
+    const original = { context: {} };
+    const sessions = new Map([['user-1', original]]);
+    deleteSessionIfCurrent(sessions, 'user-1', original);
+    expect(sessions.has('user-1')).toBe(false);
+  });
+
+  test('retains a concurrently published replacement and fails closed', () => {
+    const original = { context: {} };
+    const replacement = { context: {} };
+    const sessions = new Map([['user-1', replacement]]);
+    expect(() => deleteSessionIfCurrent(sessions, 'user-1', original))
+      .toThrow(expect.objectContaining({ code: 'session_replaced_during_close' }));
+    expect(sessions.get('user-1')).toBe(replacement);
+  });
+});


### PR DESCRIPTION
## Summary
- add atomic, digest-only session ownership claims with exact owner-header authorization
- add authenticated, side-effect-free capability readback for ownership-aware clients
- coordinate ordinary operations, deletion, timeout descendants, background cleanup, and browser launch/close lifecycle
- harden identity parsing, token transport, telemetry redaction, persistence/plugin teardown ordering, and claimed-session exclusions
- synchronize runtime OpenAPI, generated snapshots, README, and packaged documentation assets

## Security and lifecycle properties
- owner tokens are accepted only through `X-Camofox-Session-Owner`; query transport is rejected
- raw owner tokens are not persisted or emitted in responses, logs, telemetry, or provenance
- deletion waits for active and descendant operations and revalidates exact session identity before verified close
- background expiry, pressure, inactivity, orphan, YouTube, and idle cleanup paths fail closed or coordinate with active operations
- stale launch/cleanup attempts cannot publish over or destroy replacement resources

## Validation
- `npm test -- --testPathIgnorePatterns='tests/e2e/'`: 799 passed, 9 skipped\n- `npm run test:e2e`: 76 passed\n- staged JavaScript syntax checks: passed\n- generated OpenAPI parity and live docs probes: passed\n- `npm pack --dry-run --ignore-scripts --json`: required runtime/docs assets present; tests and secrets excluded\n- `git diff --check`: passed\n- independent exact-tree security/lifecycle review: `passed: true`\n\n## Notes\n- based on v1.13.0 (`8b5b095`)\n- this PR does not perform deployment or a live sourcing smoke test