### PR TITLE
fix: avoid fixed geolocation in direct sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ When a proxy is configured:
 - All traffic routes through the proxy
 - Camoufox's GeoIP automatically sets `locale`, `timezone`, and `geolocation` to match the proxy's exit IP
 - Browser fingerprint (language, timezone, coordinates) is consistent with the proxy location
-- Without a proxy, defaults to `en-US`, `America/Los_Angeles`, San Francisco coordinates
+- Without a proxy, direct contexts use the configured locale and timezone and do not set geolocation permissions or coordinates
 
 ### Telemetry
 
@@ -630,6 +630,9 @@ Browser behavior can be tuned in `camofox.config.json`:
 | `CAMOFOX_ADMIN_KEY` | Required for `POST /stop` | - |
 | `CAMOFOX_ACCESS_KEY` | If set, all routes (except `/health`, cookie import, and `/stop`) require `Authorization: Bearer <key>`. Lets you safely expose the server beyond loopback. | - |
 | `CAMOFOX_EVALUATE_MAX_BODY_SIZE` | Max JSON request body size for `POST /tabs/:tabId/evaluate`; other JSON routes remain limited to `100kb`. | `1mb` |
+| `CAMOFOX_LOCALE` | Locale for direct browser contexts; defaults to the first `CAMOFOX_LOCALES` entry when provided | `en-US` |
+| `CAMOFOX_LOCALES` | Comma-separated locales for the direct Camoufox launch | `CAMOFOX_LOCALE` |
+| `CAMOFOX_TIMEZONE` | Timezone for direct browser contexts | `America/Los_Angeles` |
 | `CAMOUFOX_EXECUTABLE` | External Camoufox executable to use instead of downloading/launching the bundled cache. Must point to a Camoufox bundle with sibling resources. | - |
 | `CAMOUFOX_EXECUTABLE_PATH` | Compatibility alias for `CAMOUFOX_EXECUTABLE` | - |
 | `CAMOFOX_EXECUTABLE_PATH` | Compatibility alias for `CAMOUFOX_EXECUTABLE` | - |

--- a/lib/browser-identity.js
+++ b/lib/browser-identity.js
@@ -1,0 +1,8 @@
+export function contextIdentityOptions({ hasProxy, locale, timezoneId }) {
+  if (hasProxy) return { permissions: ['geolocation'] };
+  return { locale, timezoneId };
+}
+
+export function launchLocale({ hasProxy, locales }) {
+  return hasProxy ? undefined : locales;
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -57,6 +57,11 @@ function inferProxyStrategy(explicitStrategy) {
   return 'round_robin';
 }
 
+function envString(value, fallback) {
+  const trimmed = String(value || '').trim();
+  return trimmed || fallback;
+}
+
 function camoufoxCacheDir(env = process.env) {
   const home = os.homedir();
   if (process.platform === 'darwin') return join(home, 'Library', 'Caches', 'camoufox');
@@ -84,6 +89,10 @@ function loadConfig({ configPath = CONFIG_PATH } = {}) {
   const newPageTimeoutMs = Number.isFinite(configuredNewPageTimeoutMs) && configuredNewPageTimeoutMs > 0
     ? configuredNewPageTimeoutMs
     : 10000;
+  const configuredLocales = envString(process.env.CAMOFOX_LOCALES, '');
+  const locale = envString(process.env.CAMOFOX_LOCALE, configuredLocales.split(',')[0] || 'en-US');
+  const locales = configuredLocales || locale;
+  const timezoneId = envString(process.env.CAMOFOX_TIMEZONE, 'America/Los_Angeles');
   return {
     port: parseInt(process.env.CAMOFOX_PORT || process.env.PORT || '9377', 10),
     bindHost: (process.env.CAMOFOX_BIND_HOST || '').trim(),
@@ -95,6 +104,9 @@ function loadConfig({ configPath = CONFIG_PATH } = {}) {
     apiKey: process.env.CAMOFOX_API_KEY || '',
     accessKey: (process.env.CAMOFOX_ACCESS_KEY || '').trim(),
     evaluateMaxBodySize: process.env.CAMOFOX_EVALUATE_MAX_BODY_SIZE || '1mb',
+    locale,
+    locales,
+    timezoneId,
     cookiesDir: process.env.CAMOFOX_COOKIES_DIR || join(os.homedir(), '.camofox', 'cookies'),
     uploadsDir: process.env.CAMOFOX_UPLOADS_DIR || join(os.homedir(), '.camofox', 'uploads'),
     profileDir: process.env.CAMOFOX_PROFILE_DIR || join(os.homedir(), '.camofox', 'profiles'),
@@ -147,6 +159,9 @@ function loadConfig({ configPath = CONFIG_PATH } = {}) {
       CAMOFOX_API_KEY: process.env.CAMOFOX_API_KEY,
       CAMOFOX_ACCESS_KEY: process.env.CAMOFOX_ACCESS_KEY,
       CAMOFOX_EVALUATE_MAX_BODY_SIZE: process.env.CAMOFOX_EVALUATE_MAX_BODY_SIZE,
+      CAMOFOX_LOCALE: process.env.CAMOFOX_LOCALE,
+      CAMOFOX_LOCALES: process.env.CAMOFOX_LOCALES,
+      CAMOFOX_TIMEZONE: process.env.CAMOFOX_TIMEZONE,
       CAMOFOX_COOKIES_DIR: process.env.CAMOFOX_COOKIES_DIR,
       CAMOFOX_UPLOADS_DIR: process.env.CAMOFOX_UPLOADS_DIR,
       CAMOFOX_TRACES_DIR: process.env.CAMOFOX_TRACES_DIR,

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ import fs from 'fs';
 import os from 'os';
 import { expandMacro } from './lib/macros.js';
 import { loadConfig } from './lib/config.js';
+import { contextIdentityOptions, launchLocale } from './lib/browser-identity.js';
 import { normalizePlaywrightProxy, createProxyPool, buildProxyUrl } from './lib/proxy.js';
 import { createFlyHelpers } from './lib/fly.js';
 import { createPluginEvents, loadPlugins } from './lib/plugins.js';
@@ -826,10 +827,15 @@ function getExternalCamoufoxLaunch() {
 async function probeGoogleSearch(candidateBrowser) {
   let context = null;
   try {
-    context = await candidateBrowser.newContext({
+    const contextOptions = {
       viewport: null,
-      permissions: ['geolocation'],
-    });
+      ...contextIdentityOptions({
+        hasProxy: !!proxyPool,
+        locale: CONFIG.locale,
+        timezoneId: CONFIG.timezoneId,
+      }),
+    };
+    context = await candidateBrowser.newContext(contextOptions);
     const page = await context.newPage();
     await page.goto('https://www.google.com/', { waitUntil: 'domcontentloaded', timeout: 30000 });
     await page.waitForTimeout(1200);
@@ -1062,6 +1068,7 @@ async function launchBrowserInstance() {
         enable_cache: true,
         proxy: launchProxy,
         geoip: !!launchProxy,
+        locale: launchLocale({ hasProxy: !!proxyPool, locales: CONFIG.locales }),
         virtual_display: vdDisplay,
         exclude_addons: CONFIG.disableDefaultAddons ? ['UBO'] : undefined,
       });
@@ -1272,15 +1279,12 @@ async function getSession(userId, { trace = false } = {}) {
       const b = await ensureBrowser();
       const contextOptions = {
         viewport: null,
-        permissions: ['geolocation'],
+        ...contextIdentityOptions({
+          hasProxy: !!proxyPool,
+          locale: CONFIG.locale,
+          timezoneId: CONFIG.timezoneId,
+        }),
       };
-      // When geoip is active (proxy configured), camoufox auto-configures
-      // locale/timezone/geolocation from the proxy IP. Without proxy, use defaults.
-      if (!CONFIG.proxy.host) {
-        contextOptions.locale = 'en-US';
-        contextOptions.timezoneId = 'America/Los_Angeles';
-        contextOptions.geolocation = { latitude: 37.7749, longitude: -122.4194 };
-      }
       let sessionProxy = null;
       if (proxyPool?.canRotateSessions) {
         sessionProxy = proxyPool.getNext(`ctx-${key}-${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`);

--- a/tests/unit/browserIdentity.test.js
+++ b/tests/unit/browserIdentity.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, test } from '@jest/globals';
+import { contextIdentityOptions, launchLocale } from '../../lib/browser-identity.js';
+
+describe('browser identity options', () => {
+  test('direct contexts use configured locale and timezone without geolocation permission', () => {
+    expect(contextIdentityOptions({
+      hasProxy: false,
+      locale: 'ru-RU',
+      timezoneId: 'Europe/Moscow',
+    })).toEqual({
+      locale: 'ru-RU',
+      timezoneId: 'Europe/Moscow',
+    });
+  });
+
+  test('proxy contexts preserve GeoIP geolocation permission', () => {
+    expect(contextIdentityOptions({
+      hasProxy: true,
+      locale: 'ru-RU',
+      timezoneId: 'Europe/Moscow',
+    })).toEqual({ permissions: ['geolocation'] });
+  });
+
+  test('launch locale is applied only to direct browser launches', () => {
+    expect(launchLocale({ hasProxy: false, locales: 'ru-RU,ru' })).toBe('ru-RU,ru');
+    expect(launchLocale({ hasProxy: true, locales: 'ru-RU,ru' })).toBeUndefined();
+  });
+});

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -20,6 +20,43 @@ describe('loadConfig', () => {
     expect(config.serverEnv.CAMOFOX_BIND_HOST).toBe('127.0.0.1');
   });
 
+  test('configures and forwards browser locale and timezone settings', () => {
+    process.env.CAMOFOX_LOCALE = ' ru-RU ';
+    process.env.CAMOFOX_LOCALES = ' ru-RU,ru ';
+    process.env.CAMOFOX_TIMEZONE = ' Europe/Moscow ';
+
+    const config = loadConfig();
+
+    expect(config.locale).toBe('ru-RU');
+    expect(config.locales).toBe('ru-RU,ru');
+    expect(config.timezoneId).toBe('Europe/Moscow');
+    expect(config.serverEnv.CAMOFOX_LOCALE).toBe(' ru-RU ');
+    expect(config.serverEnv.CAMOFOX_LOCALES).toBe(' ru-RU,ru ');
+    expect(config.serverEnv.CAMOFOX_TIMEZONE).toBe(' Europe/Moscow ');
+  });
+
+  test('keeps compatible browser locale and timezone defaults', () => {
+    delete process.env.CAMOFOX_LOCALE;
+    delete process.env.CAMOFOX_LOCALES;
+    delete process.env.CAMOFOX_TIMEZONE;
+
+    const config = loadConfig();
+
+    expect(config.locale).toBe('en-US');
+    expect(config.locales).toBe('en-US');
+    expect(config.timezoneId).toBe('America/Los_Angeles');
+  });
+
+  test('derives the context locale from the launch locale list', () => {
+    delete process.env.CAMOFOX_LOCALE;
+    process.env.CAMOFOX_LOCALES = ' ru-RU,ru ';
+
+    const config = loadConfig();
+
+    expect(config.locale).toBe('ru-RU');
+    expect(config.locales).toBe('ru-RU,ru');
+  });
+
   test('prefers CAMOUFOX_EXECUTABLE for external Camoufox executable', () => {
     process.env.CAMOUFOX_EXECUTABLE = '/nix/store/camoufox/bin/camoufox';
     process.env.CAMOUFOX_EXECUTABLE_PATH = '/ignored/camoufox';

--- a/tests/unit/launchCompat.test.js
+++ b/tests/unit/launchCompat.test.js
@@ -36,16 +36,41 @@ describe('launch compatibility source contract', () => {
 
   test('does not configure a fixed default browser context viewport', () => {
     const googleProbeOptions = sourceBetween(
-      'context = await candidateBrowser.newContext({',
+      'async function probeGoogleSearch(candidateBrowser) {',
       'const page = await context.newPage();'
     );
     const sessionContextOptions = sourceBetween(
-      'const contextOptions = {',
-      '// When geoip is active'
+      'const b = await ensureBrowser();',
+      'let sessionProxy = null;'
     );
 
     expect(googleProbeOptions).toContain('viewport: null');
     expect(sessionContextOptions).toContain('viewport: null');
     expect(`${googleProbeOptions}\n${sessionContextOptions}`).not.toMatch(/viewport\s*:\s*\{\s*width\s*:/);
+  });
+
+  test('does not grant geolocation or use fixed coordinates in direct sessions', () => {
+    const googleProbeOptions = sourceBetween(
+      'async function probeGoogleSearch(candidateBrowser) {',
+      'const page = await context.newPage();'
+    );
+    const sessionContextOptions = sourceBetween(
+      'const b = await ensureBrowser();',
+      'let sessionProxy = null;'
+    );
+
+    expect(googleProbeOptions).toContain('...contextIdentityOptions({');
+    expect(sessionContextOptions).toContain('...contextIdentityOptions({');
+    expect(sessionContextOptions).not.toContain('geolocation:');
+    expect(sessionContextOptions).not.toContain('37.7749');
+  });
+
+  test('uses configured locales for direct Camoufox launch identity', () => {
+    const launchOptionsBlock = sourceBetween(
+      'const options = await launchOptions({',
+      'options.proxy = normalizePlaywrightProxy(options.proxy);'
+    );
+
+    expect(launchOptionsBlock).toContain('locale: launchLocale({ hasProxy: !!proxyPool, locales: CONFIG.locales })');
   });
 });


### PR DESCRIPTION
## Summary

- stop assigning fixed San Francisco coordinates to direct (no-proxy) browser contexts
- make direct-session locale, language list, and timezone configurable through explicit `CAMOFOX_*` environment variables
- preserve existing proxy GeoIP behavior, including geolocation permission for proxy-backed contexts
- apply the same direct identity settings to the Google health probe
- centralize direct/proxy identity options in a behavior-tested helper

## Motivation

Every direct connection currently receives San Francisco coordinates and a granted geolocation permission, even when the network exit is elsewhere. That creates a location mismatch and grants a sensitive permission without a caller request.

The change keeps the current `en-US` / `America/Los_Angeles` defaults for compatibility, but no longer fabricates exact coordinates for direct sessions. Operators can align the browser identity with their real exit using:

- `CAMOFOX_LOCALE`
- `CAMOFOX_LOCALES`
- `CAMOFOX_TIMEZONE`

Proxy-backed sessions continue to rely on Camoufox GeoIP and retain their previous geolocation permission behavior.

## Verification

- `npm test -- --runInBand tests/unit/config.test.js tests/unit/browserIdentity.test.js tests/unit/launchCompat.test.js`
- `npm run build`
- `npm run test:mcp`
- CI-equivalent unit + plugin suite: 59 suites / 792 tests passed
- `node --check server.js`

The regression tests were added before the implementation and failed against the previous hard-coded direct-session behavior.

## Scope

This intentionally does not change proxy selection, virtual-display ownership, persistence, health-probe viewport sizing, or shutdown behavior.
