### PR TITLE
fix(ci): bump Dockerfile.ci base image to node:22-slim

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,7 +1,7 @@
 # CI/CD Dockerfile — downloads binaries during build (no bind mounts needed).
 # For local builds with pre-downloaded binaries, use the default Dockerfile + Makefile.
 
-FROM node:20-slim
+FROM node:22-slim
 
 ARG CAMOUFOX_VERSION=135.0.1
 ARG CAMOUFOX_RELEASE=beta.24

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -9,6 +9,8 @@ ARG TARGETARCH
 
 # Install dependencies for Camoufox (Firefox-based)
 RUN apt-get update && apt-get install -y \
+    make \
+    g++ \
     # Firefox dependencies
     libgtk-3-0 \
     libdbus-glib-1-2 \
@@ -65,7 +67,9 @@ WORKDIR /app
 
 COPY package.json package-lock.json ./
 COPY scripts/ ./scripts/
-RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci --production
+RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci --omit=dev \
+    && rm -rf node_modules/better-sqlite3/prebuilds \
+    && npm rebuild better-sqlite3 --build-from-source
 
 COPY server.js ./
 COPY camofox.config.json ./


### PR DESCRIPTION
CI image builds fail on `npm ci`: camoufox-js 0.11.x pulls in better-sqlite3 ^13, which has no prebuilt binary for Node 20's ABI, so prebuild-install falls back to a source build — and node-gyp dies on the slim image, which ships no compiler toolchain:

    npm error gyp ERR! cwd /app/node_modules/better-sqlite3
    npm error gyp ERR! node -v v20.20.2

Dockerfile.ci was the only image still on node:20-slim: the main Dockerfile is already on node:22-slim, and package.json declares `engines: node >= 22`. Bumping the base image restores the prebuilt-binary path — no toolchain needed, no other changes.