### PR TITLE
feat: add atomic trusted pointer drag

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ curl -X POST http://localhost:9377/tabs/TAB_ID/navigate \
 |--------|----------|-------------|
 | `GET` | `/tabs/:id/snapshot` | Accessibility snapshot with element refs. Query params: `includeScreenshot=true` (add base64 PNG), `offset=N` (paginate large snapshots) |
 | `POST` | `/tabs/:id/click` | Click element by ref or CSS selector |
+| `POST` | `/tabs/:id/drag` | Perform an atomic trusted mouse drag from `{start:{x,y}}` to `{end:{x,y}}`; optional `steps`, `durationMs`, and `button` |
 | `POST` | `/tabs/:id/type` | Type text into element |
 | `POST` | `/tabs/:id/press` | Press a keyboard key |
 | `POST` | `/tabs/:id/scroll` | Scroll page (up/down/left/right) |

--- a/lib/trusted-drag.js
+++ b/lib/trusted-drag.js
@@ -1,0 +1,119 @@
+const DRAG_BUTTONS = new Set(['left', 'right', 'middle']);
+const DRAG_REQUEST_KEYS = new Set(['userId', 'start', 'end', 'steps', 'durationMs', 'button']);
+const DRAG_POINT_KEYS = new Set(['x', 'y']);
+
+export const DRAG_DEFAULT_STEPS = 12;
+export const DRAG_MIN_STEPS = 1;
+export const DRAG_MAX_STEPS = 24;
+export const DRAG_DEFAULT_DURATION_MS = 800;
+export const DRAG_MIN_DURATION_MS = 1;
+export const DRAG_MAX_DURATION_MS = 5_000;
+
+function hasOnlyKeys(value, allowedKeys) {
+  return Object.keys(value).every(key => allowedKeys.has(key));
+}
+
+function validPoint(point) {
+  return point && typeof point === 'object' &&
+    Number.isFinite(point.x) && Number.isFinite(point.y);
+}
+
+function invalid(error) {
+  return { ok: false, error };
+}
+
+/**
+ * Validate and normalize the JSON contract for an atomic trusted drag.
+ *
+ * Keeping this pure makes the route's strict input contract testable without
+ * importing server.js (which starts the browser server as a side effect).
+ */
+export function validateTrustedDragRequest(body) {
+  const request = body && typeof body === 'object' ? body : {};
+  if (!hasOnlyKeys(request, DRAG_REQUEST_KEYS)) {
+    return invalid('unknown drag request field');
+  }
+
+  const { userId, start, end } = request;
+
+  if (typeof userId !== 'string' || userId.trim() === '') {
+    return invalid('userId required');
+  }
+  if (!validPoint(start) || !validPoint(end)) {
+    return invalid('start and end coordinates with finite x and y required');
+  }
+  if (!hasOnlyKeys(start, DRAG_POINT_KEYS) || !hasOnlyKeys(end, DRAG_POINT_KEYS)) {
+    return invalid('start and end may only contain x and y');
+  }
+
+  const steps = request.steps === undefined ? DRAG_DEFAULT_STEPS : request.steps;
+  if (!Number.isInteger(steps) || steps < DRAG_MIN_STEPS || steps > DRAG_MAX_STEPS) {
+    return invalid(`steps must be an integer between ${DRAG_MIN_STEPS} and ${DRAG_MAX_STEPS}`);
+  }
+
+  const durationMs = request.durationMs === undefined ? DRAG_DEFAULT_DURATION_MS : request.durationMs;
+  if (!Number.isInteger(durationMs) || durationMs < DRAG_MIN_DURATION_MS || durationMs > DRAG_MAX_DURATION_MS) {
+    return invalid(`durationMs must be an integer between ${DRAG_MIN_DURATION_MS} and ${DRAG_MAX_DURATION_MS}`);
+  }
+
+  const button = request.button === undefined ? 'left' : request.button;
+  if (!DRAG_BUTTONS.has(button)) {
+    return invalid('button must be one of: left, right, middle');
+  }
+
+  return {
+    ok: true,
+    value: {
+      userId: userId.trim(),
+      start: { x: start.x, y: start.y },
+      end: { x: end.x, y: end.y },
+      steps,
+      durationMs,
+      button,
+    },
+  };
+}
+
+/**
+ * Keep the gesture timeout below the tab-lock queue timeout so a concurrent
+ * request cannot time out first and tear down the tab while the drag runs.
+ */
+export function trustedDragTimeoutMs({ steps, durationMs }, handlerTimeoutMs, lockTimeoutMs) {
+  const gestureBudgetMs = durationMs + (steps + 3) * 1000;
+  return Math.min(lockTimeoutMs - 1000, Math.max(handlerTimeoutMs, gestureBudgetMs));
+}
+
+/**
+ * Dispatch one trusted, low-level mouse drag through Playwright's mouse API.
+ *
+ * `sleep` is injectable for deterministic unit tests. In production the
+ * default timer spaces the interpolated moves so their cumulative delay is
+ * exactly durationMs (subject to the host scheduler's timer resolution).
+ */
+export async function runTrustedDrag(page, { start, end, steps, durationMs, button }, sleep) {
+  const wait = sleep || ((ms) => new Promise(resolve => setTimeout(resolve, ms)));
+  await page.mouse.move(start.x, start.y);
+
+  let pressed = false;
+  try {
+    await page.mouse.down({ button });
+    pressed = true;
+
+    let elapsed = 0;
+    for (let index = 1; index <= steps; index += 1) {
+      const progress = index / steps;
+      const nextElapsed = Math.round(durationMs * progress);
+      const delay = nextElapsed - elapsed;
+      if (delay > 0) await wait(delay);
+      await page.mouse.move(
+        start.x + (end.x - start.x) * progress,
+        start.y + (end.y - start.y) * progress,
+      );
+      elapsed = nextElapsed;
+    }
+
+    return { ok: true, start, end, steps, durationMs, button };
+  } finally {
+    if (pressed) await page.mouse.up({ button });
+  }
+}

--- a/openapi.json
+++ b/openapi.json
@@ -912,6 +912,179 @@
         }
       }
     },
+    "/tabs/{tabId}/drag": {
+      "post": {
+        "tags": [
+          "Interaction"
+        ],
+        "summary": "Perform an atomic trusted mouse drag",
+        "description": "Dispatches one low-level Playwright mouse gesture: move to `start`, press `button`, move through deterministic interpolated points to `end` over `durationMs`, and release the button. This is an atomic gesture rather than a generic replacement for the individual mouse actions.\n",
+        "parameters": [
+          {
+            "name": "tabId",
+            "in": "path",
+            "required": true,
+            "description": "Managed tab identifier.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "userId",
+                  "start",
+                  "end"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Non-empty user/session identifier."
+                  },
+                  "start": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "x",
+                      "y"
+                    ],
+                    "properties": {
+                      "x": {
+                        "type": "number",
+                        "description": "Starting horizontal viewport coordinate."
+                      },
+                      "y": {
+                        "type": "number",
+                        "description": "Starting vertical viewport coordinate."
+                      }
+                    }
+                  },
+                  "end": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "x",
+                      "y"
+                    ],
+                    "properties": {
+                      "x": {
+                        "type": "number",
+                        "description": "Ending horizontal viewport coordinate."
+                      },
+                      "y": {
+                        "type": "number",
+                        "description": "Ending vertical viewport coordinate."
+                      }
+                    }
+                  },
+                  "steps": {
+                    "type": "integer",
+                    "default": 12,
+                    "minimum": 1,
+                    "maximum": 24,
+                    "description": "Number of interpolated moves after pressing the button."
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "default": 800,
+                    "minimum": 1,
+                    "maximum": 5000,
+                    "description": "Total delay, in milliseconds, distributed across the interpolated moves."
+                  },
+                  "button": {
+                    "type": "string",
+                    "enum": [
+                      "left",
+                      "right",
+                      "middle"
+                    ],
+                    "default": "left",
+                    "description": "Mouse button held for the gesture."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Completed atomic drag gesture.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "start",
+                    "end",
+                    "steps",
+                    "durationMs",
+                    "button"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "start": {
+                      "type": "object"
+                    },
+                    "end": {
+                      "type": "object"
+                    },
+                    "steps": {
+                      "type": "integer"
+                    },
+                    "durationMs": {
+                      "type": "integer"
+                    },
+                    "button": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or drag options.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tab not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Drag failed in the browser.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/tabs/{tabId}/upload": {
       "post": {
         "tags": [

--- a/server.js
+++ b/server.js
@@ -35,6 +35,7 @@ import { cleanupOrphanedTempFiles, cleanupStaleFirefoxProfiles } from './lib/tmp
 import { coalesceInflight } from './lib/inflight.js';
 import { createPageWithSessionRecovery } from './lib/new-page-recovery.js';
 import { resolveUploadPaths } from './lib/upload-paths.js';
+import { runTrustedDrag, trustedDragTimeoutMs, validateTrustedDragRequest } from './lib/trusted-drag.js';
 import { acquirePageLease, hasActivePageLeases, isPageLeased, releasePageLease, setLeasedPage } from './lib/page-lease.js';
 import { createReporter, createTabHealthTracker, collectResourceSnapshot, classifyProxyError, browserProcessTreeRssMb, browserProcessNameRssMb } from './lib/reporter.js';
 import { mountDocs } from './lib/openapi.js';
@@ -3593,6 +3594,162 @@ app.post('/tabs/:tabId/click', async (req, res) => {
         log('warn', 'post-timeout refresh failed', { error: refreshErr.message });
       }
     }
+    handleRouteError(err, req, res);
+  }
+});
+
+// Atomic trusted pointer drag
+/**
+ * @openapi
+ * /tabs/{tabId}/drag:
+ *   post:
+ *     tags: [Interaction]
+ *     summary: Perform an atomic trusted mouse drag
+ *     description: >
+ *       Dispatches one low-level Playwright mouse gesture: move to `start`, press
+ *       `button`, move through deterministic interpolated points to `end` over
+ *       `durationMs`, and release the button. This is an atomic gesture rather
+ *       than a generic replacement for the individual mouse actions.
+ *     parameters:
+ *       - name: tabId
+ *         in: path
+ *         required: true
+ *         description: Managed tab identifier.
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             additionalProperties: false
+ *             required: [userId, start, end]
+ *             properties:
+ *               userId:
+ *                 type: string
+ *                 minLength: 1
+ *                 description: Non-empty user/session identifier.
+ *               start:
+ *                 type: object
+ *                 additionalProperties: false
+ *                 required: [x, y]
+ *                 properties:
+ *                   x:
+ *                     type: number
+ *                     description: Starting horizontal viewport coordinate.
+ *                   y:
+ *                     type: number
+ *                     description: Starting vertical viewport coordinate.
+ *               end:
+ *                 type: object
+ *                 additionalProperties: false
+ *                 required: [x, y]
+ *                 properties:
+ *                   x:
+ *                     type: number
+ *                     description: Ending horizontal viewport coordinate.
+ *                   y:
+ *                     type: number
+ *                     description: Ending vertical viewport coordinate.
+ *               steps:
+ *                 type: integer
+ *                 default: 12
+ *                 minimum: 1
+ *                 maximum: 24
+ *                 description: Number of interpolated moves after pressing the button.
+ *               durationMs:
+ *                 type: integer
+ *                 default: 800
+ *                 minimum: 1
+ *                 maximum: 5000
+ *                 description: Total delay, in milliseconds, distributed across the interpolated moves.
+ *               button:
+ *                 type: string
+ *                 enum: [left, right, middle]
+ *                 default: left
+ *                 description: Mouse button held for the gesture.
+ *     responses:
+ *       200:
+ *         description: Completed atomic drag gesture.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [ok, start, end, steps, durationMs, button]
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                 start:
+ *                   type: object
+ *                 end:
+ *                   type: object
+ *                 steps:
+ *                   type: integer
+ *                 durationMs:
+ *                   type: integer
+ *                 button:
+ *                   type: string
+ *       400:
+ *         description: Invalid request body or drag options.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: Tab not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Drag failed in the browser.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+app.post('/tabs/:tabId/drag', async (req, res) => {
+  const tabId = req.params.tabId;
+
+  try {
+    const validation = validateTrustedDragRequest(req.body);
+    if (!validation.ok) return res.status(400).json({ error: validation.error });
+
+    const { userId, ...dragOptions } = validation.value;
+    // Keep centralized timeout/dead-page handling on the same normalized ID
+    // used by session lookup and concurrency accounting.
+    req.body.userId = userId;
+    const session = sessions.get(normalizeUserId(userId));
+    const found = session && findTab(session, tabId);
+    if (!found) return tabNotFoundResponse(res, req.params.tabId || req.body?.tabId);
+    session.lastAccess = Date.now();
+
+    const { tabState } = found;
+    tabState.toolCalls++; tabState.consecutiveTimeouts = 0; tabState.consecutiveFailures = 0;
+
+    // Camoufox may humanize each low-level mouse call. Keep the gesture budget
+    // below the lock acquisition timeout so a queued request cannot time out
+    // first and tear down the tab while this drag is still running.
+    const dragTimeoutMs = trustedDragTimeoutMs(
+      dragOptions,
+      HANDLER_TIMEOUT_MS,
+      TAB_LOCK_TIMEOUT_MS,
+    );
+    const result = await withUserLimit(userId, () => withTabLock(tabId, async () => {
+      try {
+        return await runTrustedDrag(tabState.page, dragOptions);
+      } finally {
+        // A pointer gesture can change rendered content without navigation.
+        // Never return a snapshot or refs captured before the gesture.
+        tabState.lastSnapshot = null;
+        tabState.refs = new Map();
+      }
+    }, dragTimeoutMs));
+
+    res.json(result);
+  } catch (err) {
+    log('error', 'drag failed', { reqId: req.reqId, tabId, error: err.message });
     handleRouteError(err, req, res);
   }
 });

--- a/tests/e2e/drag.test.js
+++ b/tests/e2e/drag.test.js
@@ -1,0 +1,65 @@
+import { createClient } from '../helpers/client.js';
+import { getSharedEnv } from './sharedEnv.js';
+
+describe('Atomic trusted drag', () => {
+  let serverUrl;
+  let testSiteUrl;
+
+  beforeAll(() => {
+    const env = getSharedEnv();
+    serverUrl = env.serverUrl;
+    testSiteUrl = env.testSiteUrl;
+  });
+
+  test('dispatches browser mouse events and lands in the drag target', async () => {
+    const client = createClient(serverUrl);
+
+    try {
+      const { tabId } = await client.createTab(`${testSiteUrl}/drag`);
+      const result = await client.drag(tabId, {
+        start: { x: 90, y: 140 },
+        end: { x: 450, y: 140 },
+        steps: 8,
+        durationMs: 120,
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        start: { x: 90, y: 140 },
+        end: { x: 450, y: 140 },
+        steps: 8,
+        durationMs: 120,
+        button: 'left',
+      });
+
+      const status = await client.evaluate(tabId, "document.getElementById('status').textContent");
+      expect(status.result).toMatch(/^dropped:\d+$/);
+      expect(Number(status.result.split(':')[1])).toBeGreaterThan(0);
+    } finally {
+      await client.cleanup();
+    }
+  }, 120000);
+
+  test('enforces the route contract before browser dispatch', async () => {
+    const client = createClient(serverUrl);
+
+    await expect(client.request('POST', '/tabs/missing-tab/drag', {
+      userId: client.userId,
+      start: { x: 10, y: 20 },
+      end: { x: 30, y: 40 },
+      unexpected: true,
+    })).rejects.toMatchObject({ status: 400 });
+
+    await expect(client.request('POST', '/tabs/missing-tab/drag', {
+      userId: client.userId,
+      start: { x: 10, y: 20, z: 30 },
+      end: { x: 30, y: 40 },
+    })).rejects.toMatchObject({ status: 400 });
+
+    await expect(client.request('POST', '/tabs/missing-tab/drag', {
+      userId: `  ${client.userId}  `,
+      start: { x: 10, y: 20 },
+      end: { x: 30, y: 40 },
+    })).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/tests/helpers/client.js
+++ b/tests/helpers/client.js
@@ -100,6 +100,10 @@ class BrowserClient {
     return this.request('POST', `/tabs/${tabId}/click`, { userId: this.userId, ...options });
   }
 
+  async drag(tabId, options) {
+    return this.request('POST', `/tabs/${tabId}/drag`, { userId: this.userId, ...options });
+  }
+
   async evaluate(tabId, expression) {
     return this.request('POST', `/tabs/${tabId}/evaluate`, { userId: this.userId, expression });
   }

--- a/tests/helpers/testSite.js
+++ b/tests/helpers/testSite.js
@@ -169,6 +169,50 @@ function createTestApp() {
     res.json({ ok: true });
   });
   
+  // Page with a low-level drag target. The endpoint test asserts browser mouse
+  // events arrive at the page and that the final mouseup lands in the target.
+  app.get('/drag', (req, res) => {
+    res.send(`
+      <!DOCTYPE html>
+      <html><head><title>Drag Test</title>
+      <style>
+        body { margin: 0; font-family: sans-serif; }
+        #source, #target { position: absolute; top: 100px; width: 100px; height: 80px; }
+        #source { left: 40px; background: #4a90e2; color: white; }
+        #target { left: 400px; background: #ddd; border: 2px dashed #555; }
+      </style>
+      </head>
+      <body>
+        <div id="source">Drag source</div>
+        <div id="target">Drop target</div>
+        <p id="status">idle</p>
+        <script>
+          const source = document.getElementById('source');
+          const target = document.getElementById('target');
+          const status = document.getElementById('status');
+          let pressed = false;
+          let moves = 0;
+          source.addEventListener('mousedown', () => {
+            pressed = true;
+            moves = 0;
+            status.textContent = 'pressed';
+          });
+          document.addEventListener('mousemove', () => {
+            if (pressed) moves += 1;
+          });
+          document.addEventListener('mouseup', (event) => {
+            if (!pressed) return;
+            pressed = false;
+            const box = target.getBoundingClientRect();
+            const landed = event.clientX >= box.left && event.clientX <= box.right &&
+              event.clientY >= box.top && event.clientY <= box.bottom;
+            status.textContent = (landed ? 'dropped:' : 'missed:') + moves;
+          });
+        </script>
+      </body></html>
+    `);
+  });
+
   // Page with clickable button
   app.get('/click', (req, res) => {
     res.send(`

--- a/tests/unit/dragEndpoint.test.js
+++ b/tests/unit/dragEndpoint.test.js
@@ -1,0 +1,201 @@
+/**
+ * Focused tests for POST /tabs/:tabId/drag.
+ *
+ * The route is embedded in server.js, so the pure request contract and mouse
+ * gesture helper are exercised directly while source assertions protect the
+ * route's load-bearing wiring (locks, counters, activity, and freshness).
+ */
+import { describe, test, expect, jest } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import {
+  DRAG_DEFAULT_DURATION_MS,
+  DRAG_DEFAULT_STEPS,
+  DRAG_MAX_DURATION_MS,
+  DRAG_MAX_STEPS,
+  runTrustedDrag,
+  trustedDragTimeoutMs,
+  validateTrustedDragRequest,
+} from '../../lib/trusted-drag.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverSrc = readFileSync(join(__dirname, '../../server.js'), 'utf8');
+
+const validRequest = () => ({
+  userId: 'agent1',
+  start: { x: 10, y: 20 },
+  end: { x: 110, y: 220 },
+});
+
+describe('trusted drag request validation', () => {
+  test('requires a non-empty string userId', () => {
+    expect(validateTrustedDragRequest({ ...validRequest(), userId: '' })).toMatchObject({ ok: false });
+    expect(validateTrustedDragRequest({ ...validRequest(), userId: '   ' })).toMatchObject({ ok: false });
+    expect(validateTrustedDragRequest({ ...validRequest(), userId: 123 })).toMatchObject({ ok: false });
+  });
+
+  test('requires finite numeric start and end coordinates', () => {
+    for (const request of [
+      { ...validRequest(), start: undefined },
+      { ...validRequest(), end: undefined },
+      { ...validRequest(), start: { x: '10', y: 20 } },
+      { ...validRequest(), end: { x: 110, y: Infinity } },
+      { ...validRequest(), start: { x: NaN, y: 20 } },
+      { ...validRequest(), end: { x: 110, y: null } },
+    ]) {
+      expect(validateTrustedDragRequest(request)).toMatchObject({ ok: false });
+    }
+  });
+
+  test('applies safe defaults', () => {
+    expect(validateTrustedDragRequest(validRequest())).toEqual({
+      ok: true,
+      value: {
+        ...validRequest(),
+        steps: DRAG_DEFAULT_STEPS,
+        durationMs: DRAG_DEFAULT_DURATION_MS,
+        button: 'left',
+      },
+    });
+  });
+
+  test('accepts bounded integer steps and duration overrides', () => {
+    const result = validateTrustedDragRequest({
+      ...validRequest(),
+      steps: 1,
+      durationMs: DRAG_MAX_DURATION_MS,
+      button: 'middle',
+    });
+    expect(result).toEqual({
+      ok: true,
+      value: { ...validRequest(), steps: 1, durationMs: DRAG_MAX_DURATION_MS, button: 'middle' },
+    });
+    expect(validateTrustedDragRequest({ ...validRequest(), steps: DRAG_MAX_STEPS, durationMs: 1, button: 'right' }).ok).toBe(true);
+  });
+
+  test('rejects invalid step, duration, and button values', () => {
+    for (const request of [
+      { ...validRequest(), steps: 0 },
+      { ...validRequest(), steps: DRAG_MAX_STEPS + 1 },
+      { ...validRequest(), steps: 1.5 },
+      { ...validRequest(), durationMs: 0 },
+      { ...validRequest(), durationMs: DRAG_MAX_DURATION_MS + 1 },
+      { ...validRequest(), durationMs: 1.5 },
+      { ...validRequest(), button: 'back' },
+    ]) {
+      expect(validateTrustedDragRequest(request)).toMatchObject({ ok: false });
+    }
+  });
+
+  test('rejects unknown top-level and coordinate properties', () => {
+    expect(validateTrustedDragRequest({ ...validRequest(), extra: true })).toMatchObject({ ok: false });
+    expect(validateTrustedDragRequest({
+      ...validRequest(),
+      start: { ...validRequest().start, z: 1 },
+    })).toMatchObject({ ok: false });
+    expect(validateTrustedDragRequest({
+      ...validRequest(),
+      end: { ...validRequest().end, label: 'target' },
+    })).toMatchObject({ ok: false });
+  });
+
+  test('keeps the drag timeout below the tab-lock queue timeout', () => {
+    const maxDrag = { steps: DRAG_MAX_STEPS, durationMs: DRAG_MAX_DURATION_MS };
+    expect(trustedDragTimeoutMs(maxDrag, 30000, 35000)).toBe(32000);
+    expect(trustedDragTimeoutMs(maxDrag, 60000, 35000)).toBe(34000);
+    expect(trustedDragTimeoutMs({ steps: 1, durationMs: 1 }, 30000, 35000)).toBe(30000);
+  });
+});
+
+describe('trusted drag helper', () => {
+  function makePage({ moveImpl } = {}) {
+    const events = [];
+    const page = {
+      mouse: {
+        move: jest.fn(async (x, y) => {
+          events.push(['move', x, y]);
+          return moveImpl?.(x, y);
+        }),
+        down: jest.fn(async (button) => events.push(['down', button])),
+        up: jest.fn(async (button) => events.push(['up', button])),
+      },
+    };
+    return { page, events };
+  }
+
+  test('moves to start, presses the requested button, interpolates to exact end, and uses deterministic total delay', async () => {
+    const { page, events } = makePage();
+    const sleep = jest.fn(async () => {});
+
+    const result = await runTrustedDrag(page, {
+      start: { x: 10, y: 20 },
+      end: { x: 110, y: 220 },
+      steps: 3,
+      durationMs: 100,
+      button: 'right',
+    }, sleep);
+
+    expect(events[0]).toEqual(['move', 10, 20]);
+    expect(events[1]).toEqual(['down', { button: 'right' }]);
+    expect(events.slice(2, 5)).toHaveLength(3);
+    expect(events[2][0]).toBe('move');
+    expect(events[2][1]).toBeCloseTo(43.33333333333333);
+    expect(events[2][2]).toBeCloseTo(86.66666666666667);
+    expect(events[3][1]).toBeCloseTo(76.66666666666666);
+    expect(events[3][2]).toBeCloseTo(153.33333333333331);
+    expect(events[4]).toEqual(['move', 110, 220]);
+    expect(events[5]).toEqual(['up', { button: 'right' }]);
+    expect(sleep.mock.calls.map(([ms]) => ms)).toEqual([33, 34, 33]);
+    expect(sleep.mock.calls.reduce((total, [ms]) => total + ms, 0)).toBe(100);
+    expect(result).toMatchObject({ ok: true, start: { x: 10, y: 20 }, end: { x: 110, y: 220 }, steps: 3, durationMs: 100, button: 'right' });
+  });
+
+  test('releases the mouse in finally when an interpolated move fails', async () => {
+    const { page, events } = makePage({
+      moveImpl: (_x, y) => {
+        if (y > 20) throw new Error('move failed');
+      },
+    });
+
+    await expect(runTrustedDrag(page, {
+      start: { x: 10, y: 20 },
+      end: { x: 110, y: 220 },
+      steps: 2,
+      durationMs: 20,
+      button: 'middle',
+    }, async () => {})).rejects.toThrow('move failed');
+    expect(events.at(-1)).toEqual(['up', { button: 'middle' }]);
+  });
+});
+
+describe('/drag source contract', () => {
+  test('registers the atomic drag route and imports the focused helper', () => {
+    expect(serverSrc).toMatch(/import \{[^}]*runTrustedDrag[^}]*\} from ['"]\.\/lib\/trusted-drag\.js['"]/s);
+    expect(serverSrc).toMatch(/app\.post\(\s*['"]\/tabs\/:tabId\/drag['"]/);
+  });
+
+  test('uses user activity, counters, both locks, and freshness invalidation', () => {
+    const start = serverSrc.indexOf("app.post('/tabs/:tabId/drag'");
+    const end = serverSrc.indexOf('\n// ', start + 1);
+    const block = serverSrc.slice(start, end === -1 ? undefined : end);
+    expect(block).toMatch(/session\.lastAccess\s*=\s*Date\.now\(\)/);
+    expect(block).toMatch(/tabState\.toolCalls\+\+/);
+    expect(block).toMatch(/withUserLimit\(/);
+    expect(block).toMatch(/withTabLock\(/);
+    expect(block).toMatch(/tabState\.lastSnapshot\s*=\s*null/);
+    expect(block).toMatch(/tabState\.refs\s*=\s*new Map\(\)/);
+    expect(block).toMatch(/req\.body\.userId\s*=\s*userId/);
+    expect(block).toMatch(/trustedDragTimeoutMs\([\s\S]*TAB_LOCK_TIMEOUT_MS/);
+    expect(block).toMatch(/withTabLock\(tabId,[\s\S]*dragTimeoutMs\)/);
+    expect(block).toMatch(/finally/);
+  });
+
+  test('performs a low-level mouse gesture rather than DOM dispatch', () => {
+    const start = serverSrc.indexOf("app.post('/tabs/:tabId/drag'");
+    const end = serverSrc.indexOf('\n// ', start + 1);
+    const block = serverSrc.slice(start, end === -1 ? undefined : end);
+    expect(block).toMatch(/runTrustedDrag\(tabState\.page/);
+    expect(block).toMatch(/res\.json\(result\)/);
+  });
+});


### PR DESCRIPTION
## Summary

- add an atomic `POST /tabs/:tabId/drag` endpoint for one trusted low-level pointer gesture
- move to the start point, hold the selected mouse button, interpolate bounded steps over a bounded duration, and always release in `finally`
- refresh session activity and invalidate cached snapshots/refs after the gesture
- document the REST contract and add focused unit plus browser-level regression coverage

## Why a focused drag endpoint

This intentionally overlaps in problem space with #3377, but not in API shape. #3377 exposes generic coordinate-level `mouse` actions (`move`, `down`, `up`, `click`) that callers must sequence themselves. This PR exposes one bounded, lock-scoped drag transaction, so the button cannot be left held between separate REST requests and the gesture uses one deterministic interpolated path.

It also incorporates the current review requirements from #3377 that apply to coordinate interaction: strict finite/bounded input validation, `session.lastAccess` refresh, tab activity counters, snapshot/ref invalidation, regenerated OpenAPI, and regression tests.

This PR does **not** add MCP or OpenClaw tools and does not supersede the broader generic mouse API in #3377.

## Validation

- `npm test -- --runInBand tests/unit/dragEndpoint.test.js tests/unit/openapi.test.js tests/unit/tabLifecycleContract.test.js` — 3 suites / 35 tests passed
- `npm run test:e2e -- --runInBand tests/e2e/drag.test.js` — 1 suite / 2 tests passed
- `npm run build`
- `npm run test:mcp`
- `node --check server.js`
- `git diff --check`

## Risk and compatibility

- additive REST endpoint; existing endpoints and tool registries are unchanged
- inputs are finite and bounded (`steps` 1–24, `durationMs` 1–5000, supported buttons only); unknown fields are rejected
- pointer release runs in `finally` after a successful press
- execution stays inside the existing per-user limiter and per-tab lock, with a bounded gesture-specific timeout budget
