### PR TITLE
fix(cookies): contain resolved cookie paths

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -52,8 +52,15 @@ function parseNetscapeCookieFile(text) {
  * @returns {Promise<Array<{name: string, value: string, domain: string, path: string, expires: number, httpOnly: boolean, secure: boolean}>>}
  */
 async function readCookieFile({ cookiesDir, cookiesPath, domainSuffix, maxBytes = 5 * 1024 * 1024 }) {
-  const resolved = path.resolve(cookiesDir, cookiesPath);
-  if (!resolved.startsWith(cookiesDir + path.sep)) {
+  if (typeof cookiesPath !== 'string' || cookiesPath.length === 0) {
+    throw new Error('cookiesPath must be a non-empty string');
+  }
+  if (path.isAbsolute(cookiesPath)) {
+    throw new Error('cookiesPath must be a relative path within the cookies directory');
+  }
+  const normalizedBase = path.resolve(cookiesDir) + path.sep;
+  const resolved = path.resolve(normalizedBase, cookiesPath);
+  if (resolved !== normalizedBase.slice(0, -1) && !resolved.startsWith(normalizedBase)) {
     throw new Error('cookiesPath must be a relative path within the cookies directory');
   }
 

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -51,18 +51,39 @@ function parseNetscapeCookieFile(text) {
  * @param {number} [opts.maxBytes=5242880] - Maximum file size in bytes
  * @returns {Promise<Array<{name: string, value: string, domain: string, path: string, expires: number, httpOnly: boolean, secure: boolean}>>}
  */
+function isPathInside(basePath, targetPath) {
+  const relative = path.relative(basePath, targetPath);
+  return relative !== ''
+    && relative !== '..'
+    && !relative.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(relative);
+}
+
 async function readCookieFile({ cookiesDir, cookiesPath, domainSuffix, maxBytes = 5 * 1024 * 1024 }) {
-  const resolved = path.resolve(cookiesDir, cookiesPath);
-  if (!resolved.startsWith(cookiesDir + path.sep)) {
+  if (typeof cookiesPath !== 'string' || cookiesPath.length === 0) {
+    throw new Error('cookiesPath must be a non-empty string');
+  }
+  if (path.isAbsolute(cookiesPath)) {
     throw new Error('cookiesPath must be a relative path within the cookies directory');
   }
 
-  const stat = await fs.stat(resolved);
+  const realCookiesDir = await fs.realpath(cookiesDir);
+  const requestedPath = path.resolve(realCookiesDir, cookiesPath);
+  if (!isPathInside(realCookiesDir, requestedPath)) {
+    throw new Error('cookiesPath must be a relative path within the cookies directory');
+  }
+
+  const realCookiePath = await fs.realpath(requestedPath);
+  if (!isPathInside(realCookiesDir, realCookiePath)) {
+    throw new Error('cookiesPath resolves outside the cookies directory');
+  }
+
+  const stat = await fs.stat(realCookiePath);
   if (stat.size > maxBytes) {
     throw new Error('Cookie file too large (max 5MB)');
   }
 
-  const text = await fs.readFile(resolved, 'utf8');
+  const text = await fs.readFile(realCookiePath, 'utf8');
   let cookies = parseNetscapeCookieFile(text);
   if (domainSuffix) {
     cookies = cookies.filter((c) => c.domain.endsWith(domainSuffix));

--- a/tests/unit/autoCookieImport.test.js
+++ b/tests/unit/autoCookieImport.test.js
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { jest } from '@jest/globals';
-import { importBootstrapCookies } from '../../lib/cookies.js';
+import { importBootstrapCookies, readCookieFile } from '../../lib/cookies.js';
 
 describe('importBootstrapCookies', () => {
   let tmpDir;
@@ -63,5 +63,41 @@ describe('importBootstrapCookies', () => {
 
     expect(result.imported).toBe(0);
     expect(logger.warn).toHaveBeenCalled();
+  });
+
+  test('reads a nested cookie file and an in-directory symlink', async () => {
+    const nestedDir = path.join(tmpDir, 'nested');
+    await fs.mkdir(nestedDir);
+    await fs.writeFile(
+      path.join(nestedDir, 'cookies.txt'),
+      '.example.com\tTRUE\t/\tTRUE\t1700000000\tlogged_in\tyes\n'
+    );
+    await fs.symlink(path.join(nestedDir, 'cookies.txt'), path.join(tmpDir, 'cookies-link.txt'));
+
+    await expect(readCookieFile({ cookiesDir: tmpDir, cookiesPath: 'nested/cookies.txt' }))
+      .resolves.toEqual([expect.objectContaining({ name: 'logged_in', value: 'yes' })]);
+    await expect(readCookieFile({ cookiesDir: tmpDir, cookiesPath: 'cookies-link.txt' }))
+      .resolves.toEqual([expect.objectContaining({ name: 'logged_in', value: 'yes' })]);
+  });
+
+  test('rejects traversal, absolute paths, and symlinks that resolve outside the cookie directory', async () => {
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'camofox-outside-cookies-'));
+    const outsideFile = path.join(outsideDir, 'cookies.txt');
+    await fs.writeFile(
+      outsideFile,
+      '.example.com\tTRUE\t/\tTRUE\t1700000000\toutside\tsecret\n'
+    );
+    await fs.symlink(outsideFile, path.join(tmpDir, 'escape.txt'));
+
+    try {
+      await expect(readCookieFile({ cookiesDir: tmpDir, cookiesPath: '../cookies.txt' }))
+        .rejects.toThrow('relative path within the cookies directory');
+      await expect(readCookieFile({ cookiesDir: tmpDir, cookiesPath: outsideFile }))
+        .rejects.toThrow('relative path within the cookies directory');
+      await expect(readCookieFile({ cookiesDir: tmpDir, cookiesPath: 'escape.txt' }))
+        .rejects.toThrow('resolves outside the cookies directory');
+    } finally {
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Preserves the original #8294 commit and adds realpath containment so cookie paths cannot escape `CAMOFOX_COOKIES_DIR` through symlinks.

Tests: `npm test -- tests/unit/autoCookieImport.test.js`