### PR TITLE
fix: stop broadcasting typed text to plugins

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -36,7 +36,7 @@
  *
  *   INPUT
  *     tab:click               { userId, tabId, ref, selector }
- *     tab:type                { userId, tabId, text, ref, mode }
+ *     tab:type                { userId, tabId, textLength, ref, mode }
  *     tab:scroll              { userId, tabId, direction, amount }
  *     tab:press               { userId, tabId, key }
  *
@@ -200,4 +200,14 @@ export async function loadPlugins(app, ctx, options = {}) {
   }
 
   return loaded;
+}
+
+export function typeEventPayload({ userId, tabId, text, ref, mode }) {
+  return {
+    userId,
+    tabId,
+    textLength: typeof text === 'string' ? text.length : 0,
+    ref,
+    mode: mode || 'fill',
+  };
 }

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ import { expandMacro } from './lib/macros.js';
 import { loadConfig } from './lib/config.js';
 import { normalizePlaywrightProxy, createProxyPool, buildProxyUrl } from './lib/proxy.js';
 import { createFlyHelpers } from './lib/fly.js';
-import { createPluginEvents, loadPlugins } from './lib/plugins.js';
+import { createPluginEvents, loadPlugins, typeEventPayload } from './lib/plugins.js';
 import { requireAuth, accessKeyMiddleware, timingSafeCompare as _timingSafeCompare, isLoopbackAddress as _isLoopbackAddress } from './lib/auth.js';
 import { windowSnapshot } from './lib/snapshot.js';
 import {
@@ -4033,7 +4033,7 @@ app.post('/tabs/:tabId/type', async (req, res) => {
       if (shouldSubmit) await tabState.page.keyboard.press('Enter');
     });
     
-    pluginEvents.emit('tab:type', { userId: req.body.userId, tabId, text: req.body.text, ref: req.body.ref, mode: req.body.mode || 'fill' });
+    pluginEvents.emit('tab:type', typeEventPayload({ userId: req.body.userId, tabId, text: req.body.text, ref: req.body.ref, mode: req.body.mode }));
     res.json({ ok: true });
   } catch (err) {
     log('error', 'type failed', { reqId: req.reqId, error: err.message });

--- a/tests/unit/pluginTypeEvent.test.js
+++ b/tests/unit/pluginTypeEvent.test.js
@@ -1,0 +1,46 @@
+/**
+ * The tab:type plugin event carried the typed text verbatim, and the text
+ * typed into a login form is a password. Any plugin subscribing to the
+ * documented contract received it. These tests pin the payload to a length.
+ *
+ * Pure payload builder -- no server spawn.
+ */
+import { describe, expect, test } from '@jest/globals';
+
+import { typeEventPayload } from '../../lib/plugins.js';
+
+describe('typeEventPayload', () => {
+  test('reports a length instead of the typed text', () => {
+    const payload = typeEventPayload({
+      userId: 'u1',
+      tabId: 't1',
+      text: 'hunter2-correct-horse',
+      ref: 'input[name=password]',
+      mode: 'fill',
+    });
+
+    expect(payload).toEqual({
+      userId: 'u1',
+      tabId: 't1',
+      textLength: 21,
+      ref: 'input[name=password]',
+      mode: 'fill',
+    });
+  });
+
+  test('no property of the payload contains the typed text', () => {
+    const secret = 'hunter2-correct-horse';
+    const payload = typeEventPayload({ userId: 'u1', tabId: 't1', text: secret });
+
+    expect(JSON.stringify(payload)).not.toContain(secret);
+  });
+
+  test('defaults mode to fill', () => {
+    expect(typeEventPayload({ userId: 'u', tabId: 't', text: 'x' }).mode).toBe('fill');
+  });
+
+  test('a missing or non-string text reports zero rather than throwing', () => {
+    expect(typeEventPayload({ userId: 'u', tabId: 't' }).textLength).toBe(0);
+    expect(typeEventPayload({ userId: 'u', tabId: 't', text: null }).textLength).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem

`server.js` emits the `tab:type` plugin event with the typed text verbatim:

```js
pluginEvents.emit('tab:type', { userId, tabId, text: req.body.text, ref, mode });
```

and `lib/plugins.js` documents `text` as part of the public plugin contract. The text typed into a login form is a password, so any plugin subscribing to `tab:type` receives credentials it never asked for — including plugins installed from elsewhere.

No shipped plugin subscribes to `tab:type`, so nothing in-tree depends on the field today.

### Change

Emits `textLength` instead of `text`. The payload is built by a small pure helper placed next to the contract it implements in `lib/plugins.js`, so the shape is unit-testable without spawning a server — matching the approach in `tests/unit/accessKey.test.js`.

### Contract change

This breaks the documented plugin event: a plugin reading `event.text` now reads `undefined`. `lib/plugins.js` is updated to document `textLength`. Happy to gate it behind config instead if you'd rather not change the contract in a patch release.

### Tests

`tests/unit/pluginTypeEvent.test.js` — 4 tests, one asserting no property of the serialised payload contains the typed text.

```
tests/unit/{pluginTypeEvent,plugins,sessionDestroyingEvent,serverShutdownEvent}.test.js
Test Suites: 4 passed    Tests: 31 passed
```

For transparency: the full `tests/unit` suite is already red on `master` at `e5a36f5` — 10 suites / 17 tests fail before this change. None of those suites import `lib/plugins.js`.