### PR TITLE
Dockerfile: fix two independent aarch64 build/runtime failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,12 @@ RUN apt-get update && apt-get install -y \
 
 # Pre-bake Camoufox browser binary into image (downloaded at build time)
 # Note: unzip returns exit code 1 for warnings (Unicode filenames), so we use || true and verify
+# -f so a 404 fails here instead of writing "Not Found" into the .zip: without it the
+# build dies three commands later on "unzip: cannot find zipfile directory", which
+# points at the archive rather than at the URL that was actually wrong. Note the Linux
+# arm asset is named lin.arm64.zip -- pass --build-arg ARCH=arm64, not aarch64.
 RUN mkdir -p /root/.cache/camoufox \
-    && curl -L -o /tmp/camoufox.zip "https://github.com/daijro/camoufox/releases/download/v${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}/camoufox-${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}-lin.${ARCH}.zip" \
+    && curl -fL -o /tmp/camoufox.zip "https://github.com/daijro/camoufox/releases/download/v${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}/camoufox-${CAMOUFOX_VERSION}-${CAMOUFOX_RELEASE}-lin.${ARCH}.zip" \
     && (unzip -q /tmp/camoufox.zip -d /root/.cache/camoufox || true) \
     && rm /tmp/camoufox.zip \
     && chmod -R 755 /root/.cache/camoufox \
@@ -79,6 +83,12 @@ RUN apt-get update \
 COPY server.js ./
 COPY camofox.config.json ./
 COPY lib/ ./lib/
+# lib/cookies.js is a compatibility re-export from ../mcp/lib/cookies.mjs, so mcp/
+# must ship even though the MCP server itself is not run here. Without it the
+# persistence plugin dies at load with ERR_MODULE_NOT_FOUND, the server starts
+# anyway, /health keeps reporting ok, and no profile is ever written -- i.e. the
+# container silently loses the durable-profile feature it exists to provide.
+COPY mcp/ ./mcp/
 COPY plugins/ ./plugins/
 COPY scripts/ ./scripts/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM node:22-slim AS camofox-browser
+# Trixie (glibc 2.41), not bookworm (2.36): better-sqlite3 ships an arm64 prebuild
+# linked against GLIBC_2.38, so on bookworm it loads and then dies at runtime with
+# "version `GLIBC_2.38' not found" the first time a tab is opened. amd64 is
+# unaffected because that prebuild targets an older glibc.
+FROM node:22-trixie-slim AS camofox-browser
 
 # Pinned Camoufox version for reproducible builds
 # Update these when upgrading Camoufox
@@ -25,7 +29,8 @@ RUN apt-get update && apt-get install -y \
     libxtst6 \
     # Mesa OpenGL/EGL for WebGL support (software rendering via llvmpipe)
     # Without these, Firefox cannot create WebGL contexts -- a major bot detection signal
-    libegl1-mesa \
+    # libegl1 -- named libegl1-mesa on bookworm, dropped in trixie
+    libegl1 \
     libgl1-mesa-dri \
     libgbm1 \
     # Xvfb virtual display -- runs Camoufox as if on a real desktop (better anti-detection)
@@ -60,7 +65,16 @@ WORKDIR /app
 
 COPY package.json package-lock.json ./
 COPY scripts/ ./scripts/
-RUN npm ci --omit=dev
+# better-sqlite3 has no prebuild matching this node/arch, so npm ci falls back to
+# `node-gyp rebuild`, which fails on node:*-slim with "Error: not found: make".
+# Install a toolchain for the build and purge it in the same layer so it does not
+# land in the image. Independent of the glibc issue noted at the FROM line: this
+# one fails at build time on any Debian release, that one at runtime on bookworm.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential python3 \
+    && npm ci --omit=dev \
+    && apt-get purge -y --auto-remove build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY server.js ./
 COPY camofox.config.json ./


### PR DESCRIPTION
The image can't be built or run on `linux/arm64` today. Two independent defects stack, so fixing either one alone still fails — I spent a couple of builds thinking I'd found "the" root cause before realising there were two.

## 1. Build time — fails on any Debian release

`npm ci --omit=dev` finds no `better-sqlite3` prebuild matching this node/arch and falls back to `node-gyp rebuild`, which dies on `node:*-slim`:

```
Error: not found: make
```

Fix: install `build-essential` + `python3`, run the install, and purge them in the same layer so the toolchain doesn't land in the final image.

## 2. Runtime — bookworm only, and it doesn't fail at startup

`better-sqlite3` ships a **bundled** `prebuilds/linux-arm64.node` linked against `GLIBC_2.38`. Bookworm ships **2.36**. The module resolves fine, the server starts and reports healthy, and then the **first tab open** throws:

```
ERR_DLOPEN_FAILED: /app/node_modules/better-sqlite3/prebuilds/linux-arm64.node:
  /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
```

`node:22-trixie-slim` ships glibc **2.41**, which satisfies it.

Worth noting for anyone who tries the obvious workaround first: `npm_config_build_from_source=true` + `npm rebuild --build-from-source` does **not** fix this. The loader prefers the bundled `prebuilds/<platform>-<arch>.node` **file** over anything in `build/Release/`, and the forced build left `.deps` + `obj.target` behind with no linked `.node` — a half-build that looks like a build. Matching the glibc is the reliable fix; the alternative is `rm -rf node_modules/better-sqlite3/prebuilds`, which felt more invasive than a base bump.

## Package rename that comes with trixie

`libegl1-mesa` is dropped in trixie — it's `libegl1` now. `libgl1-mesa-dri`, `libgbm1` and `libasound2` are unchanged (no t64 churn on these).

## What I tested

`linux/arm64` only, on Amazon Linux 2023 / aarch64:

- Image builds clean from a cold cache.
- `/health` returns `{"ok":true,"engine":"camoufox","browserConnected":true,"browserRunning":true,"activeTabs":2,...}` with tabs actually open — i.e. past the point where defect 2 used to throw.
- `ldd --version` in the image reports `2.41`, and `libEGL.so.1` is present.

**I have not built or run this on amd64.** amd64 is unaffected by defect 2 (its prebuild targets an older glibc), so for amd64 this change is a base-image bump plus the toolchain fix from defect 1. If you'd rather not move the base image for everyone, the alternative is a conditional on `TARGETARCH` — happy to rework it that way, or to split the two fixes into separate commits if that's easier to review.