### PR TITLE
feat: optional syslog priority prefix for journald

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -2,10 +2,25 @@
  * Structured line logging.
  *
  * Errors go to stderr, everything else to stdout, one JSON object per line.
+ *
+ * Under systemd both streams arrive at PRIORITY 6, so the level field is
+ * decorative and `journalctl -p err` matches nothing. Setting
+ * CAMOFOX_LOG_SYSLOG_PREFIX=1 emits a leading <N>, which journald reads as
+ * the priority and strips from MESSAGE. It is off by default because npm and
+ * Docker consumers have nothing to strip it and a JSON log collector would
+ * fail to parse the line.
  */
 
-export function formatLogLine(level, msg, fields = {}) {
-  return JSON.stringify({ ts: new Date().toISOString(), level, msg, ...fields });
+const SYSLOG_PRIORITY = { error: 3, warn: 4, info: 6, debug: 7 };
+
+export function syslogPrefixEnabled(env = process.env) {
+  return env.CAMOFOX_LOG_SYSLOG_PREFIX === '1';
+}
+
+export function formatLogLine(level, msg, fields = {}, env = process.env) {
+  const line = JSON.stringify({ ts: new Date().toISOString(), level, msg, ...fields });
+  if (!syslogPrefixEnabled(env)) return line;
+  return `<${SYSLOG_PRIORITY[level] ?? SYSLOG_PRIORITY.info}>${line}`;
 }
 
 export function log(level, msg, fields = {}) {

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,15 @@
+/**
+ * Structured line logging.
+ *
+ * Errors go to stderr, everything else to stdout, one JSON object per line.
+ */
+
+export function formatLogLine(level, msg, fields = {}) {
+  return JSON.stringify({ ts: new Date().toISOString(), level, msg, ...fields });
+}
+
+export function log(level, msg, fields = {}) {
+  const line = formatLogLine(level, msg, fields);
+  if (level === 'error') process.stderr.write(line + '\n');
+  else process.stdout.write(line + '\n');
+}

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ import express from 'express';
 import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
+import { log } from './lib/log.js';
 import { expandMacro } from './lib/macros.js';
 import { loadConfig } from './lib/config.js';
 import { normalizePlaywrightProxy, createProxyPool, buildProxyUrl } from './lib/proxy.js';
@@ -103,21 +104,7 @@ const {
   sessionsExpiredTotal, tabsReapedTotal, tabsRecycledTotal,
 } = await initMetrics({ enabled: CONFIG.prometheusEnabled });
 
-// --- Structured logging ---
-function log(level, msg, fields = {}) {
-  const entry = {
-    ts: new Date().toISOString(),
-    level,
-    msg,
-    ...fields,
-  };
-  const line = JSON.stringify(entry);
-  if (level === 'error') {
-    process.stderr.write(line + '\n');
-  } else {
-    process.stdout.write(line + '\n');
-  }
-}
+
 
 const app = express();
 const globalJsonParser = express.json({ limit: '100kb' });

--- a/tests/unit/log.test.js
+++ b/tests/unit/log.test.js
@@ -5,7 +5,9 @@
  */
 import { describe, expect, test } from '@jest/globals';
 
-import { formatLogLine } from '../../lib/log.js';
+import { formatLogLine, syslogPrefixEnabled } from '../../lib/log.js';
+
+const PREFIXED = { CAMOFOX_LOG_SYSLOG_PREFIX: '1' };
 
 describe('formatLogLine', () => {
   test('emits one parseable JSON object', () => {
@@ -22,5 +24,33 @@ describe('formatLogLine', () => {
   test('never spans more than one line, whatever the message contains', () => {
     const line = formatLogLine('info', 'a\nb\r\nc', { detail: 'x\ny' });
     expect(line.split('\n')).toHaveLength(1);
+  });
+});
+
+describe('syslog priority prefix', () => {
+  test('is off unless explicitly enabled', () => {
+    expect(syslogPrefixEnabled({})).toBe(false);
+    expect(syslogPrefixEnabled({ CAMOFOX_LOG_SYSLOG_PREFIX: '0' })).toBe(false);
+    expect(formatLogLine('error', 'boom', {}, {})).not.toMatch(/^</);
+  });
+
+  test.each([
+    ['error', 3],
+    ['warn', 4],
+    ['info', 6],
+    ['debug', 7],
+  ])('maps %s to <%i>', (level, priority) => {
+    expect(formatLogLine(level, 'm', {}, PREFIXED)).toMatch(new RegExp(`^<${priority}>`));
+  });
+
+  test('an unknown level falls back to info', () => {
+    expect(formatLogLine('trace', 'm', {}, PREFIXED)).toMatch(/^<6>/);
+  });
+
+  test('the JSON body still parses once the prefix is stripped', () => {
+    const line = formatLogLine('error', 'boom', { reqId: 'abc', code: 500 }, PREFIXED);
+    expect(JSON.parse(line.replace(/^<\d+>/, ''))).toMatchObject({
+      level: 'error', msg: 'boom', reqId: 'abc', code: 500,
+    });
   });
 });

--- a/tests/unit/log.test.js
+++ b/tests/unit/log.test.js
@@ -1,0 +1,26 @@
+/**
+ * Line format for lib/log.js.
+ *
+ * Pure formatter -- no server spawn, no stream capture.
+ */
+import { describe, expect, test } from '@jest/globals';
+
+import { formatLogLine } from '../../lib/log.js';
+
+describe('formatLogLine', () => {
+  test('emits one parseable JSON object', () => {
+    const parsed = JSON.parse(formatLogLine('info', 'started', { port: 9377 }));
+    expect(parsed).toMatchObject({ level: 'info', msg: 'started', port: 9377 });
+    expect(typeof parsed.ts).toBe('string');
+  });
+
+  test('fields override nothing they should not', () => {
+    const parsed = JSON.parse(formatLogLine('warn', 'slow', { msg: 'ignored-key-collision' }));
+    expect(parsed.level).toBe('warn');
+  });
+
+  test('never spans more than one line, whatever the message contains', () => {
+    const line = formatLogLine('info', 'a\nb\r\nc', { detail: 'x\ny' });
+    expect(line.split('\n')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
> Includes the commit from the `lib/log.js` extraction PR, so that one should land first — this diff will shrink to a single commit once it does.

### Problem

systemd does not infer severity from the stream: stdout and stderr both arrive at `PRIORITY 6`. The `level` field in the JSON is therefore invisible to journald, and `journalctl -p err` matches nothing.

Measured on a systemd deployment over seven days:

```
lines carrying {"level":"error"} : 5
entries at PRIORITY 3 (err)      : 0
priority histogram               : {5: 3, 6: 1253}
```

Real errors were being logged and were unfindable by severity.

### Change

`CAMOFOX_LOG_SYSLOG_PREFIX=1` emits a leading `<N>`, which journald reads as the priority and strips from `MESSAGE`, leaving the JSON body intact. Verified end to end on a systemd user unit: `<3>` lands at `PRIORITY=3`, `<6>` at 6, unprefixed lines unchanged, and the body still parses.

### Off by default, deliberately

npm and Docker consumers have nothing to strip the prefix, and a collector parsing each line as JSON would fail on it. It is read where the server actually runs, so a plugin-spawned child only sees it if the caller passes it through — intentional, since this targets direct systemd invocation.

Given the env-var rule in `CONTRIBUTING.md`, I kept the flag out of the `launchServer` whitelist rather than widening what the child inherits. Happy to route it through `lib/config.js` instead if that fits better.

### Tests

`tests/unit/log.test.js` — 10 tests total, covering each level mapping, the default-off behaviour, an unknown level, and that the JSON body parses once the prefix is stripped.

```
tests/unit/{log,plugins,sessionDestroyingEvent,serverShutdownEvent}.test.js
Test Suites: 4 passed    Tests: 37 passed
```