### PR TITLE
fix(docker): build on Linux ARM64 and include mcp/ module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,10 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     unzip \
-    # yt-dlp runtime dependency
-    python3-minimal \
+    # Native-module build tools (better-sqlite3 has no prebuilt for node22/arm64)
+    build-essential \
+    # yt-dlp runtime dependency + node-gyp interpreter
+    python3 \
     && rm -rf /var/lib/apt/lists/*
 
 # Pre-bake Camoufox browser binary into image (downloaded at build time)
@@ -61,11 +63,17 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY scripts/ ./scripts/
 RUN npm ci --omit=dev
+# better-sqlite3 ships prebuildify prebuilds built against glibc 2.38, but this
+# base (node:22-slim = Debian bookworm) ships glibc 2.36, so the shipped
+# linux-arm64.node fails to load at runtime. Drop the prebuilds and compile
+# from source against the container's own glibc instead.
+RUN cd node_modules/better-sqlite3 && rm -rf prebuilds && npm run build-release
 
 COPY server.js ./
 COPY camofox.config.json ./
 COPY lib/ ./lib/
 COPY plugins/ ./plugins/
+COPY mcp/ ./mcp/
 COPY scripts/ ./scripts/
 
 # Install default plugin dependencies (apt packages + post-install hooks)


### PR DESCRIPTION
## Problem

The Docker image fails to build and run on Linux ARM64 (aarch64) hosts (e.g. Oracle Ampere, Raspberry Pi):

1. **`better-sqlite3` fails at runtime** — the shipped prebuildify binary `prebuilds/linux-arm64.node` is linked against glibc 2.38, but the `node:22-slim` base (Debian bookworm) ships glibc 2.36, so loading it throws `GLIBC_2.38 not found`.
2. **No toolchain in the base image** — `node:22-slim` has no `make`/`g++`, so even when the prebuild doesn't match, `node-gyp` can't compile a fallback.
3. **`mcp/` is not copied** — `lib/cookies.js` imports `/app/mcp/lib/cookies.mjs`, but the Dockerfile never `COPY mcp/`, so the `persistence` plugin fails to load with `ERR_MODULE_NOT_FOUND`.

## Fix

- Add `build-essential` + `python3` to the base image.
- Drop `better-sqlite3`'s prebuilds and compile from source (`npm run build-release`) against the container's own glibc, so the native module always matches the target platform.
- `COPY mcp/ ./mcp/`.

## Testing

Built and ran on Linux aarch64 (Oracle Ampere):

- `camoufox launched` cleanly (no glibc error).
- `POST /tabs` + `GET /tabs/:id/snapshot` returned real page content with element refs.
- The `persistence` plugin loads without error.
