### PR TITLE
fix(vnc): clean up Xvfb socket + lock file on kill()

### DIFF
--- a/lib/tmp-cleanup.js
+++ b/lib/tmp-cleanup.js
@@ -88,6 +88,28 @@ export function cleanupStaleFirefoxProfiles({ tmpDir, minAgeMs = 2 * 60 * 1000, 
   return result;
 }
 
+/**
+ * Remove a single Xvfb display's socket + lock file. camoufox-js's
+ * VirtualDisplay.kill() (dist/virtdisplay.js) sends SIGTERM but never
+ * unlinks these, and Xvfb itself doesn't reliably self-clean on exit --
+ * especially when it ends up force-killed a moment later as a process-tree
+ * survivor rather than exiting from the SIGTERM cleanly. Call once the
+ * Xvfb process has actually exited, not right after signaling it.
+ */
+export function removeXvfbDisplayFiles(displayNum, { socketDir = '/tmp/.X11-unix', lockDir = process.env.TMPDIR || os.tmpdir() } = {}) {
+  if (displayNum === null || displayNum === undefined) return;
+  for (const target of [
+    path.join(socketDir, `X${displayNum}`),
+    path.join(lockDir, `.X${displayNum}-lock`),
+  ]) {
+    try {
+      fs.rmSync(target, { force: true });
+    } catch {
+      // already gone or permission denied -- not ours to surface
+    }
+  }
+}
+
 /** Recursively calculate directory size (best effort, fast). */
 function _dirSizeSync(dirPath) {
   let total = 0;

--- a/plugins/vnc/index.js
+++ b/plugins/vnc/index.js
@@ -46,6 +46,7 @@
 
 import { resolveVncConfig, startWatcher } from './vnc-launcher.js';
 import { requireAuth } from '../../lib/auth.js';
+import { removeXvfbDisplayFiles } from '../../lib/tmp-cleanup.js';
 
 export async function register(app, ctx, pluginConfig = {}) {
   const { events, config, log, sessions, VirtualDisplay, safeError } = ctx;
@@ -71,6 +72,17 @@ export async function register(app, ctx, pluginConfig = {}) {
         return patched;
       }
       return args;
+    }
+
+    kill() {
+      const displayNum = this._display;
+      const proc = this.proc;
+      super.kill();
+      if (proc && proc.exitCode === null && proc.signalCode === null) {
+        proc.once('exit', () => removeXvfbDisplayFiles(displayNum));
+      } else {
+        removeXvfbDisplayFiles(displayNum);
+      }
     }
   }
 

--- a/plugins/vnc/vnc.test.js
+++ b/plugins/vnc/vnc.test.js
@@ -34,11 +34,18 @@ jest.unstable_mockModule('../../lib/auth.js', () => ({
   requireAuth: () => (_req, _res, next) => next(),
 }));
 
+const mockRemoveXvfbDisplayFiles = jest.fn();
+jest.unstable_mockModule('../../lib/tmp-cleanup.js', () => ({
+  removeXvfbDisplayFiles: mockRemoveXvfbDisplayFiles,
+}));
+
 // Minimal VirtualDisplay mock (real class has side-effects that break in test)
 class MockVirtualDisplay {
   get xvfb_args() {
     return ['-screen', '0', '1x1x24', '-ac', '-nolisten', 'tcp'];
   }
+
+  kill() {}
 }
 
 const { register } = await import('./index.js');
@@ -61,6 +68,7 @@ describe('vnc plugin', () => {
       VirtualDisplay: MockVirtualDisplay,
       createVirtualDisplay: () => new MockVirtualDisplay(),
     };
+    mockRemoveXvfbDisplayFiles.mockClear();
     mockStartWatcher.mockClear();
     mockStartWatcher.mockImplementation(mockWatcher);
     mockResolveVncConfig.mockClear();
@@ -159,6 +167,45 @@ describe('vnc plugin', () => {
     const args = vd.xvfb_args;
     const screenIdx = args.indexOf('0');
     expect(args[screenIdx + 1]).toBe('1920x1080x32');
+  });
+
+  test('kill() defers socket cleanup until the Xvfb process actually exits', async () => {
+    await register(mockApp, ctx, { enabled: true });
+
+    const vd = ctx.createVirtualDisplay();
+    vd._display = 99;
+    const proc = new EventEmitter();
+    proc.exitCode = null;
+    proc.signalCode = null;
+    vd.proc = proc;
+
+    vd.kill();
+    expect(mockRemoveXvfbDisplayFiles).not.toHaveBeenCalled();
+
+    proc.emit('exit');
+    expect(mockRemoveXvfbDisplayFiles).toHaveBeenCalledWith(99);
+  });
+
+  test('kill() cleans up immediately if the process already exited', async () => {
+    await register(mockApp, ctx, { enabled: true });
+
+    const vd = ctx.createVirtualDisplay();
+    vd._display = 42;
+    vd.proc = { exitCode: 0, signalCode: null };
+
+    vd.kill();
+    expect(mockRemoveXvfbDisplayFiles).toHaveBeenCalledWith(42);
+  });
+
+  test('kill() cleans up immediately when there is no tracked process', async () => {
+    await register(mockApp, ctx, { enabled: true });
+
+    const vd = ctx.createVirtualDisplay();
+    vd._display = 7;
+    vd.proc = null;
+
+    vd.kill();
+    expect(mockRemoveXvfbDisplayFiles).toHaveBeenCalledWith(7);
   });
 
   test('storage_state endpoint returns 404 for unknown user', async () => {

--- a/server.js
+++ b/server.js
@@ -31,7 +31,7 @@ import {
   startMemoryReporter, stopMemoryReporter,
 } from './lib/metrics.js';
 import { actionFromReq, classifyError } from './lib/request-utils.js';
-import { cleanupOrphanedTempFiles, cleanupStaleFirefoxProfiles } from './lib/tmp-cleanup.js';
+import { cleanupOrphanedTempFiles, cleanupStaleFirefoxProfiles, removeXvfbDisplayFiles } from './lib/tmp-cleanup.js';
 import { coalesceInflight } from './lib/inflight.js';
 import { createPageWithSessionRecovery } from './lib/new-page-recovery.js';
 import { createReporter, createTabHealthTracker, collectResourceSnapshot, classifyProxyError, browserProcessTreeRssMb, browserProcessNameRssMb } from './lib/reporter.js';
@@ -794,6 +794,17 @@ class DefaultVirtualDisplay extends VirtualDisplay {
       return patched;
     }
     return args;
+  }
+
+  kill() {
+    const displayNum = this._display;
+    const proc = this.proc;
+    super.kill();
+    if (proc && proc.exitCode === null && proc.signalCode === null) {
+      proc.once('exit', () => removeXvfbDisplayFiles(displayNum));
+    } else {
+      removeXvfbDisplayFiles(displayNum);
+    }
   }
 }
 

--- a/tests/unit/tmpCleanup.test.js
+++ b/tests/unit/tmpCleanup.test.js
@@ -5,7 +5,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { cleanupOrphanedTempFiles, cleanupStaleFirefoxProfiles } from '../../lib/tmp-cleanup.js';
+import { cleanupOrphanedTempFiles, cleanupStaleFirefoxProfiles, removeXvfbDisplayFiles } from '../../lib/tmp-cleanup.js';
 
 function makeTmpDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'camofox-test-'));
@@ -157,5 +157,56 @@ describe('cleanupStaleFirefoxProfiles', () => {
   it('handles nonexistent tmpDir gracefully', () => {
     const result = cleanupStaleFirefoxProfiles({ tmpDir: '/tmp/camofox-nonexistent-dir-xyz' });
     expect(result.scanned).toBe(0);
+  });
+});
+
+describe('removeXvfbDisplayFiles', () => {
+  it('removes both the socket and lock file for the given display', () => {
+    const socketDir = makeTmpDir();
+    const lockDir = makeTmpDir();
+    const socket = path.join(socketDir, 'X99');
+    const lock = path.join(lockDir, '.X99-lock');
+    fs.writeFileSync(socket, '');
+    fs.writeFileSync(lock, '12345');
+
+    removeXvfbDisplayFiles(99, { socketDir, lockDir });
+
+    expect(fs.existsSync(socket)).toBe(false);
+    expect(fs.existsSync(lock)).toBe(false);
+    fs.rmSync(socketDir, { recursive: true, force: true });
+    fs.rmSync(lockDir, { recursive: true, force: true });
+  });
+
+  it('removes whichever of the two exists, leaving unrelated displays alone', () => {
+    const socketDir = makeTmpDir();
+    const lockDir = makeTmpDir();
+    const targetSocket = path.join(socketDir, 'X42');
+    const otherSocket = path.join(socketDir, 'X0');
+    fs.writeFileSync(targetSocket, '');
+    fs.writeFileSync(otherSocket, '');
+    // No .X42-lock written -- only the socket exists for this display.
+
+    removeXvfbDisplayFiles(42, { socketDir, lockDir });
+
+    expect(fs.existsSync(targetSocket)).toBe(false);
+    expect(fs.existsSync(otherSocket)).toBe(true);
+    fs.rmSync(socketDir, { recursive: true, force: true });
+    fs.rmSync(lockDir, { recursive: true, force: true });
+  });
+
+  it('does not throw when neither file exists', () => {
+    const socketDir = makeTmpDir();
+    const lockDir = makeTmpDir();
+    expect(() => removeXvfbDisplayFiles(7777, { socketDir, lockDir })).not.toThrow();
+    fs.rmSync(socketDir, { recursive: true, force: true });
+    fs.rmSync(lockDir, { recursive: true, force: true });
+  });
+
+  it.each([null, undefined])('is a no-op for displayNum=%p', (displayNum) => {
+    const socketDir = makeTmpDir();
+    const lockDir = makeTmpDir();
+    expect(() => removeXvfbDisplayFiles(displayNum, { socketDir, lockDir })).not.toThrow();
+    fs.rmSync(socketDir, { recursive: true, force: true });
+    fs.rmSync(lockDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Problem

`camoufox-js`'s `VirtualDisplay.kill()` (`node_modules/camoufox-js/dist/virtdisplay.js`) sends Xvfb `SIGTERM` but never unlinks the `/tmp/.X11-unix/X<n>` socket or `.X<n>-lock` file it created. Neither `VncVirtualDisplay` (`plugins/vnc/index.js`) nor `DefaultVirtualDisplay` (`server.js`) compensated for that.

On a long-running deployment with the VNC plugin enabled and the browser restarting periodically (health-check-driven restarts, proxy session rotation, etc.), these files accumulate with no cap. On mine, `/tmp/.X11-unix` grew from ~3,200 to ~6,200 stale entries over 6 further days of continuous uptime. That's one new entry per restart cycle, never cleaned up, going back to whenever the VNC plugin was first enabled on that host.

This is a plain resource leak in `/tmp` (harmless on its own until inode/entry limits become a concern on a long-lived host), but it's also user-visible: other local tooling that enumerates `/tmp/.X11-unix` to discover running X displays can pick these up as false candidates. I ran into this indirectly through a remote-desktop tool on the same host intermittently misbehaving, traced it down through the accumulating socket count, and ended up here.

## Root cause

- `VirtualDisplay.execute_xvfb()` spawns Xvfb with an explicit display number and `detached: true`.
- `VirtualDisplay.kill()` only calls `this.proc.kill()` (SIGTERM). It has no cleanup step for the socket/lock file it's implicitly responsible for.
- `_closeBrowserFullyImpl` in `server.js` also runs `_forceKillProcessTree`/`_forceKillBrowserProcesses` shortly after, which can SIGKILL Xvfb as a "browser survivor process" if it hasn't exited from the SIGTERM yet.
- Whether it's the graceful SIGTERM path or the SIGKILL-as-survivor path, nothing ever removes the socket/lock file afterward.

**Caveat on reproduction:** I wrote a minimal isolated repro (spawn/kill `VirtualDisplay` directly in a loop, with and without a connected X client via `xclock`, with and without a follow-up `SIGKILL`) and it did **not** reliably reproduce the leak within a few dozen cycles. Xvfb seems to clean up after itself fine under those simplified conditions. So the trigger seems to depend on something a short synthetic test doesn't capture: sustained real load, a fully-initialized Firefox/Camoufox client rather than a lightweight one, timing under contention, or something else I haven't isolated. I'm flagging this explicitly rather than claiming a clean repro I don't actually have. The leak itself is real and directly confirmed via extended live operation (`ls /tmp/.X11-unix | wc -l` measured over multiple days, not inferred), but I can't hand you a 10-second script that proves the exact trigger condition.

Given that, I think the fix is worth taking regardless of pinning down the precise trigger: nothing in `VirtualDisplay.kill()`'s contract guarantees the socket/lock file is removed, so explicit cleanup after confirmed process exit is a safe, unconditional improvement instead of relying on implicit Xvfb self-cleanup behavior.

## Fix

- Added `removeXvfbDisplayFiles(displayNum, { socketDir, lockDir })` to `lib/tmp-cleanup.js`, alongside the existing `cleanupOrphanedTempFiles`/`cleanupStaleFirefoxProfiles` (same category of problem: files left behind by the Xvfb/Firefox/Camoufox process lifecycle that nothing else cleans up).
- Overrode `kill()` in both `VncVirtualDisplay` and `DefaultVirtualDisplay` to call it once the Xvfb child process has actually exited (`proc.once('exit', ...)` if still running, immediately if it already has). Covers both the plain-SIGTERM and force-killed-as-survivor paths.

## Testing

```
$ NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit --runInBand --forceExit
Test Suites: 49 passed, 49 total
Tests:       718 passed, 718 total

$ NODE_OPTIONS='--experimental-vm-modules' npx jest --forceExit plugins/
Test Suites: 6 passed, 6 total
Tests:       45 passed, 45 total
```

Added:
- `tests/unit/tmpCleanup.test.js`: 5 new tests for `removeXvfbDisplayFiles` (removes both files, removes whichever exists without touching unrelated displays, no-op when neither exists, no-op for `null`/`undefined` display).
- `plugins/vnc/vnc.test.js`: 3 new tests for `VncVirtualDisplay.kill()`. Covers deferring cleanup until the tracked process's `exit` event, cleaning up immediately if the process already exited, and cleaning up immediately if there's no tracked process at all.

I also ran the full suite (`npm test`, no `--config`) before and after this change to make sure nothing regressed: `tests/e2e/*` fails identically before and after (67 failures either way). Those need `npm run test:e2e`'s global setup (writes `/tmp/camofox-e2e-env.json`), which the plain default config doesn't provide, and that's unrelated to this change. This PR adds exactly 8 new passing tests on top of that baseline (764 → 772 passing), nothing else moved.

## Notes

- Followed `CONTRIBUTING.md`: no `process.env`/`child_process` added to either plugin/route-handler file, no comments narrating what the code does (kept the one rationale comment on `removeXvfbDisplayFiles` itself, matching the existing doc-comment on `cleanupStaleFirefoxProfiles` right above it).
- Scope kept intentionally narrow. Didn't touch the unrelated pre-existing local changes to `camofox.config.json`/`package-lock.json` in my working tree, they're not part of this fix.