### PR TITLE
fix(docker): add native build tools for better-sqlite3 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ ARG ARCH=x86_64
 
 # Install dependencies for Camoufox (Firefox-based)
 RUN apt-get update && apt-get install -y \
+    # Native module build tools (for better-sqlite3 / node-gyp)
+    python3 \
+    make \
+    g++ \
     # Firefox dependencies
     libgtk-3-0 \
     libdbus-glib-1-2 \


### PR DESCRIPTION
## Description
This pull request fixes a build failure during `npm ci` where native node modules (such as `better-sqlite3`) fail to compile via `node-gyp`. 

On slim Debian/Ubuntu-based Docker images, the build fails because tools like `python3`, `make`, and `g++` are missing. This PR adds those build dependencies to the `Dockerfile` prior to running package installation.

## Changes Made
- Added `python3`, `make`, and `g++` installation step in the `Dockerfile` via `apt-get`.

## Testing
- Verified that a fresh container build completes successfully without throwing `gyp ERR!` or exit code 1 errors.