### PR TITLE
fix(server): pin browser launch env to X11 so Wayland desktops never see a window

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,18 @@ Sessions auto-expire after 30 minutes of inactivity. The browser itself shuts do
 
 When a session's tab limit is reached, the oldest/least-used tab is automatically recycled instead of returning an error -- so long-running agent sessions don't hit dead ends.
 
+### Virtual display and Wayland desktops
+
+On Linux the browser is launched headful inside a private Xvfb display rather than in true headless mode: Xvfb provides GLX, so WebGL works via Mesa llvmpipe instead of returning "no context" (a strong bot signal). The window is real but exists only on the virtual display -- nothing should ever appear on your desktop.
+
+Two host-environment leaks can break that invisibility, and both are handled:
+
+1. **Wayland backend bypass.** Firefox selects its display backend *before* honoring `DISPLAY`. If the service inherits `WAYLAND_DISPLAY` from a Wayland session (Hyprland, GNOME, KDE -- and desktops like omarchy also export `MOZ_ENABLE_WAYLAND=1` session-wide), the Wayland backend wins, `DISPLAY=:N` (the Xvfb) is ignored, and the browser opens a visible window on your real compositor -- tiling into the active workspace and kicking neighbors out of fullscreen. The server therefore launches the browser with a sanitized environment (`lib/display-env.js`): `WAYLAND_DISPLAY` and `XDG_SESSION_TYPE` removed, `MOZ_ENABLE_WAYLAND=0` and `GDK_BACKEND=x11` forced. Playwright replaces the child environment with the provided one, so removal is genuine. Your desktop session is never modified.
+
+2. **Xvfb display-number collision.** `camoufox-js` runs `Xvfb -displayfd`, letting the X server pick a display number starting at `:0`. On a Wayland desktop, `:0` belongs to Xwayland but the *abstract-namespace* socket for it is typically unclaimed, so Xvfb can steal the display out from under the compositor and break every X11 app on the desktop. If you run the server as a desktop service, pin Xvfb to a private display range (a `PATH` shim intercepting the Xvfb invocation works; see the systemd notes in the deployment kit) or run the whole stack in a container.
+
+To verify the browser is invisible on a Hyprland desktop: create a tab, then check `hyprctl clients -j` -- no `camoufox` client should be listed, while screenshots through the API keep working.
+
 ## Security Model
 
 This section documents the security boundaries of camofox-browser for users and automated security reviewers.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -14,9 +14,12 @@ module.exports = {
     '**/scripts/**/*.test.js'
   ],
   
-  // Ignore patterns
+  // Ignore patterns. E2E suites need the globalSetup in jest.config.e2e.cjs
+  // (it writes /tmp/camofox-e2e-env.json); without it they fail at import, so
+  // they only run via `npm run test:e2e` -- same split CI uses.
   testPathIgnorePatterns: [
-    '/node_modules/'
+    '/node_modules/',
+    '/tests/e2e/'
   ],
   
   // Setup and teardown

--- a/lib/display-env.js
+++ b/lib/display-env.js
@@ -1,0 +1,34 @@
+// lib/display-env.js -- Launch environment for the browser under Xvfb.
+//
+// Firefox picks its display backend BEFORE honoring DISPLAY: if
+// WAYLAND_DISPLAY is present (and MOZ_ENABLE_WAYLAND=1, which Wayland
+// desktops like Hyprland/omarchy export session-wide), the Wayland backend
+// wins, DISPLAY is ignored, and the browser opens a real window on the
+// user's compositor -- tiling into their active workspace and kicking apps
+// out of fullscreen -- while the Xvfb display renders for nobody.
+//
+// Playwright REPLACES the child environment with the `env` launch option
+// when one is provided (playwright-core browserType: `options.env ? ... :
+// process.env`), so deleting the Wayland variables from a copy here truly
+// removes them from the browser process without touching the desktop
+// session. camoufox-js then sets DISPLAY to the virtual display on this
+// same object.
+
+/**
+ * Build a browser launch environment pinned to the X11 backend, so the
+ * window can only ever appear on the virtual (Xvfb) display.
+ *
+ * @param {NodeJS.ProcessEnv} [baseEnv] - Environment to copy (default process.env).
+ * @returns {NodeJS.ProcessEnv} New object; the input is never mutated.
+ */
+export function x11PinnedEnv(baseEnv = process.env) {
+  const env = { ...baseEnv };
+  // With WAYLAND_DISPLAY set, the Wayland backend outranks DISPLAY even when
+  // MOZ_ENABLE_WAYLAND=0 is also set on some Firefox builds -- removal is the
+  // only reliable off switch.
+  delete env.WAYLAND_DISPLAY;
+  delete env.XDG_SESSION_TYPE;
+  env.MOZ_ENABLE_WAYLAND = '0';
+  env.GDK_BACKEND = 'x11';
+  return env;
+}

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "prepublishOnly": "npm run build",
     "start": "node server.js",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest --runInBand --forceExit",
-    "test:e2e": "NODE_OPTIONS='--experimental-vm-modules' jest --runInBand --forceExit tests/e2e",
+    "test:e2e": "NODE_OPTIONS='--experimental-vm-modules' jest --config jest.config.e2e.cjs --runInBand --forceExit",
     "test:plugins": "NODE_OPTIONS='--experimental-vm-modules' jest --forceExit plugins/",
     "test:live": "RUN_LIVE_TESTS=1 NODE_OPTIONS='--experimental-vm-modules' jest --runInBand --forceExit tests/live",
     "test:debug": "DEBUG_SERVER=1 NODE_OPTIONS='--experimental-vm-modules' jest --runInBand --forceExit",

--- a/server.js
+++ b/server.js
@@ -32,6 +32,7 @@ import {
 } from './lib/metrics.js';
 import { actionFromReq, classifyError } from './lib/request-utils.js';
 import { cleanupOrphanedTempFiles, cleanupStaleFirefoxProfiles } from './lib/tmp-cleanup.js';
+import { x11PinnedEnv } from './lib/display-env.js';
 import { coalesceInflight } from './lib/inflight.js';
 import { createReporter, createTabHealthTracker, collectResourceSnapshot, classifyProxyError, browserProcessTreeRssMb } from './lib/reporter.js';
 import { mountDocs } from './lib/openapi.js';
@@ -983,6 +984,12 @@ async function launchBrowserInstance() {
         proxy: launchProxy,
         geoip: !!launchProxy,
         virtual_display: vdDisplay,
+        // Pin the browser to the Xvfb display. Without this, a session-wide
+        // WAYLAND_DISPLAY (Hyprland, GNOME, KDE on Wayland) makes Firefox pick
+        // its Wayland backend, ignore DISPLAY, and open a visible window on
+        // the user's desktop. Passing env also stops camoufox-js from
+        // mutating process.env (it sets DISPLAY on whatever object it gets).
+        env: useVirtualDisplay ? x11PinnedEnv() : undefined,
       });
       options.proxy = normalizePlaywrightProxy(options.proxy);
       await pluginEvents.emitAsync('browser:launching', { options });

--- a/tests/unit/displayEnv.test.js
+++ b/tests/unit/displayEnv.test.js
@@ -1,0 +1,40 @@
+import { x11PinnedEnv } from '../../lib/display-env.js';
+
+describe('x11PinnedEnv', () => {
+  test('removes Wayland session variables', () => {
+    const env = x11PinnedEnv({
+      WAYLAND_DISPLAY: 'wayland-1',
+      XDG_SESSION_TYPE: 'wayland',
+      HOME: '/home/user',
+    });
+    expect(env).not.toHaveProperty('WAYLAND_DISPLAY');
+    expect(env).not.toHaveProperty('XDG_SESSION_TYPE');
+  });
+
+  test('forces the X11 backend', () => {
+    const env = x11PinnedEnv({ MOZ_ENABLE_WAYLAND: '1', GDK_BACKEND: 'wayland,x11,*' });
+    expect(env.MOZ_ENABLE_WAYLAND).toBe('0');
+    expect(env.GDK_BACKEND).toBe('x11');
+  });
+
+  test('preserves unrelated variables', () => {
+    const env = x11PinnedEnv({ HOME: '/home/user', PATH: '/usr/bin', DISPLAY: ':0' });
+    expect(env.HOME).toBe('/home/user');
+    expect(env.PATH).toBe('/usr/bin');
+    // DISPLAY passes through untouched; camoufox-js repoints it at the Xvfb display.
+    expect(env.DISPLAY).toBe(':0');
+  });
+
+  test('never mutates the input', () => {
+    const input = { WAYLAND_DISPLAY: 'wayland-1', MOZ_ENABLE_WAYLAND: '1' };
+    x11PinnedEnv(input);
+    expect(input).toEqual({ WAYLAND_DISPLAY: 'wayland-1', MOZ_ENABLE_WAYLAND: '1' });
+  });
+
+  test('defaults to process.env without mutating it', () => {
+    const before = { ...process.env };
+    const env = x11PinnedEnv();
+    expect(env.MOZ_ENABLE_WAYLAND).toBe('0');
+    expect(process.env).toEqual(before);
+  });
+});


### PR DESCRIPTION
## Problem

On Wayland desktops (Hyprland, GNOME, KDE), the browser opens a **visible window on the user's real compositor** instead of rendering into its private Xvfb virtual display. On tiling compositors it lands in the active workspace, splits the layout, and kicks neighboring windows out of fullscreen.

## Root cause

Firefox selects its display backend **before** honoring `DISPLAY`. The server child inherits `WAYLAND_DISPLAY` from the session (and desktops like omarchy export `MOZ_ENABLE_WAYLAND=1` session-wide, including into the systemd user manager). camoufox-js only overrides `DISPLAY` on the inherited environment, so the Wayland backend wins, `DISPLAY=:N` (the Xvfb) is ignored, and the Xvfb renders for nobody.

Verified live on Hyprland: the camoufox process had `DISPLAY=:153` (correct Xvfb) **and** `WAYLAND_DISPLAY=wayland-1` + `MOZ_ENABLE_WAYLAND=1`; `hyprctl clients` showed the browser as a native Wayland window (`xwayland: false`) tiled into the user's workspace.

## Fix

`launchBrowserInstance` now passes a sanitized environment to `launchOptions` whenever a virtual display is in use (new `lib/display-env.js`): removes `WAYLAND_DISPLAY` and `XDG_SESSION_TYPE`, forces `MOZ_ENABLE_WAYLAND=0` and `GDK_BACKEND=x11`. Playwright **replaces** the child env with the provided one (`options.env ? envArrayToObject(options.env) : process.env`), so the removal is genuine. Side benefit: camoufox-js no longer mutates the server's own `process.env.DISPLAY` (it writes `DISPLAY` onto whatever env object it receives).

Verified on the same machine after the fix: browser child env shows `DISPLAY=:1xx`, no `WAYLAND_DISPLAY`, `MOZ_ENABLE_WAYLAND=0`, `GDK_BACKEND=x11`; `hyprctl clients` lists no camoufox window; screenshots through the API keep working (WebGL via Xvfb intact).

## Also in this PR

- **Test script alignment**: plain `npm test` always failed locally because the default jest config matched `tests/e2e/` without the e2e globalSetup (`ENOENT /tmp/camofox-e2e-env.json`). The default config now ignores `tests/e2e/` and `test:e2e` passes `--config jest.config.e2e.cjs` — the exact split CI already uses (`.github/workflows/ci.yml` never runs plain `npm test`). No CI behavior change.
- **Docs**: new README section (*Virtual display and Wayland desktops*) documenting this failure mode and the related Xvfb `-displayfd` display-number collision hazard on Wayland hosts.

## Tests

- New `tests/unit/displayEnv.test.js` (5 tests: Wayland vars removed, X11 forced, unrelated vars preserved, input never mutated, `process.env` default never mutated).
- Full suite: 46 suites passed, 2 skipped.