### PR TITLE
fix: pass viewport: null on the health-probe browser context too

### DIFF
--- a/server.js
+++ b/server.js
@@ -6144,7 +6144,7 @@ setInterval(async () => {
   
   let testContext;
   try {
-    testContext = await browser.newContext();
+    testContext = await browser.newContext({ viewport: null });
     const page = await testContext.newPage();
     await page.goto('about:blank', { timeout: 5000 });
     await page.close();

--- a/tests/unit/launchCompat.test.js
+++ b/tests/unit/launchCompat.test.js
@@ -48,4 +48,13 @@ describe('launch compatibility source contract', () => {
     expect(sessionContextOptions).toContain('viewport: null');
     expect(`${googleProbeOptions}\n${sessionContextOptions}`).not.toMatch(/viewport\s*:\s*\{\s*width\s*:/);
   });
+
+  test('health probe context also uses a null viewport', () => {
+    const healthProbeOptions = sourceBetween(
+      'testContext = await browser.newContext(',
+      'const page = await testContext.newPage();'
+    );
+
+    expect(healthProbeOptions).toContain('viewport: null');
+  });
 });


### PR DESCRIPTION
## Summary

#7266 fixed the `Found property "<root>.viewport.isMobile" ... not described in this scheme` juggler rejection by switching to `viewport: null` in `probeGoogleSearch()` and `getSession()`'s context options. There's a third call site it missed: the active health probe (the `setInterval` block a bit further down in `server.js`) calls `browser.newContext()` with no arguments at all, which still picks up Playwright's implicit default viewport and hits the same rejection.

## Why this matters

I hit this indirectly while chasing an unrelated Xvfb cleanup bug (#9252) on a long-running deployment. The browser was restarting every ~2-3 minutes, logged each time as:

```
"level":"warn","msg":"health probe failed","error":"browser.newContext: Protocol error (Browser.setDefaultViewport): ERROR: failed to call method 'Browser.setDefaultViewport' with parameters {...\"viewport\":{...\"isMobile\":false}}\nFound property \"<root>.viewport.isMobile\" - false which is not described in this scheme"
"level":"error","msg":"restarting browser","reason":"health probe failed"
```

So the health probe, whose whole job is to detect a genuinely hung browser, was itself the thing tripping the failure on an otherwise healthy browser, repeatedly. Each restart also churns a new Xvfb process, which is what made that separate leak accumulate as fast as it did on my host.

## Fix

`testContext = await browser.newContext();` becomes `testContext = await browser.newContext({ viewport: null });`, matching the pattern #7266 already established at the other two call sites.

## Testing

Extended `tests/unit/launchCompat.test.js` (added in #7266, "same source-contract idiom as `tests/unit/noSecrets.test.js`") with a fourth case for this call site. Confirmed it actually catches the bug: ran it against the unpatched line first (fails: `Expected substring: "viewport: null"`), then with the fix (passes).

```
$ NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit --runInBand --forceExit
Test Suites: 49 passed, 49 total
Tests:       714 passed, 714 total

$ NODE_OPTIONS='--experimental-vm-modules' npx jest --forceExit plugins/
Test Suites: 6 passed, 6 total
Tests:       42 passed, 42 total
```

One-line fix, one new assertion, no other files touched.