### PR TITLE
fix: add build-essential to Dockerfile for native addon compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG ARCH=x86_64
 
 # Install dependencies for Camoufox (Firefox-based)
 RUN apt-get update && apt-get install -y \
+    build-essential \
     # Firefox dependencies
     libgtk-3-0 \
     libdbus-glib-1-2 \


### PR DESCRIPTION
## Problem

Docker build fails with `gyp ERR! not found: make` when compiling the `better-sqlite3` native addon. The `node:22-slim` base image does not include `make` or `gcc`.

## Fix

Added `build-essential` to the `apt-get install` line in the Dockerfile. This package provides `make`, `gcc`, and other tools needed for compiling Node.js native addons.

## Testing

```
docker build -t camofox-browser .
docker run -p 9377:9377 camofox-browser
```

Build succeeds and server starts correctly on port 9377.

Fixes #8746