### PR TITLE
fix: allow persistence-safe shutdown budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,6 +645,7 @@ Browser behavior can be tuned in `camofox.config.json`:
 | `SESSION_TIMEOUT_MS` | Session inactivity timeout | `1800000` (30min) |
 | `BROWSER_IDLE_TIMEOUT_MS` | Kill browser when idle (0 = never) | `300000` (5min) |
 | `HANDLER_TIMEOUT_MS` | Max time for any handler | `30000` (30s) |
+| `CAMOFOX_SHUTDOWN_TIMEOUT_MS` | Maximum time graceful shutdown waits for persistence checkpoints and browser/session cleanup before forcing exit. Must be a positive integer. | `45000` (45s) |
 | `MAX_CONCURRENT_PER_USER` | Concurrent request cap per user | `3` |
 | `MAX_OLD_SPACE_SIZE` | Node.js V8 heap limit (MB) | `128` |
 | `PROXY_STRATEGY` | Proxy mode: `backconnect` (rotating sticky sessions) or blank (single endpoint) | - |

--- a/lib/config.js
+++ b/lib/config.js
@@ -57,6 +57,11 @@ function inferProxyStrategy(explicitStrategy) {
   return 'round_robin';
 }
 
+function parsePositiveTimeoutMs(value, fallback) {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 && parsed <= 2_147_483_647 ? parsed : fallback;
+}
+
 function camoufoxCacheDir(env = process.env) {
   const home = os.homedir();
   if (process.platform === 'darwin') return join(home, 'Library', 'Caches', 'camoufox');
@@ -79,6 +84,7 @@ function camoufoxExecutablePath(env = process.env) {
 function loadConfig({ configPath = CONFIG_PATH } = {}) {
   const externalCamoufoxExecutable = camoufoxExecutablePath();
   const browserIdleTimeoutMs = parseInt(process.env.BROWSER_IDLE_TIMEOUT_MS, 10);
+  const shutdownTimeoutMs = parsePositiveTimeoutMs(process.env.CAMOFOX_SHUTDOWN_TIMEOUT_MS, 45000);
   const fileConfig = readCamofoxConfig(configPath);
   const configuredNewPageTimeoutMs = Number(fileConfig.newPageTimeoutMs);
   const newPageTimeoutMs = Number.isFinite(configuredNewPageTimeoutMs) && configuredNewPageTimeoutMs > 0
@@ -102,6 +108,7 @@ function loadConfig({ configPath = CONFIG_PATH } = {}) {
     tracesMaxBytes: parseInt(process.env.CAMOFOX_TRACES_MAX_BYTES || String(50 * 1024 * 1024), 10),
     tracesTtlHours: parseInt(process.env.CAMOFOX_TRACES_TTL_HOURS || '24', 10),
     handlerTimeoutMs: parseInt(process.env.HANDLER_TIMEOUT_MS) || 30000,
+    shutdownTimeoutMs,
     newPageTimeoutMs,
     maxConcurrentPerUser: parseInt(process.env.MAX_CONCURRENT_PER_USER) || 3,
     sessionTimeoutMs: parseInt(process.env.SESSION_TIMEOUT_MS) || 600000,
@@ -153,6 +160,7 @@ function loadConfig({ configPath = CONFIG_PATH } = {}) {
       CAMOFOX_TRACES_MAX_BYTES: process.env.CAMOFOX_TRACES_MAX_BYTES,
       CAMOFOX_TRACES_TTL_HOURS: process.env.CAMOFOX_TRACES_TTL_HOURS,
       CAMOFOX_DISABLE_DEFAULT_ADDONS: process.env.CAMOFOX_DISABLE_DEFAULT_ADDONS,
+      CAMOFOX_SHUTDOWN_TIMEOUT_MS: process.env.CAMOFOX_SHUTDOWN_TIMEOUT_MS,
       CAMOUFOX_EXECUTABLE: process.env.CAMOUFOX_EXECUTABLE,
       CAMOUFOX_EXECUTABLE_PATH: process.env.CAMOUFOX_EXECUTABLE_PATH,
       CAMOFOX_EXECUTABLE_PATH: process.env.CAMOFOX_EXECUTABLE_PATH,

--- a/server.js
+++ b/server.js
@@ -6453,7 +6453,7 @@ async function gracefulShutdown(signal) {
   const forceTimeout = setTimeout(() => {
     log('error', 'shutdown timed out, forcing exit');
     process.exit(1);
-  }, 10000);
+  }, CONFIG.shutdownTimeoutMs);
   forceTimeout.unref();
 
   server.close();

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -69,6 +69,24 @@ describe('loadConfig', () => {
     expect(loadConfig().browserRssRestartThresholdMb).toBe(2048);
   });
 
+  test('uses a positive shutdown watchdog timeout and forwards it to server subprocesses', () => {
+    delete process.env.CAMOFOX_SHUTDOWN_TIMEOUT_MS;
+    expect(loadConfig().shutdownTimeoutMs).toBe(45000);
+
+    process.env.CAMOFOX_SHUTDOWN_TIMEOUT_MS = '60000';
+    const configured = loadConfig();
+    expect(configured.shutdownTimeoutMs).toBe(60000);
+    expect(configured.serverEnv.CAMOFOX_SHUTDOWN_TIMEOUT_MS).toBe('60000');
+
+    for (const value of ['0', '-1', 'not-a-number', 'Infinity', '2147483648', '9007199254740992']) {
+      process.env.CAMOFOX_SHUTDOWN_TIMEOUT_MS = value;
+      expect(loadConfig().shutdownTimeoutMs).toBe(45000);
+    }
+
+    process.env.CAMOFOX_SHUTDOWN_TIMEOUT_MS = '2147483647';
+    expect(loadConfig().shutdownTimeoutMs).toBe(2147483647);
+  });
+
   test('reads newPageTimeoutMs from camofox.config.json with a 10s fallback', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'camofox-config-'));
     const configPath = path.join(dir, 'camofox.config.json');

--- a/tests/unit/shutdownBudget.test.js
+++ b/tests/unit/shutdownBudget.test.js
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const serverSource = fs.readFileSync(path.resolve(process.cwd(), 'server.js'), 'utf8');
+
+function gracefulShutdownSource() {
+  const start = serverSource.indexOf('async function gracefulShutdown');
+  const end = serverSource.indexOf("process.on('SIGTERM'", start);
+  return serverSource.slice(start, end);
+}
+
+describe('shutdown budget', () => {
+  test('gracefulShutdown arms its watchdog with the centralized CONFIG value', () => {
+    const source = gracefulShutdownSource();
+
+    expect(source).toMatch(/const forceTimeout = setTimeout\([\s\S]*?,\s*CONFIG\.shutdownTimeoutMs\);/);
+    expect(source).not.toMatch(/},\s*10000\);/);
+    expect(source).toMatch(/forceTimeout\.unref\(\);/);
+  });
+});


### PR DESCRIPTION
## Summary

- replace the fixed 10-second forced-exit watchdog with centralized `CAMOFOX_SHUTDOWN_TIMEOUT_MS` configuration
- use a persistence-safe 45-second default
- reject zero, negative, non-integer, infinite, unsafe-integer, and above-Node-timer-limit values by falling back to the default
- forward the setting through the existing explicit child-process environment whitelist

## Motivation

Graceful shutdown awaits `server:shutdown` listeners before closing browser contexts. The persistence plugin uses that window to checkpoint storage state, optionally including IndexedDB. With multiple active sessions or larger IndexedDB state, the existing 10-second watchdog can terminate the process while those awaited checkpoints are still running.

The watchdog remains bounded and armed before shutdown work begins; only its validated budget becomes configurable.

## Verification

- `npm test -- --runInBand tests/unit/config.test.js tests/unit/shutdownBudget.test.js tests/unit/serverShutdownEvent.test.js plugins/persistence/plugin.test.js plugins/persistence/persistence.test.js`
- `npm run build`
- `npm run test:mcp`
- CI-equivalent unit + plugin suite: 59 suites / 786 tests passed
- `node --check server.js`

The new regression tests were added before the implementation and failed while `gracefulShutdown()` still used the fixed 10-second value.

## Scope

This does not change checkpoint ordering, make persistence concurrent, enable IndexedDB by default, or alter normal runtime behavior. The only user-visible difference is the bounded wait during shutdown.
