### PR TITLE
fix(docker): install build toolchain and copy mcp/ directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ ARG ARCH=x86_64
 
 # Install dependencies for Camoufox (Firefox-based)
 RUN apt-get update && apt-get install -y \
+    # Build toolchain for native npm addons (e.g. better-sqlite3)
+    build-essential \
+    python3 \
     # Firefox dependencies
     libgtk-3-0 \
     libdbus-glib-1-2 \
@@ -38,8 +41,6 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     unzip \
-    # yt-dlp runtime dependency
-    python3-minimal \
     && rm -rf /var/lib/apt/lists/*
 
 # Pre-bake Camoufox browser binary into image (downloaded at build time)
@@ -65,6 +66,7 @@ RUN npm ci --omit=dev
 COPY server.js ./
 COPY camofox.config.json ./
 COPY lib/ ./lib/
+COPY mcp/ ./mcp/
 COPY plugins/ ./plugins/
 COPY scripts/ ./scripts/
 


### PR DESCRIPTION
Two Docker build/runtime issues hit when building `master` fresh:

1. `npm ci --omit=dev` fails compiling `better-sqlite3` via node-gyp because the `node:22-slim` base image has no `make`/C++ toolchain. Adds `build-essential` and `python3` to the existing apt-get install layer (and drops the now-redundant `python3-minimal`, since `python3` already depends on it).
2. The `persistence` plugin fails to load at runtime (`ERR_MODULE_NOT_FOUND`) because `lib/cookies.js` imports `../mcp/lib/cookies.mjs`, but the Dockerfile never copies `mcp/` into the image. Adds `COPY mcp/ ./mcp/` next to the existing `COPY lib/ ./lib/` line. Only built-in Node modules are needed by that file, so no extra install step is required.

Fixes #8639, Fixes #8652

Tests: `make build && make up`, confirmed clean build and `"plugin loaded","plugin":"persistence"` in `docker logs`.